### PR TITLE
Updates docker-compose to zipkin 1.9.0

### DIFF
--- a/spring-cloud-sleuth-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-zipkin/docker-compose.yml
@@ -1,22 +1,35 @@
 cassandra:
-  image: itszero/zipkin-cassandra
+  image: quay.io/openzipkin/zipkin-cassandra:1.9.0
+  ports:
+    - 9042:9042
 collector:
-  image: itszero/zipkin-collector
+  image: quay.io/openzipkin/zipkin-collector:1.9.0
+  environment:
+    - BLOCK_ON_CASSANDRA=true
   expose:
     - 9410
   ports:
     - 9410:9410
+    - 9900:9900
   links:
     - cassandra:db
 query:
-  image: itszero/zipkin-query
+  image: quay.io/openzipkin/zipkin-query:1.9.0
+  environment:
+    - BLOCK_ON_CASSANDRA=true
   expose:
     - 9411
+  ports:
+    - 9411:9411
+    - 9901:9901
   links:
     - cassandra:db
+    - collector
 web:
-  image: itszero/zipkin-web
-  links:
-    - query
+  image: quay.io/openzipkin/zipkin-web:1.9.0
   ports:
-    - 8082:8080
+    - 8080:8080
+    - 9990:9990
+  links:
+    - collector
+    - query


### PR DESCRIPTION
Tested with `spring-cloud-sleuth-sample-zipkin`, except I needed to change application.yml to use it (as docker isn't on localhost).

Noob q: What's the CLI arg equiv of:
```diff
index 20f9a1c..7d196e0 100644
--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/main/resources/application.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: testSleuthZipkin
+  zipkin:
+    host: 192.168.99.100
 
 logging:
   pattern:
```