### PR TITLE
Removed ConditionalOnMissingBean. Fixes #42

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
@@ -57,13 +56,11 @@ public class TraceWebAutoConfiguration {
 	private Trace trace;
 
 	@Bean
-	@ConditionalOnMissingBean
 	public TraceWebAspect traceWebAspect() {
 		return new TraceWebAspect(this.trace);
 	}
 
 	@Bean
-	@ConditionalOnMissingBean
 	public FilterRegistrationBean traceWebFilter(ApplicationEventPublisher publisher) {
 		Pattern pattern = StringUtils.hasText(this.skipPattern) ? Pattern.compile(this.skipPattern)
 				: TraceFilter.DEFAULT_SKIP_PATTERN;


### PR DESCRIPTION
Come to think of it - it's better to remove the `ConditionalOnMissingBean` since we already wrapped the whole configuration file with `ConditionalOnMissingProperty`