### PR TITLE
Updates to latest zipkin/brave 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -48,8 +48,6 @@ logging:
 8. Hit `http://localhost:3380`, `http://localhost:3380/call`, `http://localhost:3380/async` for some interesting sample traces (the app callas back to itself).
 9. Goto `http://localhost:8082` for zipkin web (8080 if running locally from source, the host is the docker host, so if you are using boot2docker it will be different)
 
-WARNING: The docker images for zipkin are old and don't work very well (the UI in particular). Zipkin is in a state of flux, but it should settle down soon when there is an actual release. Best results actually come from building from source and running the jar files (the query and collector services need command line arguments, so check the zipkin README for updates).
-
 NOTE: You can see the zipkin spans without the UI (in logs) if you run the sample with `sample.zipkin.enabled=false`.
 
 There are a few samples with slightly different features:

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 			</dependency>
 			<dependency>
 				<groupId>com.github.kristofa</groupId>
-				<artifactId>brave-zipkin-spancollector</artifactId>
+				<artifactId>brave-spancollector-scribe</artifactId>
 				<version>${brave.version}</version>
 			</dependency>
 			<dependency>
@@ -202,7 +202,7 @@
 	</dependencyManagement>
 
 	<properties>
-		<brave.version>3.0.0</brave.version>
+		<brave.version>3.1.0</brave.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
 		<spock.version>1.0-groovy-2.4</spock.version>

--- a/spring-cloud-sleuth-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-zipkin/docker-compose.yml
@@ -1,35 +1,39 @@
-cassandra:
-  image: quay.io/openzipkin/zipkin-cassandra:1.9.0
+mysql:
+  image: openzipkin/zipkin-mysql:1.25.0
   ports:
-    - 9042:9042
+    - 3306:3306
 collector:
-  image: quay.io/openzipkin/zipkin-collector:1.9.0
+  image: openzipkin/zipkin-collector:1.25.0
   environment:
-    - BLOCK_ON_CASSANDRA=true
+    - TRANSPORT_TYPE=scribe
+    - STORAGE_TYPE=mysql
   expose:
     - 9410
   ports:
     - 9410:9410
     - 9900:9900
   links:
-    - cassandra:db
+    - mysql:storage
 query:
-  image: quay.io/openzipkin/zipkin-query:1.9.0
+  image: openzipkin/zipkin-query:1.25.0
   environment:
-    - BLOCK_ON_CASSANDRA=true
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
+    - STORAGE_TYPE=mysql
   expose:
     - 9411
   ports:
     - 9411:9411
     - 9901:9901
   links:
-    - cassandra:db
-    - collector
+    - mysql:storage
 web:
-  image: quay.io/openzipkin/zipkin-web:1.9.0
+  image: openzipkin/zipkin-web:1.25.0
+  environment:
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
   ports:
     - 8080:8080
     - 9990:9990
   links:
-    - collector
     - query

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -43,7 +43,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.github.kristofa</groupId>
-			<artifactId>brave-zipkin-spancollector</artifactId>
+			<artifactId>brave-spancollector-scribe</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocator.java
@@ -41,7 +41,7 @@ public class DiscoveryClientEndpointLocator implements EndpointLocator {
 	}
 
 	@Override
-	public Endpoint locate(Span span) {
+	public Endpoint local() {
 		ServiceInstance instance = this.client.getLocalServiceInstance();
 		return new Endpoint(getIpAddress(instance),
 				new Integer(instance.getPort()).shortValue(), instance.getServiceId());

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/EndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/EndpointLocator.java
@@ -16,19 +16,16 @@
 
 package org.springframework.cloud.sleuth.zipkin;
 
-import org.springframework.cloud.sleuth.Span;
-
 import com.twitter.zipkin.gen.Endpoint;
 
 /**
- * Strategy for locating a Brave "Endpoin" from a Spring Cloud Span (and whatever other
- * environment properties might be available).
+ * Strategy for locating a zipkin {@linkplain Endpoint} for the current process.
  *
  * @author Dave Syer
  *
  */
 public interface EndpointLocator {
 
-	Endpoint locate(Span span);
+	Endpoint local();
 
 }

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
@@ -28,22 +28,22 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.github.kristofa.brave.SpanCollector;
-import com.github.kristofa.brave.zipkin.ZipkinSpanCollector;
+import com.github.kristofa.brave.scribe.ScribeSpanCollector;
 
 /**
  * @author Spencer Gibb
  */
 @Configuration
 @EnableConfigurationProperties
-@ConditionalOnClass(ZipkinSpanCollector.class)
+@ConditionalOnClass(ScribeSpanCollector.class)
 @ConditionalOnProperty(value = "spring.zipkin.enabled", matchIfMissing = true)
 public class ZipkinAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(SpanCollector.class)
-	public ZipkinSpanCollector spanCollector() {
+	public ScribeSpanCollector spanCollector() {
 		ZipkinProperties zipkin = zipkinProperties();
-		ZipkinSpanCollector collector = new ZipkinSpanCollector(zipkin.getHost(),
+		ScribeSpanCollector collector = new ScribeSpanCollector(zipkin.getHost(),
 				zipkin.getPort(), zipkin.getCollector());
 		return collector;
 	}
@@ -55,7 +55,7 @@ public class ZipkinAutoConfiguration {
 
 	@Bean
 	public ZipkinSpanListener sleuthTracer(SpanCollector spanCollector, EndpointLocator endpointLocator) {
-		return new ZipkinSpanListener(spanCollector, endpointLocator);
+		return new ZipkinSpanListener(spanCollector, endpointLocator.local());
 	}
 
 	@Configuration

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.sleuth.zipkin;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import com.github.kristofa.brave.zipkin.ZipkinSpanCollectorParams;
+import com.github.kristofa.brave.scribe.ScribeSpanCollectorParams;
 
 import lombok.Data;
 
@@ -33,5 +33,5 @@ public class ZipkinProperties {
 	private String host = "localhost";
 	private int port = 9410;
 	private boolean enabled = true;
-	private ZipkinSpanCollectorParams collector = new ZipkinSpanCollectorParams();
+	private ScribeSpanCollectorParams collector = new ScribeSpanCollectorParams();
 }


### PR DESCRIPTION
Zipkin now has Span.timestamp/duration, so no more need for
"aquire/release".

This also corrects the host/endpoint logged for timeline annotations, as
it should always be the local process.

See https://github.com/openzipkin/zipkin/blob/master/zipkin-thrift/src/main/thrift/com/twitter/zipkin/zipkinCore.thrift