### PR TITLE
Added passing of trace data

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
+import org.springframework.cloud.sleuth.IdGenerator;
 import org.springframework.cloud.sleuth.TraceAccessor;
 import org.springframework.cloud.sleuth.TraceManager;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
@@ -65,10 +66,10 @@ public class TraceWebAutoConfiguration {
 	}
 
 	@Bean
-	public FilterRegistrationBean traceWebFilter(ApplicationEventPublisher publisher) {
+	public FilterRegistrationBean traceWebFilter(ApplicationEventPublisher publisher, IdGenerator idGenerator) {
 		Pattern pattern = StringUtils.hasText(this.skipPattern) ? Pattern.compile(this.skipPattern)
 				: TraceFilter.DEFAULT_SKIP_PATTERN;
-		TraceFilter filter = new TraceFilter(this.traceManager, pattern);
+		TraceFilter filter = new TraceFilter(this.traceManager, pattern, idGenerator);
 		filter.setApplicationEventPublisher(publisher);
 		return new FilterRegistrationBean(filter);
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectITest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectITest.java
@@ -16,7 +16,6 @@ import java.util.concurrent.Callable;
 
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +42,6 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
 @SpringApplicationConfiguration(classes = {RestTemplateTraceAspectITest.CorrelationIdAspectSpecConfiguration.class})
-@Ignore("Will fail due to not setting initial values for Trace and Span IDs")
 @RunWith(JUnitParamsRunner.class)
 public class RestTemplateTraceAspectITest extends MvcWiremockITest {
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterITest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterITest.java
@@ -2,11 +2,11 @@ package org.springframework.cloud.sleuth.instrument.web;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.sleuth.IdGenerator;
 import org.springframework.cloud.sleuth.Trace;
 import org.springframework.cloud.sleuth.TraceManager;
 import org.springframework.cloud.sleuth.instrument.DefaultTestAutoConfiguration;
@@ -20,10 +20,12 @@ import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(TraceFilterITest.class)
 @DefaultTestAutoConfiguration
-@Ignore("Will fail cause no tracing data is set on the TraceFilter")
 public class TraceFilterITest extends MvcITest {
 
+	private static final String PING_ENDPOINT = "/ping";
+
 	@Autowired TraceManager traceManager;
+	@Autowired IdGenerator idGenerator;
 
 	@Test
 	public void should_create_and_return_trace_in_HTTP_header() throws Exception {
@@ -43,11 +45,11 @@ public class TraceFilterITest extends MvcITest {
 
 	@Override
 	protected void configureMockMvcBuilder(DefaultMockMvcBuilder mockMvcBuilder) {
-		mockMvcBuilder.addFilters(new TraceFilter(traceManager));
+		mockMvcBuilder.addFilters(new TraceFilter(traceManager, idGenerator));
 	}
 
 	private MvcResult whenSentPingWithoutTracingData() throws Exception {
-		return mockMvc.perform(MockMvcRequestBuilders.get("/ping").accept(MediaType.TEXT_PLAIN)).andReturn();
+		return mockMvc.perform(MockMvcRequestBuilders.get(PING_ENDPOINT).accept(MediaType.TEXT_PLAIN)).andReturn();
 	}
 
 	private MvcResult whenSentPingWithTraceId(String passedCorrelationId) throws Exception {
@@ -55,7 +57,7 @@ public class TraceFilterITest extends MvcITest {
 	}
 
 	private MvcResult sendPingWithTraceId(String headerName, String passedCorrelationId) throws Exception {
-		return mockMvc.perform(MockMvcRequestBuilders.get("/ping").accept(MediaType.TEXT_PLAIN)
+		return mockMvc.perform(MockMvcRequestBuilders.get(PING_ENDPOINT).accept(MediaType.TEXT_PLAIN)
 				.header(headerName, passedCorrelationId)).andReturn();
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
@@ -70,7 +70,7 @@ public class TraceFilterIntegrationTests {
 
 	@Test
 	public void startsNewTrace() throws Exception {
-		TraceFilter filter = new TraceFilter(this.traceManager);
+		TraceFilter filter = new TraceFilter(this.traceManager, new RandomUuidGenerator());
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TraceContextHolder.getCurrentTrace());
 	}
@@ -79,7 +79,7 @@ public class TraceFilterIntegrationTests {
 	public void continuesSpanFromHeaders() throws Exception {
 		this.request = builder().header(Trace.SPAN_ID_NAME, "myspan")
 				.header(Trace.TRACE_ID_NAME, "mytraceManager").buildRequest(new MockServletContext());
-		TraceFilter filter = new TraceFilter(this.traceManager);
+		TraceFilter filter = new TraceFilter(this.traceManager, new RandomUuidGenerator());
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TraceContextHolder.getCurrentSpan());
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/MvcWiremockITest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/MvcWiremockITest.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.sleuth.instrument.web.common;
 
 import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.sleuth.IdGenerator;
 import org.springframework.cloud.sleuth.TraceManager;
 import org.springframework.cloud.sleuth.instrument.web.TraceFilter;
 import org.springframework.test.context.ContextConfiguration;
@@ -28,6 +29,7 @@ public abstract class MvcWiremockITest extends MvcITest {
 	protected WireMock wireMock;
 	@Autowired protected HttpMockServer httpMockServer;
 	@Autowired protected TraceManager trace;
+	@Autowired protected IdGenerator idGenerator;
 
 	@Override
 	@Before
@@ -41,16 +43,8 @@ public abstract class MvcWiremockITest extends MvcITest {
 		this.wireMock.register(mapping.willReturn(response));
 	}
 
-	public WireMock getWireMock() {
-		return this.wireMock;
-	}
-
-	public void setWireMock(WireMock wireMock) {
-		this.wireMock = wireMock;
-	}
-
 	@Override
 	protected void configureMockMvcBuilder(DefaultMockMvcBuilder mockMvcBuilder) {
-		mockMvcBuilder.addFilters(new TraceFilter(this.trace));
+		mockMvcBuilder.addFilters(new TraceFilter(this.trace, idGenerator));
 	}
 }


### PR DESCRIPTION
@dsyer, @spencergibb - I've modified the way trace data is passed in the filter. IMO we should always pass the values of tracing to the response. If the data is not there we should generate it.