### PR TITLE
Fixes missing zipkin service name and polishes span converters.

### DIFF
--- a/spring-cloud-sleuth-stream/pom.xml
+++ b/spring-cloud-sleuth-stream/pom.xml
@@ -51,6 +51,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>2.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/ServerPropertiesHostLocator.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/ServerPropertiesHostLocator.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.sleuth.stream;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
 import org.springframework.cloud.sleuth.Span;
@@ -28,15 +27,14 @@ import org.springframework.context.event.EventListener;
  */
 public class ServerPropertiesHostLocator implements HostLocator {
 
-	@Value("${spring.application.name:application}")
-	private String appName;
-
-	private ServerProperties serverProperties;
-
+	private final ServerProperties serverProperties;
+	private final String appName;
 	private Integer port;
 
-	public ServerPropertiesHostLocator(ServerProperties serverProperties) {
+	public ServerPropertiesHostLocator(ServerProperties serverProperties,
+																		 String appName) {
 		this.serverProperties = serverProperties;
+		this.appName = appName;
 	}
 
 	@Override
@@ -80,7 +78,7 @@ public class ServerPropertiesHostLocator implements HostLocator {
 
 	private String getServiceName(Span span) {
 		String serviceName;
-		if (span.getProcessId() != null) {
+		if (span.getProcessId() != null) { // TODO: javadocs say this isn't nullable!
 			serviceName = span.getProcessId().toLowerCase();
 		}
 		else {

--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfiguration.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.sleuth.stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -77,9 +78,12 @@ public class SleuthStreamAutoConfiguration {
 		@Autowired(required = false)
 		private ServerProperties serverProperties;
 
+		@Value("${spring.application.name:unknown}")
+		private String appName;
+
 		@Bean
 		public HostLocator zipkinEndpointLocator() {
-			return new ServerPropertiesHostLocator(this.serverProperties);
+			return new ServerPropertiesHostLocator(this.serverProperties, this.appName);
 		}
 
 	}
@@ -91,6 +95,9 @@ public class SleuthStreamAutoConfiguration {
 		@Autowired(required = false)
 		private ServerProperties serverProperties;
 
+		@Value("${spring.application.name:unknown}")
+		private String appName;
+
 		@Autowired(required = false)
 		private DiscoveryClient client;
 
@@ -99,7 +106,7 @@ public class SleuthStreamAutoConfiguration {
 			if (this.client != null) {
 				return new DiscoveryClientHostLocator(this.client);
 			}
-			return new ServerPropertiesHostLocator(this.serverProperties);
+			return new ServerPropertiesHostLocator(this.serverProperties, this.appName);
 		}
 
 	}

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/ServerPropertiesHostLocatorTests.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/ServerPropertiesHostLocatorTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.stream;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.cloud.sleuth.MilliSpan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServerPropertiesHostLocatorTests {
+  MilliSpan span = new MilliSpan(1, 3, "name", "traceId", Collections.<String>emptyList(), "spanId", true, true, "processId");
+
+  @Test
+  public void portDefaultsTo8080() {
+    ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(new ServerProperties(), "unknown");
+
+    assertThat(locator.locate(span).getPort()).isEqualTo((short) 8080);
+  }
+
+  @Test
+  public void portFromServerProperties() {
+    ServerProperties properties = new ServerProperties();
+    properties.setPort(1234);
+
+    ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(properties, "unknown");
+
+    assertThat(locator.locate(span).getPort()).isEqualTo((short) 1234);
+  }
+
+  @Test
+  public void portDefaultsToLocalhost() {
+    ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(new ServerProperties(), "unknown");
+
+    assertThat(locator.locate(span).getAddress())
+        .isEqualTo("127.0.0.1");
+  }
+
+  @Test
+  public void hostFromServerPropertiesIp() throws UnknownHostException {
+    ServerProperties properties = new ServerProperties();
+    properties.setAddress(InetAddress.getByAddress(new byte[]{1, 2, 3, 4}));
+
+    ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(properties, "unknown");
+
+    assertThat(locator.locate(span).getAddress())
+        .isEqualTo("1.2.3.4");
+  }
+}

--- a/spring-cloud-sleuth-zipkin-stream/pom.xml
+++ b/spring-cloud-sleuth-zipkin-stream/pom.xml
@@ -82,6 +82,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>2.1.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.zipkin.stream;
+
+import io.zipkin.BinaryAnnotation;
+import io.zipkin.Endpoint;
+import java.util.Collections;
+import org.junit.Test;
+import org.springframework.cloud.sleuth.MilliSpan;
+import org.springframework.cloud.sleuth.stream.Host;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipkinMessageListenerTests {
+	MilliSpan span = new MilliSpan(1, 3, "name", "traceId", Collections.<String>emptyList(), "spanId", true, true, "processId");
+	Host host = new Host("myservice", "1.2.3.4", 8080);
+	Endpoint endpoint = Endpoint.create("myservice", 1 << 24 | 2 << 16 | 3 << 8 | 4, 8080);
+
+	/** Sleuth timestamps are millisecond granularity while zipkin is microsecond. */
+	@Test
+	public void convertsTimestampAndDurationToMicroseconds() {
+		long start = System.currentTimeMillis();
+		span.addTimelineAnnotation("http/request/retry"); // System.currentTimeMillis
+
+		io.zipkin.Span result = ZipkinMessageListener.convert(span, host);
+
+		assertThat(result.timestamp)
+				.isEqualTo(span.getBegin() * 1000);
+		assertThat(result.duration)
+				.isEqualTo((span.getEnd() - span.getBegin()) * 1000);
+		assertThat(result.annotations.get(0).timestamp)
+				.isGreaterThanOrEqualTo(start * 1000)
+				.isLessThanOrEqualTo(System.currentTimeMillis() * 1000);
+	}
+
+	/** Sleuth host corresponds to annotation/binaryAnnotation.host in zipkin. */
+	@Test
+	public void annotationsIncludeHost() {
+		span.addTimelineAnnotation("http/request/retry");
+		span.addAnnotation("spring-boot/version", "1.3.1.RELEASE");
+
+		io.zipkin.Span result = ZipkinMessageListener.convert(span, host);
+
+		assertThat(result.annotations.get(0).endpoint)
+				.isEqualTo(endpoint);
+		assertThat(result.binaryAnnotations.get(0).endpoint)
+				.isEqualTo(result.annotations.get(0).endpoint);
+	}
+
+	/**
+	 * In zipkin, the service context is attached to annotations. Sleuth spans
+	 * that have no annotations will get an "lc" one, which allows them to be
+	 * queryable in zipkin by service name.
+	 */
+	@Test
+	public void spanWithoutAnnotationsLogsComponent() {
+		io.zipkin.Span result = ZipkinMessageListener.convert(span, host);
+
+		assertThat(result.binaryAnnotations)
+				.containsOnly(BinaryAnnotation.create("lc", span.getProcessId(), endpoint));
+	}
+
+	// TODO: "unknown" bc process id, documented as not nullable, is null in some tests.
+	@Test
+	public void nullProcessIdCoercesToUnknownServiceName() {
+		MilliSpan noProcessId = MilliSpan.builder().traceId("xxxx").name("parent").remote(true).build();
+
+		io.zipkin.Span result = ZipkinMessageListener.convert(noProcessId, host);
+
+		assertThat(result.binaryAnnotations)
+				.containsOnly(BinaryAnnotation.create("lc", "unknown", endpoint));
+	}
+}

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.sleuth.zipkin;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
 import org.springframework.cloud.util.InetUtils;
@@ -30,15 +29,14 @@ import com.twitter.zipkin.gen.Endpoint;
  */
 public class ServerPropertiesEndpointLocator implements EndpointLocator {
 
-	@Value("${spring.application.name:application}")
-	private String appName;
-
-	private ServerProperties serverProperties;
-
+	private final ServerProperties serverProperties;
+  private final String appName;
 	private Integer port;
 
-	public ServerPropertiesEndpointLocator(ServerProperties serverProperties) {
+	public ServerPropertiesEndpointLocator(ServerProperties serverProperties,
+																				 String appName) {
 		this.serverProperties = serverProperties;
+		this.appName = appName;
 	}
 
 	@Override

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.sleuth.zipkin;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -65,9 +66,12 @@ public class ZipkinAutoConfiguration {
 		@Autowired(required=false)
 		private ServerProperties serverProperties;
 
+		@Value("${spring.application.name:unknown}")
+		private String appName;
+
 		@Bean
 		public EndpointLocator zipkinEndpointLocator() {
-			return new ServerPropertiesEndpointLocator(this.serverProperties);
+			return new ServerPropertiesEndpointLocator(this.serverProperties, this.appName);
 		}
 
 	}
@@ -79,13 +83,16 @@ public class ZipkinAutoConfiguration {
 		@Autowired(required=false)
 		private ServerProperties serverProperties;
 
+		@Value("${spring.application.name:unknown}")
+		private String appName;
+
 		@Autowired(required=false)
 		private DiscoveryClient client;
 
 		@Bean
 		public EndpointLocator zipkinEndpointLocator() {
 			return new FallbackHavingEndpointLocator(discoveryClientEndpointLocator(),
-					new ServerPropertiesEndpointLocator(this.serverProperties));
+					new ServerPropertiesEndpointLocator(this.serverProperties, this.appName));
 		}
 
 		private DiscoveryClientEndpointLocator discoveryClientEndpointLocator() {

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocatorTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocatorTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.zipkin;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ServerPropertiesEndpointLocatorTests {
+
+  @Test
+  public void portDefaultsTo8080() {
+    ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(new ServerProperties(), "unknown");
+
+    assertThat(locator.local().port).isEqualTo((short) 8080);
+  }
+
+  @Test
+  public void portFromServerProperties() {
+    ServerProperties properties = new ServerProperties();
+    properties.setPort(1234);
+
+    ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(properties, "unknown");
+
+    assertThat(locator.local().port).isEqualTo((short) 1234);
+  }
+
+  @Test
+  public void portDefaultsToLocalhost() {
+    ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(new ServerProperties(), "unknown");
+
+    assertThat(locator.local().ipv4)
+        .isEqualTo(127 << 24 | 1);
+  }
+
+  @Test
+  public void hostFromServerPropertiesIp() throws UnknownHostException {
+    ServerProperties properties = new ServerProperties();
+    properties.setAddress(InetAddress.getByAddress(new byte[]{1, 2, 3, 4}));
+
+    ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(properties, "unknown");
+
+    assertThat(locator.local().ipv4)
+        .isEqualTo(1 << 24 | 2 << 16 | 3 << 8 | 4);
+  }
+}

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.sleuth.zipkin;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import com.twitter.zipkin.gen.Endpoint;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -66,21 +69,71 @@ public class ZipkinSpanListenerTests {
 	@Autowired
 	private ZipkinTestConfiguration test;
 
+	@Autowired
+	private ZipkinSpanListener listener;
+
 	@PostConstruct
 	public void init() {
 		this.test.spans.clear();
 	}
 
+	Span parent = MilliSpan.builder().traceId("xxxx").name("parent").remote(true).build();
+
+	/** Sleuth timestamps are millisecond granularity while zipkin is microsecond. */
 	@Test
-	public void acquireAndRelease() {
+	public void convertsTimestampAndDurationToMicroseconds() {
+		long start = System.currentTimeMillis();
+		parent.addTimelineAnnotation("http/request/retry"); // System.currentTimeMillis
+
+		com.twitter.zipkin.gen.Span result = listener.convert(parent);
+
+		assertThat(result.timestamp)
+				.isEqualTo(parent.getBegin() * 1000);
+		assertThat(result.duration)
+				.isEqualTo((parent.getEnd() - parent.getBegin()) * 1000);
+		assertThat(result.annotations.get(0).timestamp)
+				.isGreaterThanOrEqualTo(start * 1000)
+				.isLessThanOrEqualTo(System.currentTimeMillis() * 1000);
+	}
+
+	/** Sleuth host corresponds to annotation/binaryAnnotation.host in zipkin. */
+	@Test
+	public void annotationsIncludeHost() {
+		parent.addTimelineAnnotation("http/request/retry");
+		parent.addAnnotation("spring-boot/version", "1.3.1.RELEASE");
+
+		com.twitter.zipkin.gen.Span result = listener.convert(parent);
+
+		assertThat(result.annotations.get(0).host)
+				.isEqualTo(listener.localEndpoint);
+		assertThat(result.binary_annotations.get(0).host)
+				.isEqualTo(result.annotations.get(0).host);
+	}
+
+	/** zipkin's Endpoint.serviceName should never be null. */
+	@Test
+	public void localEndpointIncludesServiceName() {
+		assertThat(listener.localEndpoint.service_name)
+				.isNotEmpty();
+	}
+
+	/**
+	 * In zipkin, the service context is attached to annotations. Sleuth spans
+	 * that have no annotations will get an "lc" one, which allows them to be
+	 * queryable in zipkin by service name.
+	 */
+	@Test
+	public void spanWithoutAnnotationsLogsComponent() {
 		Trace context = this.traceManager.startSpan("foo");
 		this.traceManager.close(context);
 		assertEquals(1, this.test.spans.size());
+		assertThat(this.test.spans.get(0).getBinary_annotations())
+				.extracting("host.service_name")
+				.isEqualTo("unknown"); // TODO: "unknown" bc process id, documented as not nullable, is null.
 	}
 
 	@Test
 	public void rpcAnnotations() {
-		Span parent = MilliSpan.builder().traceId("xxxx").name("parent").remote(true).build();
 		Trace context = this.traceManager.startSpan("child", parent);
 		this.application.publishEvent(new ClientSentEvent(this, context.getSpan()));
 		this.application.publishEvent(new ServerReceivedEvent(this, parent, context.getSpan()));


### PR DESCRIPTION
Fixes missing zipkin service name and polishes span converters.

Missing service name:

Zipkin service names were logged as null, which is invalid and led to
them showing up as "unknown" in the zipkin ui. This was due to a wiring
bug, and a special-case, which this change fixes.

The special-case was when a sleuth span had no annotations. Since zipkin
service names are attached to annotations, they are only queryable when 
annotations exist. When there are no annotations, we add the "lc" 
binary annotation, which makes that span attached to the correct service
in zipkin.

Polishing:

Zipkin timestamps were not always set as microseconds. This fixes that.

The de-facto label in zipkin for unknown service is "unknown". This
fixes the code, which formerly fell back to "application".

This also removes complexity in assigning timestamp and duration as we
no longer need to make pseudo-annotations "acquire" and "release".

Finally, this adds tests about above consistently to both scs-zipkin and
scs-zipkin-stream.