### PR TITLE
Updates to zipkin-java 0.4.1, particularly docker images

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<brave.version>3.4.0</brave.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.4.0</zipkin-java.version>
+		<zipkin-java.version>0.4.1</zipkin-java.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -85,13 +85,13 @@
 			<dependency>
 				<groupId>io.zipkin</groupId>
 				<artifactId>zipkin-java-core</artifactId>
-				<version>0.4.0</version>
+				<version>0.4.1</version>
 				<scope>compile</scope>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin</groupId>
 				<artifactId>zipkin-java-server</artifactId>
-				<version>0.4.0</version>
+				<version>0.4.1</version>
 				<scope>compile</scope>
 			</dependency>
 		</dependencies>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/src/main/resources/application.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/src/main/resources/application.yml
@@ -7,14 +7,6 @@ spring:
   datasource:
     initialize: false
 
-zipkin:
-  collector:
-    sample-rate: 1.0 # percentage to traces to retain
-  query:
-    lookback: 86400000 # 7 days in millis
-  store:
-    type: mem # default is inMemory
-
 ---
 spring:
   profiles: mysql
@@ -30,4 +22,4 @@ spring:
     enabled: false
 zipkin:
   store:
-    type: mysql # default is inMemory
+    type: mysql # default is mem (in-memory)

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
@@ -3,16 +3,16 @@ mysql:
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-query:1.30.0
+  image: openzipkin/zipkin-java:0.4.1
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
     - STORAGE_TYPE=mysql
+    # - JAVA_OPTS=your jvm params here
   expose:
     - 9411
   ports:
     - 9411:9411
-    - 9901:9901
   links:
     - mysql:storage
 web:

--- a/spring-cloud-sleuth-zipkin-stream/src/test/resources/application.yml
+++ b/spring-cloud-sleuth-zipkin-stream/src/test/resources/application.yml
@@ -1,7 +1,0 @@
-zipkin:
-  collector:
-    sample-rate: 1.0 # percentage to traces to retain
-  query:
-    lookback: 86400000 # 7 days in millis
-  store:
-    type: mem # default is inMemory

--- a/spring-cloud-sleuth-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-zipkin/docker-compose.yml
@@ -3,16 +3,16 @@ mysql:
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-query:1.30.0
+  image: openzipkin/zipkin-java:0.4.1
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
     - STORAGE_TYPE=mysql
+    # - JAVA_OPTS=your jvm params here
   expose:
     - 9411
   ports:
     - 9411:9411
-    - 9901:9901
   links:
     - mysql:storage
 web:


### PR DESCRIPTION
Zipkin 0.4.1 obviates some duplication of configuration. It is also the
first version that's published as a docker image.

By switching to the published image of zipkin-java, we can be more
consistent, as `spring-cloud-sleuth-zipkin-stream` is derived from that,
not the scala query service.