### PR TITLE
Introduces HttpZipkinSpanReporter

### DIFF
--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/pom.xml
@@ -81,6 +81,10 @@
 			<artifactId>lombok</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.github.kristofa</groupId>
+			<artifactId>brave-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/pom.xml
@@ -69,6 +69,10 @@
 			<artifactId>lombok</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.github.kristofa</groupId>
+			<artifactId>brave-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/IntegrationTestZipkinSpanReporter.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/IntegrationTestZipkinSpanReporter.java
@@ -15,25 +15,26 @@
  */
 package tools;
 
-import com.github.kristofa.brave.LoggingSpanCollector;
-import com.twitter.zipkin.gen.Span;
-
+import io.zipkin.Span;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import lombok.extern.apachecommons.CommonsLog;
+import org.springframework.cloud.sleuth.zipkin.ZipkinSpanReporter;
 
 /**
  * Span Collector that logs spans and adds Spans to a list
  *
  * @author Marcin Grzejszczak
  */
-public class IntegrationTestSpanCollector extends LoggingSpanCollector {
+@CommonsLog
+public class IntegrationTestZipkinSpanReporter implements ZipkinSpanReporter {
 
-	public List<Span> hashedSpans = Collections.<Span>synchronizedList(new LinkedList<Span>());
+	public List<Span> hashedSpans = Collections.synchronizedList(new LinkedList<>());
 
 	@Override
-	public void collect(Span span) {
-		super.collect(span);
+	public void report(Span span) {
+		log.info(span);
 		hashedSpans.add(span);
 	}
 

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -42,8 +42,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.github.kristofa</groupId>
-			<artifactId>brave-core</artifactId>
+			<groupId>io.zipkin</groupId>
+			<artifactId>zipkin-java-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -59,6 +59,12 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>mockwebserver</artifactId>
+			<version>3.0.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocator.java
@@ -20,7 +20,7 @@ import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.util.InetUtils;
 
-import com.twitter.zipkin.gen.Endpoint;
+import io.zipkin.Endpoint;
 
 /**
  * An {@link EndpointLocator} that tries to find local service information from a
@@ -43,8 +43,7 @@ public class DiscoveryClientEndpointLocator implements EndpointLocator {
 		if (instance == null) {
 			throw new NoServiceInstanceAvailableException();
 		}
-		return new Endpoint(getIpAddress(instance),
-				new Integer(instance.getPort()).shortValue(), instance.getServiceId());
+		return Endpoint.create(instance.getServiceId(), getIpAddress(instance), instance.getPort());
 	}
 
 	private int getIpAddress(ServiceInstance instance) {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/EndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/EndpointLocator.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.sleuth.zipkin;
 
-import com.twitter.zipkin.gen.Endpoint;
+import io.zipkin.Endpoint;
 
 /**
  * Strategy for locating a zipkin {@linkplain Endpoint} for the current process.

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocator.java
@@ -1,6 +1,6 @@
 package org.springframework.cloud.sleuth.zipkin;
 
-import com.twitter.zipkin.gen.Endpoint;
+import io.zipkin.Endpoint;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporter.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporter.java
@@ -1,0 +1,139 @@
+package org.springframework.cloud.sleuth.zipkin;
+
+import io.zipkin.Codec;
+import io.zipkin.Span;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.apachecommons.CommonsLog;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Submits spans using Zipkin's {@code POST /spans} endpoint.
+ */
+@CommonsLog
+public final class HttpZipkinSpanReporter implements ZipkinSpanReporter, Flushable, Closeable {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  private final String url;
+  private final BlockingQueue<Span> pending = new LinkedBlockingQueue<>(1000);
+  private final Flusher flusher; // Nullable for testing
+
+  /**
+   * @param baseUrl URL of the zipkin query server instance. Like: http://localhost:9411/
+   * @param flushInterval in seconds. 0 implies spans are {@link #flush() flushed} externally.
+   */
+  public HttpZipkinSpanReporter(String baseUrl, int flushInterval) {
+    this.url = baseUrl + (baseUrl.endsWith("/") ? "" : "/") + "api/v1/spans";
+    this.flusher = flushInterval > 0 ? new Flusher(this, flushInterval) : null;
+  }
+
+  /**
+   * Queues the span for collection, or drops it if the queue is full.
+   *
+   * @param span Span, should not be <code>null</code>.
+   */
+  @Override
+  public void report(Span span) {
+    // TODO: metrics.incrementAcceptedSpans(1);
+    if (!pending.offer(span)) {
+      // TODO: metrics.incrementDroppedSpans(1);
+    }
+  }
+
+  /**
+   * Calling this will flush any pending spans to the http transport on the current thread.
+   */
+  @Override
+  public void flush() {
+    if (pending.isEmpty()) return;
+    List<Span> drained = new ArrayList<>(pending.size());
+    pending.drainTo(drained);
+    if (drained.isEmpty()) return;
+
+    // json-encode the spans for transport
+    byte[] json = Codec.JSON.writeSpans(drained);
+    // NOTE: https://github.com/openzipkin/zipkin-java/issues/66 will throw instead of return null.
+    if (json == null) {
+      log.debug("failed to encode spans, dropping them: " + drained);
+      // TODO: metrics.incrementDroppedSpans(spanCount);
+      return;
+    }
+
+    // Send the json to the zipkin endpoint
+    try {
+      postSpans(json);
+    } catch (IOException e) {
+      if (log.isDebugEnabled()) { // don't pollute logs unless debug is on.
+        // TODO: logger test
+        log.debug("error POSTing spans to " + url + ": as json: " + new String(json, UTF_8), e);
+      }
+      // TODO: metrics.incrementDroppedSpans(spanCount);
+      return;
+    }
+  }
+
+  /** Calls flush on a fixed interval */
+  static final class Flusher implements Runnable {
+    final Flushable flushable;
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    Flusher(Flushable flushable, int flushInterval) {
+      this.flushable = flushable;
+      this.scheduler.scheduleWithFixedDelay(this, 0, flushInterval, SECONDS);
+    }
+
+    @Override
+    public void run() {
+      try {
+        flushable.flush();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  void postSpans(byte[] json) throws IOException {
+    // intentionally not closing the connection, so as to use keep-alives
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    connection.setRequestMethod("POST");
+    connection.addRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+    connection.setFixedLengthStreamingMode(json.length);
+    connection.getOutputStream().write(json);
+
+    try (InputStream in = connection.getInputStream()) {
+      while (in.read() != -1) ; // skip
+    } catch (IOException e) {
+      try (InputStream err = connection.getErrorStream()) {
+        if (err != null) { // possible, if the connection was dropped
+          while (err.read() != -1) ; // skip
+        }
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Requests a cease of delivery. There will be at most one in-flight request processing after this
+   * call returns.
+   */
+  @Override
+  public void close() {
+    if (flusher != null) flusher.scheduler.shutdown();
+    // throw any outstanding spans on the floor
+    int dropped = pending.drainTo(new LinkedList<>());
+    // TODO: metrics.incrementDroppedSpans(dropped);
+  }
+}

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.embedded.EmbeddedServletContainerInitial
 import org.springframework.cloud.util.InetUtils;
 import org.springframework.context.event.EventListener;
 
-import com.twitter.zipkin.gen.Endpoint;
+import io.zipkin.Endpoint;
 
 /**
  * @author Dave Syer
@@ -43,7 +43,7 @@ public class ServerPropertiesEndpointLocator implements EndpointLocator {
 	public Endpoint local() {
 		int address = getAddress();
 		Integer port = getPort();
-		Endpoint ep = new Endpoint(address, port.shortValue(), this.appName);
+		Endpoint ep = Endpoint.create(this.appName, address, port);
 		return ep;
 	}
 
@@ -71,7 +71,7 @@ public class ServerPropertiesEndpointLocator implements EndpointLocator {
 			return InetUtils.getIpAddressAsInt(this.serverProperties.getAddress().getHostAddress());
 		}
 		else {
-			return 127 <<24|1;
+			return 127 << 24 | 1;
 		}
 	}
 }

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.sleuth.zipkin;
 
-import com.github.kristofa.brave.HttpSpanCollector;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.Data;
@@ -32,5 +31,5 @@ public class ZipkinProperties {
 	private String host = "localhost";
 	private int port = 9411;
 	private boolean enabled = true;
-	private HttpSpanCollector.Config httpConfig = HttpSpanCollector.Config.builder().build();
+	private int flushInterval = 1;
 }

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanReporter.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanReporter.java
@@ -1,0 +1,11 @@
+package org.springframework.cloud.sleuth.zipkin;
+
+import io.zipkin.Span;
+
+public interface ZipkinSpanReporter {
+  /**
+   * Receives completed spans from {@link ZipkinSpanListener} and submits them to a Zipkin
+   * collector.
+   */
+  void report(Span span);
+}

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocatorTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocatorTests.java
@@ -1,6 +1,6 @@
 package org.springframework.cloud.sleuth.zipkin;
 
-import com.twitter.zipkin.gen.Endpoint;
+import io.zipkin.Endpoint;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
@@ -14,7 +14,7 @@ public class FallbackHavingEndpointLocatorTests {
 
 	@Mock DiscoveryClientEndpointLocator discoveryClientEndpointLocator;
 	@Mock ServerPropertiesEndpointLocator serverPropertiesEndpointLocator;
-	Endpoint expectedEndpoint = new Endpoint();
+	Endpoint expectedEndpoint = Endpoint.create("my-tomcat", 127 << 24 | 1, 8080);
 
 	@Test
 	public void should_use_system_property_locator_if_discovery_client_locator_is_not_present() {

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
@@ -1,0 +1,96 @@
+package org.springframework.cloud.sleuth.zipkin;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.SocketPolicy;
+import io.zipkin.Codec;
+import io.zipkin.Span;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpZipkinSpanReporterTest {
+
+  @Rule
+  public final MockWebServer server = new MockWebServer();
+
+  // set flush interval to 0 so that tests can drive flushing explicitly
+  HttpZipkinSpanReporter reporter = new HttpZipkinSpanReporter(server.url("").toString(), 0);
+
+  @Test
+  public void reportDoesntDoIO() throws Exception {
+    reporter.report(span(1L, "foo"));
+
+    assertThat(server.getRequestCount()).isZero();
+  }
+
+  @Test
+  public void reportIncrementsAcceptedMetrics() throws Exception {
+    reporter.report(span(1L, "foo"));
+
+    // TODO: assertThat(metrics.acceptedSpans.get()).isEqualTo(1);
+    // TODO: assertThat(metrics.droppedSpans.get()).isZero();
+  }
+
+  @Test
+  public void dropsWhenQueueIsFull() throws Exception {
+    for (int i = 0; i < 1001; i++)
+      reporter.report(span(1L, "foo"));
+
+    // TODO: assertThat(metrics.acceptedSpans.get()).isEqualTo(1001);
+    // TODO: assertThat(metrics.droppedSpans.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void postsSpans() throws Exception {
+    server.enqueue(new MockResponse());
+
+    reporter.report(span(1L, "foo"));
+    reporter.report(span(2L, "bar"));
+
+    reporter.flush(); // manually flush the spans
+
+    // Ensure a proper request was sent
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getRequestLine()).isEqualTo("POST /api/v1/spans HTTP/1.1");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json");
+
+    // Now, let's read back the spans we sent!
+    List<io.zipkin.Span> zipkinSpans = Codec.JSON.readSpans(request.getBody().readByteArray());
+    assertThat(zipkinSpans).containsExactly(
+        span(1L, "foo"),
+        span(2L, "bar")
+    );
+  }
+
+  @Test
+  public void incrementsDroppedSpansWhenServerErrors() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500));
+
+    reporter.report(span(1L, "foo"));
+    reporter.report(span(2L, "bar"));
+
+    reporter.flush(); // manually flush the spans
+
+    // TODO: assertThat(metrics.droppedSpans.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void incrementsDroppedSpansWhenServerDisconnects() throws Exception {
+    server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+
+    reporter.report(span(1L, "foo"));
+    reporter.report(span(2L, "bar"));
+
+    reporter.flush(); // manually flush the spans
+
+    // TODO: assertThat(metrics.droppedSpans.get()).isEqualTo(2);
+  }
+
+  static Span span(long traceId, String spanName) {
+    return new io.zipkin.Span.Builder().traceId(traceId).id(traceId).name(spanName).build();
+  }
+}


### PR DESCRIPTION
Brave's span collector, which turned out to not be a great tool for
direct use. Brave internally creates spans before sending to its
collector, so validation is implicit. The flip side of this is using the
collector directly does not validate spans. This means it is easy to
send invalid ones, for example missing span names. The problem is more
difficult as the data is in binary (thrift).

This introduces HttpZipkinSpanReporter, which validates via zipkin-java
classes before sending on the wire. Moreover, this sends in json to make
debugging problems easier.

This does not fully remove the Brave dependency, as further work is
needed. Particularly, Brave is indirectly referenced in other code.

See https://github.com/openzipkin/zipkin-java/issues/68
See #98 (Reporter is an OpenTracing term)