### PR TITLE
Prefers the word event when adding to a Span's timeline

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Log.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Log.java
@@ -25,12 +25,25 @@ import lombok.RequiredArgsConstructor;
 @Data
 @RequiredArgsConstructor
 public class Log {
-	private final long time;
-	private final String msg;
+	/**
+	 * The epoch timestamp of the log record; often set via {@link System#currentTimeMillis()}.
+	 */
+	private final long timestamp;
+
+	/**
+	 * Event (if not null) should be the stable name of some notable moment in the lifetime of a Span.
+	 * For instance, a Span representing a browser page load might add an Event for each of the
+	 * Performance.timing moments here: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming
+	 *
+	 * <p>While it is not a formal requirement, Event strings will be most useful if they are *not*
+	 * unique; rather, tracing systems should be able to use them to understand how two similar Spans
+	 * relate from an internal timing perspective.
+	 */
+	private final String event;
 
 	@SuppressWarnings("unused")
 	private Log() {
-		this.time = 0;
-		this.msg = null;
+		this.timestamp = 0;
+		this.event = null;
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -170,11 +170,10 @@ public class Span {
 	}
 
 	/**
-	 * Add a log or timeline annotation associated with this span
+	 * Add an {@link Log#event event} to the timeline associated with this span.
 	 */
-	public void log(String msg) {
-		this.logs.add(new Log(System.currentTimeMillis(),
-				msg));
+	public void logEvent(String event) {
+		this.logs.add(new Log(System.currentTimeMillis(), event));
 	}
 
 	/**
@@ -188,7 +187,7 @@ public class Span {
 	}
 
 	/**
-	 * Get any logs or annotations (read only)
+	 * Get any timestamped events (read only)
 	 * <p/>
 	 * <p/>
 	 * Will never be null.

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/JsonLogSpanListenerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/JsonLogSpanListenerTests.java
@@ -48,7 +48,7 @@ public class JsonLogSpanListenerTests {
 				.end(10)
 				.build();
 		span.tag("myKey", "myVal");
-		span.log("myTimelineAnnotation");
+		span.logEvent("myTimelineAnnotation");
 		listener.stop(new SpanReleasedEvent(this, span));
 
 		String output = this.output.toString().trim();

--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/StreamSpanListener.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/StreamSpanListener.java
@@ -65,34 +65,34 @@ public class StreamSpanListener {
 	@EventListener
 	@Order(0)
 	public void start(SpanAcquiredEvent event) {
-		event.getSpan().log("acquire");
+		event.getSpan().logEvent("acquire");
 	}
 
 	@EventListener
 	@Order(0)
 	public void serverReceived(ServerReceivedEvent event) {
 		if (event.getParent() != null && event.getParent().isRemote()) {
-			event.getParent().log(SERVER_RECV);
+			event.getParent().logEvent(SERVER_RECV);
 		}
 	}
 
 	@EventListener
 	@Order(0)
 	public void clientSend(ClientSentEvent event) {
-		event.getSpan().log(CLIENT_SEND);
+		event.getSpan().logEvent(CLIENT_SEND);
 	}
 
 	@EventListener
 	@Order(0)
 	public void clientReceive(ClientReceivedEvent event) {
-		event.getSpan().log(CLIENT_RECV);
+		event.getSpan().logEvent(CLIENT_RECV);
 	}
 
 	@EventListener
 	@Order(0)
 	public void serverSend(ServerSentEvent event) {
 		if (event.getParent() != null && event.getParent().isRemote()) {
-			event.getParent().log(SERVER_SEND);
+			event.getParent().logEvent(SERVER_SEND);
 			this.queue.add(event.getParent());
 		}
 	}
@@ -100,7 +100,7 @@ public class StreamSpanListener {
 	@EventListener
 	@Order(0)
 	public void release(SpanReleasedEvent event) {
-		event.getSpan().log("release");
+		event.getSpan().logEvent("release");
 		if (event.getSpan().isExportable()) {
 			this.queue.add(event.getSpan());
 		}

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListener.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListener.java
@@ -106,8 +106,8 @@ public class ZipkinMessageListener {
 		for (Log ta : span.logs()) {
 			Annotation zipkinAnnotation = new Annotation.Builder()
 					.endpoint(endpoint)
-					.timestamp(ta.getTime() * 1000) // Zipkin is in microseconds
-					.value(ta.getMsg())
+					.timestamp(ta.getTimestamp() * 1000) // Zipkin is in microseconds
+					.value(ta.getEvent())
 					.build();
 			zipkinSpan.addAnnotation(zipkinAnnotation);
 		}

--- a/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
@@ -36,7 +36,7 @@ public class ZipkinMessageListenerTests {
 	@Test
 	public void convertsTimestampAndDurationToMicroseconds() {
 		long start = System.currentTimeMillis();
-		this.span.log("hystrix/retry"); // System.currentTimeMillis
+		this.span.logEvent("hystrix/retry"); // System.currentTimeMillis
 
 		zipkin.Span result = ZipkinMessageListener.convert(this.span, this.host);
 
@@ -52,7 +52,7 @@ public class ZipkinMessageListenerTests {
 	/** Sleuth host corresponds to annotation/binaryAnnotation.host in zipkin. */
 	@Test
 	public void annotationsIncludeHost() {
-		this.span.log("hystrix/retry");
+		this.span.logEvent("hystrix/retry");
 		this.span.tag("spring-boot/version", "1.3.1.RELEASE");
 
 		zipkin.Span result = ZipkinMessageListener.convert(this.span, this.host);

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
@@ -71,7 +71,7 @@ public class ZipkinSpanListener {
 			// If an inbound RPC call, it should log a "sr" annotation.
 			// If possible, it should log a binary annotation of "ca", indicating the
 			// caller's address (ex X-Forwarded-For header)
-			event.getParent().log(Constants.SERVER_RECV);
+			event.getParent().logEvent(Constants.SERVER_RECV);
 		}
 	}
 
@@ -81,20 +81,20 @@ public class ZipkinSpanListener {
 		// For an outbound RPC call, it should log a "cs" annotation.
 		// If possible, it should log a binary annotation of "sa", indicating the
 		// destination address.
-		event.getSpan().log(Constants.CLIENT_SEND);
+		event.getSpan().logEvent(Constants.CLIENT_SEND);
 	}
 
 	@EventListener
 	@Order(0)
 	public void clientReceive(ClientReceivedEvent event) {
-		event.getSpan().log(Constants.CLIENT_RECV);
+		event.getSpan().logEvent(Constants.CLIENT_RECV);
 	}
 
 	@EventListener
 	@Order(0)
 	public void serverSend(ServerSentEvent event) {
 		if (event.getParent() != null && event.getParent().isRemote()) {
-			event.getParent().log(Constants.SERVER_SEND);
+			event.getParent().logEvent(Constants.SERVER_SEND);
 			this.reporter.report(convert(event.getParent()));
 		}
 	}
@@ -163,8 +163,8 @@ public class ZipkinSpanListener {
 		for (Log ta : span.logs()) {
 			Annotation zipkinAnnotation = new Annotation.Builder()
 					.endpoint(endpoint)
-					.timestamp(ta.getTime() * 1000) // Zipkin is in microseconds
-					.value(ta.getMsg()).build();
+					.timestamp(ta.getTimestamp() * 1000) // Zipkin is in microseconds
+					.value(ta.getEvent()).build();
 			zipkinSpan.addAnnotation(zipkinAnnotation);
 		}
 	}

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
@@ -75,7 +75,7 @@ public class ZipkinSpanListenerTests {
 	@Test
 	public void convertsTimestampAndDurationToMicroseconds() {
 		long start = System.currentTimeMillis();
-		this.parent.log("hystrix/retry"); // System.currentTimeMillis
+		this.parent.logEvent("hystrix/retry"); // System.currentTimeMillis
 
 		zipkin.Span result = this.listener.convert(this.parent);
 
@@ -91,7 +91,7 @@ public class ZipkinSpanListenerTests {
 	/** Sleuth host corresponds to annotation/binaryAnnotation.host in zipkin. */
 	@Test
 	public void annotationsIncludeHost() {
-		this.parent.log("hystrix/retry");
+		this.parent.logEvent("hystrix/retry");
 		this.parent.tag("spring-boot/version", "1.3.1.RELEASE");
 
 		zipkin.Span result = this.listener.convert(this.parent);


### PR DESCRIPTION
Span.logs are really timestamped events. This clarifies the naming and
documentation around that.

See https://github.com/opentracing/opentracing-go/pull/39