### PR TITLE
[#142] Initial implementation of span duration histogram

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/GaugeServiceBasedSpanDurationReporterService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/GaugeServiceBasedSpanDurationReporterService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.metric;
+
+import org.springframework.boot.actuate.metrics.GaugeService;
+import org.springframework.util.StringUtils;
+
+/**
+ * Service to operate on span duration statistics.
+ *
+ * @author Marcin Grzejszczak
+ */
+public class GaugeServiceBasedSpanDurationReporterService implements SpanDurationReporterService {
+	private final String metricPrefix;
+	private final GaugeService gaugeService;
+
+	public GaugeServiceBasedSpanDurationReporterService(String metricPrefix,
+			GaugeService gaugeService) {
+		this.metricPrefix = metricPrefix;
+		this.gaugeService = gaugeService;
+	}
+
+	@Override
+	public void submitDuration(String metricName, double duration) {
+		String metricFullName = metricName;
+		if (StringUtils.hasText(this.metricPrefix)) {
+			metricFullName = this.metricPrefix + "." + metricName;
+		}
+		this.gaugeService.submit(metricFullName, duration);
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/NoOpSpanDurationReporterService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/NoOpSpanDurationReporterService.java
@@ -19,19 +19,10 @@ package org.springframework.cloud.sleuth.metric;
 /**
  * @author Marcin Grzejszczak
  */
-public interface SpanReporterService {
+public class NoOpSpanDurationReporterService implements SpanDurationReporterService {
 
-	/**
-	 * Called when spans are submitted to SpanCollector for processing.
-	 *
-	 * @param quantity the number of spans accepted.
-	 */
-	void incrementAcceptedSpans(long quantity);
+	@Override
+	public void submitDuration(String metricName, double duration) {
 
-	/**
-	 * Called when spans become lost for any reason and won't be delivered to the target collector.
-	 *
-	 * @param quantity the number of spans dropped.
-	 */
-	void incrementDroppedSpans(long quantity);
+	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SleuthMetricProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SleuthMetricProperties.java
@@ -26,6 +26,8 @@ public class SleuthMetricProperties {
 
 		private String droppedName = "counter.span.dropped";
 
+		private String durationPrefixName = "histogram.span";
+
 		public String getAcceptedName() {
 			return this.acceptedName;
 		}
@@ -40,6 +42,14 @@ public class SleuthMetricProperties {
 
 		public void setDroppedName(String droppedName) {
 			this.droppedName = droppedName;
+		}
+
+		public String getDurationPrefixName() {
+			return this.durationPrefixName;
+		}
+
+		public void setDurationPrefixName(String durationPrefixName) {
+			this.durationPrefixName = durationPrefixName;
 		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SpanDurationReporterService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SpanDurationReporterService.java
@@ -19,19 +19,14 @@ package org.springframework.cloud.sleuth.metric;
 /**
  * @author Marcin Grzejszczak
  */
-public interface SpanReporterService {
+public interface SpanDurationReporterService {
 
 	/**
-	 * Called when spans are submitted to SpanCollector for processing.
+	 * Once the span is closed - it's duration will be submitted for metric aggregation
 	 *
-	 * @param quantity the number of spans accepted.
+	 * @param metricName the name of the metric
+	 * @param duration the duration of a span
 	 */
-	void incrementAcceptedSpans(long quantity);
+	void submitDuration(String metricName, double duration);
 
-	/**
-	 * Called when spans become lost for any reason and won't be delivered to the target collector.
-	 *
-	 * @param quantity the number of spans dropped.
-	 */
-	void incrementDroppedSpans(long quantity);
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -16,16 +16,7 @@
 
 package org.springframework.cloud.sleuth.instrument.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-
-import java.util.Random;
-
+import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -46,7 +37,15 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
-import lombok.SneakyThrows;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 /**
  * @author Spencer Gibb

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilterTests.java
@@ -16,11 +16,7 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.verify;
-
-import java.util.Random;
-
+import com.netflix.zuul.context.RequestContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +27,10 @@ import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.context.ApplicationEventPublisher;
 
-import com.netflix.zuul.context.RequestContext;
+import java.util.Random;
+
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Dave Syer

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilterTests.java
@@ -16,13 +16,7 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
-import java.util.Random;
-
+import com.netflix.zuul.context.RequestContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +28,12 @@ import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.context.ApplicationEventPublisher;
 
-import com.netflix.zuul.context.RequestContext;
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Dave Syer


### PR DESCRIPTION
## DO NOT MERGE YET

Example of the output of `/metrics` endpoint for the brewery

The naming seems bizarre for some of the metrics:
- with async processing
- when span name contains `.` , `/` and simillar things

CC @dsyer , @adriancole , @spencergibb 

```
{
mem: 155397,
mem.free: 15467,
processors: 8,
instance.uptime: 122911,
uptime: 162752,
systemload.average: 2.82,
heap.committed: 64512,
heap.init: 65536,
heap.used: 49044,
heap: 64512,
nonheap.committed: 92544,
nonheap.init: 2496,
nonheap.used: 90901,
nonheap: 0,
threads.peak: 64,
threads.daemon: 53,
threads.totalStarted: 90,
threads: 64,
classes: 11408,
classes.loaded: 11408,
classes.unloaded: 0,
gc.ps_scavenge.count: 364,
gc.ps_scavenge.time: 1871,
gc.ps_marksweep.count: 3,
gc.ps_marksweep.time: 596,
histogram.span.bottle.snapshot.median: 8,
histogram.span.calling_bottling_from_maturing.snapshot.98thPercentile: 28,
histogram.span.bottle.snapshot.stdDev: 8.497848891251797,
histogram.span.MvcAsync9.snapshot.min: 0,
histogram.span.http/ingredient/MALT.snapshot.95thPercentile: 36,
histogram.span.MvcAsync4.snapshot.999thPercentile: 2,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.75thPercentile: 587,
histogram.span.message/events.count: 8,
histogram.span.inside_maturing.snapshot.stdDev: 267.432303342336,
histogram.span.MvcAsync9.snapshot.98thPercentile: 0,
histogram.span.inside_reporting.snapshot.98thPercentile: 5,
histogram.span.http/favicon.ico.snapshot.min: 33,
histogram.span.MvcAsync10.snapshot.999thPercentile: 1,
histogram.span.http/favicon.ico.snapshot.999thPercentile: 33,
histogram.span.MvcAsync2.snapshot.99thPercentile: 1,
histogram.span.http/ingredient/MALT.snapshot.mean: 21.065130453037106,
histogram.span.MvcAsync10.snapshot.max: 1,
histogram.span.MvcAsync3.snapshot.max: 1,
histogram.span.MvcAsync5.snapshot.mean: 1,
histogram.span.MvcAsync6.snapshot.median: 94,
histogram.span.http/ingredient/HOP.snapshot.999thPercentile: 14,
histogram.span.http/ingredient/WATER.snapshot.min: 8,
histogram.span.MvcAsync8.snapshot.median: 1,
histogram.span.inside_aggregating.snapshot.75thPercentile: 1,
gauge.response.star-star: 7,
histogram.span.inside_aggregating.snapshot.999thPercentile: 1,
histogram.span.MvcAsync4.snapshot.99thPercentile: 2,
histogram.span.inside_ingredients.snapshot.75thPercentile: 0,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.min: 110,
histogram.span.http/ingredient/MALT.snapshot.min: 7,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.min: 134,
histogram.span.inside_reporting.snapshot.min: 0,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.min: 32,
histogram.span.calling_presenting_from_maturing.snapshot.98thPercentile: 522,
histogram.span.MvcAsync1.count: 1,
histogram.span.calling_bottling_from_maturing.snapshot.median: 9,
histogram.span.MvcAsync6.snapshot.75thPercentile: 94,
histogram.span.pool-9-thread-1.snapshot.max: 4522,
histogram.span.calling_presenting_from_maturing.snapshot.99thPercentile: 522,
histogram.span.calling_presenting.snapshot.999thPercentile: 18,
histogram.span.http/health.snapshot.median: 909,
histogram.span.MvcAsync4.snapshot.median: 2,
histogram.span.MvcAsync8.snapshot.98thPercentile: 1,
histogram.span.inside_reporting.snapshot.median: 0,
histogram.span.message/events.snapshot.99thPercentile: 17,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.95thPercentile: 134,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.max: 587,
histogram.span.http/health.snapshot.min: 909,
histogram.span.http/ingredient/YEAST.snapshot.min: 11,
histogram.span.http/favicon.ico.snapshot.max: 33,
histogram.span.MvcAsync8.count: 1,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.98thPercentile: 110,
gauge.response.star-star.favicon.ico: 33,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.95thPercentile: 587,
histogram.span.http/favicon.ico.snapshot.mean: 33,
histogram.span.pool-9-thread-1.snapshot.mean: 4522,
histogram.span.http/health.snapshot.max: 1075,
histogram.span.MvcAsync2.snapshot.stdDev: 0,
histogram.span.calling_presenting.snapshot.98thPercentile: 18,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.stdDev: 0,
histogram.span.pool-12-thread-1.snapshot.98thPercentile: 90,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.mean: 587,
histogram.span.http/ingredient/YEAST.snapshot.mean: 11,
histogram.span.calling_bottling_from_maturing.snapshot.99thPercentile: 28,
histogram.span.bottle.snapshot.98thPercentile: 25,
histogram.span.MvcAsync1.snapshot.98thPercentile: 4600,
histogram.span.MvcAsync7.snapshot.95thPercentile: 0,
histogram.span.http/health.snapshot.stdDev: 82.9160333482969,
histogram.span.MvcAsync9.snapshot.median: 0,
histogram.span.SimpleAsyncTaskExecutor-3.count: 1,
histogram.span.MvcAsync1.snapshot.999thPercentile: 4600,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.98thPercentile: 32,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.99thPercentile: 32,
histogram.span.MvcAsync5.snapshot.stdDev: 0,
histogram.span.inside_aggregating.snapshot.median: 0,
histogram.span.MvcAsync2.snapshot.mean: 1,
histogram.span.MvcAsync10.count: 1,
histogram.span.MvcAsync4.count: 1,
histogram.span.inside_bottling.snapshot.median: 8,
histogram.span.http/ingredient/MALT.snapshot.stdDev: 14.49347744597977,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.stdDev: 0,
histogram.span.calling_presenting_from_maturing.snapshot.median: 10,
histogram.span.MvcAsync5.count: 1,
histogram.span.MvcAsync8.snapshot.mean: 1,
histogram.span.MvcAsync2.snapshot.98thPercentile: 1,
histogram.span.inside_ingredients.snapshot.max: 1,
histogram.span.http/.snapshot.mean: 7,
histogram.span.http/health.snapshot.999thPercentile: 1075,
histogram.span.http/health.snapshot.75thPercentile: 1075,
histogram.span.http/.snapshot.max: 7,
histogram.span.pool-9-thread-1.count: 1,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.median: 587,
histogram.span.MvcAsync8.snapshot.stdDev: 0,
histogram.span.SimpleAsyncTaskExecutor-4.count: 1,
histogram.span.http/health.snapshot.99thPercentile: 1075,
histogram.span.bottle.snapshot.999thPercentile: 25,
histogram.span.inside_reporting.snapshot.75thPercentile: 1,
histogram.span.MvcAsync2.snapshot.999thPercentile: 1,
counter.span.accepted: 77,
histogram.span.http/ingredient/HOP.snapshot.stdDev: 2.9986505060647803,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.95thPercentile: 32,
histogram.span.inside_maturing.snapshot.median: 31,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.stdDev: 0,
counter.status.200.ingredients: 2,
histogram.span.MvcAsync7.snapshot.75thPercentile: 0,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.75thPercentile: 134,
histogram.span.MvcAsync9.snapshot.99thPercentile: 0,
histogram.span.inside_ingredients.snapshot.95thPercentile: 1,
histogram.span.bottle.snapshot.mean: 16.308782266903467,
histogram.span.MvcAsync5.snapshot.98thPercentile: 1,
histogram.span.inside_maturing.count: 2,
histogram.span.http/ingredient/YEAST.count: 2,
histogram.span.MvcAsync3.snapshot.98thPercentile: 1,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.95thPercentile: 110,
histogram.span.MvcAsync6.snapshot.mean: 94,
histogram.span.MvcAsync5.snapshot.99thPercentile: 1,
histogram.span.MvcAsync3.snapshot.95thPercentile: 1,
histogram.span.http/ingredient/YEAST.snapshot.999thPercentile: 11,
histogram.span.calling_bottling_from_maturing.snapshot.95thPercentile: 28,
histogram.span.inside_reporting.count: 8,
histogram.span.MvcAsync2.snapshot.min: 1,
histogram.span.inside_bottling.snapshot.999thPercentile: 23,
histogram.span.inside_bottling.snapshot.stdDev: 7.498101962869233,
histogram.span.http/health.count: 2,
histogram.span.inside_reporting.snapshot.mean: 0.8549547308676202,
histogram.span.MvcAsync7.snapshot.99thPercentile: 0,
histogram.span.http/ingredient/MALT.snapshot.98thPercentile: 36,
histogram.span.bottle.snapshot.75thPercentile: 25,
histogram.span.pool-12-thread-1.snapshot.75thPercentile: 90,
histogram.span.http/ingredient/WATER.snapshot.75thPercentile: 13,
histogram.span.http/.snapshot.75thPercentile: 7,
histogram.span.calling_bottling_from_maturing.snapshot.max: 28,
histogram.span.http/favicon.ico.snapshot.75thPercentile: 33,
histogram.span.inside_bottling.snapshot.99thPercentile: 23,
histogram.span.http/.snapshot.min: 7,
gauge.response.ingredients: 100,
histogram.span.inside_maturing.snapshot.min: 31,
histogram.span.message/events.snapshot.mean: 3.4347596679760213,
histogram.span.MvcAsync7.snapshot.98thPercentile: 0,
histogram.span.http/.count: 1,
histogram.span.http/ingredient/WATER.snapshot.mean: 10.42502249190295,
histogram.span.MvcAsync10.snapshot.mean: 1,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.98thPercentile: 134,
histogram.span.http/ingredient/YEAST.snapshot.median: 11,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.999thPercentile: 32,
histogram.span.http/.snapshot.stdDev: 0,
histogram.span.http/favicon.ico.snapshot.98thPercentile: 33,
histogram.span.calling_bottling_from_maturing.snapshot.mean: 18.286286063009754,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.999thPercentile: 587,
histogram.span.calling_presenting.snapshot.max: 18,
histogram.span.MvcAsync2.snapshot.max: 1,
histogram.span.inside_maturing.snapshot.max: 566,
histogram.span.http/ingredients.snapshot.999thPercentile: 4696,
histogram.span.http/ingredients.snapshot.98thPercentile: 4696,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.75thPercentile: 110,
histogram.span.MvcAsync10.snapshot.stdDev: 0,
histogram.span.http/ingredients.snapshot.min: 100,
counter.status.200.ingredient.ingredient: 8,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.999thPercentile: 110,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.min: 587,
histogram.span.inside_maturing.snapshot.75thPercentile: 566,
histogram.span.inside_ingredients.snapshot.min: 0,
histogram.span.http/health.snapshot.98thPercentile: 1075,
histogram.span.calling_presenting.snapshot.75thPercentile: 18,
histogram.span.MvcAsync1.snapshot.95thPercentile: 4600,
histogram.span.http/favicon.ico.snapshot.99thPercentile: 33,
histogram.span.MvcAsync9.snapshot.95thPercentile: 0,
histogram.span.MvcAsync9.snapshot.max: 0,
histogram.span.http/ingredient/HOP.snapshot.75thPercentile: 14,
histogram.span.calling_presenting_from_maturing.count: 2,
histogram.span.http/ingredient/WATER.snapshot.stdDev: 2.4988754217206504,
histogram.span.http/ingredient/HOP.snapshot.max: 14,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.999thPercentile: 134,
histogram.span.MvcAsync3.snapshot.99thPercentile: 1,
histogram.span.MvcAsync3.snapshot.min: 1,
histogram.span.inside_reporting.snapshot.stdDev: 1.5937924874871983,
histogram.span.http/ingredient/WATER.count: 2,
histogram.span.MvcAsync5.snapshot.95thPercentile: 1,
histogram.span.http/favicon.ico.snapshot.median: 33,
histogram.span.message/events.snapshot.min: 1,
histogram.span.inside_bottling.snapshot.95thPercentile: 23,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.99thPercentile: 110,
histogram.span.calling_bottling_from_maturing.snapshot.stdDev: 9.497595819634363,
histogram.span.http/ingredients.snapshot.max: 4696,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.max: 110,
histogram.span.http/ingredients.snapshot.median: 100,
histogram.span.MvcAsync6.snapshot.stdDev: 0,
histogram.span.MvcAsync2.snapshot.median: 1,
histogram.span.MvcAsync8.snapshot.max: 1,
histogram.span.MvcAsync3.snapshot.median: 1,
histogram.span.inside_ingredients.snapshot.98thPercentile: 1,
histogram.span.calling_bottling_from_maturing.snapshot.999thPercentile: 28,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.mean: 110,
histogram.span.calling_bottling_from_maturing.snapshot.min: 9,
histogram.span.http/health.snapshot.95thPercentile: 1075,
histogram.span.inside_aggregating.snapshot.min: 0,
histogram.span.http/.snapshot.999thPercentile: 7,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.max: 32,
histogram.span.inside_reporting.snapshot.max: 5,
histogram.span.MvcAsync1.snapshot.stdDev: 0,
histogram.span.MvcAsync1.snapshot.99thPercentile: 4600,
histogram.span.http/ingredients.snapshot.99thPercentile: 4696,
histogram.span.calling_bottling_from_maturing.count: 2,
histogram.span.message/events.snapshot.95thPercentile: 17,
counter.status.200.star-star.favicon.ico: 1,
histogram.span.MvcAsync10.snapshot.95thPercentile: 1,
histogram.span.MvcAsync5.snapshot.min: 1,
histogram.span.MvcAsync6.snapshot.max: 94,
histogram.span.http/ingredient/MALT.snapshot.999thPercentile: 36,
histogram.span.MvcAsync7.snapshot.max: 0,
histogram.span.calling_presenting_from_maturing.snapshot.999thPercentile: 522,
histogram.span.inside_aggregating.snapshot.99thPercentile: 1,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.median: 134,
histogram.span.pool-9-thread-1.snapshot.min: 4522,
histogram.span.MvcAsync1.snapshot.max: 4600,
histogram.span.SimpleAsyncTaskExecutor-1.count: 1,
histogram.span.inside_bottling.snapshot.min: 8,
histogram.span.MvcAsync1.snapshot.mean: 4600,
histogram.span.calling_bottling_from_maturing.snapshot.75thPercentile: 28,
histogram.span.MvcAsync1.snapshot.75thPercentile: 4600,
histogram.span.pool-9-thread-1.snapshot.median: 4522,
histogram.span.inside_maturing.snapshot.99thPercentile: 566,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.98thPercentile: 587,
histogram.span.MvcAsync9.count: 1,
histogram.span.http/ingredient/HOP.snapshot.median: 8,
histogram.span.pool-12-thread-1.snapshot.mean: 90,
histogram.span.calling_presenting.snapshot.mean: 11.86502277663774,
histogram.span.pool-12-thread-1.snapshot.999thPercentile: 90,
histogram.span.inside_reporting.snapshot.999thPercentile: 5,
histogram.span.pool-12-thread-1.snapshot.median: 90,
histogram.span.MvcAsync3.snapshot.999thPercentile: 1,
histogram.span.inside_bottling.snapshot.98thPercentile: 23,
histogram.span.MvcAsync3.count: 1,
histogram.span.inside_maturing.snapshot.98thPercentile: 566,
counter.status.200.health: 2,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.75thPercentile: 32,
histogram.span.inside_bottling.snapshot.mean: 15.331278470797177,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.99thPercentile: 587,
histogram.span.MvcAsync7.snapshot.stdDev: 0,
histogram.span.pool-9-thread-1.snapshot.98thPercentile: 4522,
histogram.span.http/ingredient/YEAST.snapshot.98thPercentile: 11,
histogram.span.pool-9-thread-1.snapshot.stdDev: 0,
histogram.span.calling_presenting_from_maturing.snapshot.mean: 260.2409718032103,
histogram.span.inside_aggregating.snapshot.98thPercentile: 1,
histogram.span.message/events.snapshot.stdDev: 5.04982309361472,
histogram.span.inside_maturing.snapshot.mean: 292.4822654584326,
histogram.span.http/ingredient/WATER.snapshot.98thPercentile: 13,
histogram.span.http/ingredients.snapshot.95thPercentile: 4696,
histogram.span.MvcAsync3.snapshot.mean: 1,
histogram.span.http/ingredients.snapshot.75thPercentile: 4696,
histogram.span.inside_ingredients.snapshot.99thPercentile: 1,
histogram.span.http/ingredient/WATER.snapshot.max: 13,
histogram.span.http/ingredient/YEAST.snapshot.max: 11,
histogram.span.bottle.snapshot.max: 25,
gauge.response.health: 910,
histogram.span.inside_ingredients.snapshot.stdDev: 0.3349217856258955,
histogram.span.MvcAsync2.snapshot.95thPercentile: 1,
histogram.span.message/events.snapshot.75thPercentile: 2,
histogram.span.http/.snapshot.98thPercentile: 7,
histogram.span.SimpleAsyncTaskExecutor-4.snapshot.median: 110,
histogram.span.SimpleAsyncTaskExecutor-2.count: 1,
histogram.span.MvcAsync4.snapshot.75thPercentile: 2,
histogram.span.bottle.count: 2,
histogram.span.MvcAsync9.snapshot.999thPercentile: 0,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.mean: 32,
histogram.span.MvcAsync2.count: 1,
histogram.span.MvcAsync9.snapshot.75thPercentile: 0,
counter.status.404.star-star: 1,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.max: 134,
histogram.span.pool-12-thread-1.snapshot.min: 90,
histogram.span.http/ingredient/MALT.snapshot.99thPercentile: 36,
histogram.span.http/.snapshot.median: 7,
histogram.span.MvcAsync6.snapshot.99thPercentile: 94,
histogram.span.MvcAsync10.snapshot.median: 1,
histogram.span.http/ingredient/MALT.snapshot.median: 7,
histogram.span.MvcAsync1.snapshot.min: 4600,
histogram.span.inside_aggregating.snapshot.95thPercentile: 1,
histogram.span.http/ingredient/YEAST.snapshot.75thPercentile: 11,
histogram.span.inside_aggregating.count: 2,
histogram.span.http/favicon.ico.snapshot.95thPercentile: 33,
histogram.span.MvcAsync4.snapshot.min: 2,
histogram.span.pool-9-thread-1.snapshot.95thPercentile: 4522,
histogram.span.inside_bottling.count: 2,
histogram.span.MvcAsync3.snapshot.75thPercentile: 1,
histogram.span.pool-12-thread-1.count: 1,
histogram.span.inside_aggregating.snapshot.stdDev: 0.4988630959396238,
histogram.span.SimpleAsyncTaskExecutor-1.snapshot.stdDev: 0,
histogram.span.inside_ingredients.snapshot.mean: 0.12874887540485253,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.99thPercentile: 134,
histogram.span.http/ingredient/YEAST.snapshot.stdDev: 0,
histogram.span.inside_bottling.snapshot.75thPercentile: 23,
histogram.span.http/favicon.ico.count: 1,
histogram.span.calling_presenting_from_maturing.snapshot.95thPercentile: 522,
gauge.response.ingredient.ingredient: 12,
histogram.span.pool-12-thread-1.snapshot.stdDev: 0,
histogram.span.MvcAsync9.snapshot.mean: 0,
histogram.span.MvcAsync5.snapshot.75thPercentile: 1,
histogram.span.inside_maturing.snapshot.999thPercentile: 566,
histogram.span.MvcAsync8.snapshot.min: 1,
histogram.span.pool-12-thread-1.snapshot.max: 90,
histogram.span.MvcAsync9.snapshot.stdDev: 0,
histogram.span.http/favicon.ico.snapshot.stdDev: 0,
histogram.span.inside_reporting.snapshot.99thPercentile: 5,
histogram.span.MvcAsync6.snapshot.98thPercentile: 94,
histogram.span.bottle.snapshot.99thPercentile: 25,
histogram.span.calling_presenting_from_maturing.snapshot.min: 10,
histogram.span.MvcAsync8.snapshot.999thPercentile: 1,
histogram.span.message/events.snapshot.98thPercentile: 17,
histogram.span.http/ingredient/HOP.snapshot.95thPercentile: 14,
histogram.span.http/ingredient/HOP.count: 2,
histogram.span.MvcAsync8.snapshot.99thPercentile: 1,
histogram.span.SimpleAsyncTaskExecutor-2.snapshot.mean: 134,
histogram.span.http/ingredient/MALT.snapshot.max: 36,
histogram.span.http/health.snapshot.mean: 988.2675190845613,
histogram.span.pool-9-thread-1.snapshot.999thPercentile: 4522,
histogram.span.calling_presenting_from_maturing.snapshot.max: 522,
histogram.span.http/ingredient/WATER.snapshot.99thPercentile: 13,
histogram.span.MvcAsync7.count: 1,
histogram.span.MvcAsync4.snapshot.mean: 2,
histogram.span.pool-12-thread-1.snapshot.99thPercentile: 90,
histogram.span.inside_aggregating.snapshot.mean: 0.4663011645670992,
histogram.span.http/ingredient/WATER.snapshot.999thPercentile: 13,
histogram.span.MvcAsync8.snapshot.95thPercentile: 1,
histogram.span.pool-9-thread-1.snapshot.75thPercentile: 4522,
histogram.span.calling_presenting.snapshot.min: 6,
histogram.span.calling_presenting.snapshot.99thPercentile: 18,
histogram.span.inside_ingredients.count: 8,
histogram.span.MvcAsync10.snapshot.min: 1,
histogram.span.MvcAsync10.snapshot.98thPercentile: 1,
histogram.span.MvcAsync6.snapshot.95thPercentile: 94,
histogram.span.http/ingredient/MALT.snapshot.75thPercentile: 36,
histogram.span.MvcAsync6.count: 1,
histogram.span.http/ingredient/HOP.snapshot.min: 8,
histogram.span.bottle.snapshot.min: 8,
histogram.span.MvcAsync7.snapshot.min: 0,
histogram.span.message/events.snapshot.999thPercentile: 17,
histogram.span.bottle.snapshot.95thPercentile: 25,
histogram.span.inside_aggregating.snapshot.max: 1,
histogram.span.pool-9-thread-1.snapshot.99thPercentile: 4522,
histogram.span.MvcAsync6.snapshot.999thPercentile: 94,
histogram.span.inside_bottling.snapshot.max: 23,
histogram.span.MvcAsync6.snapshot.min: 94,
histogram.span.http/ingredient/YEAST.snapshot.99thPercentile: 11,
histogram.span.MvcAsync5.snapshot.median: 1,
histogram.span.http/ingredients.snapshot.mean: 2329.0806745571913,
histogram.span.inside_maturing.snapshot.95thPercentile: 566,
histogram.span.inside_reporting.snapshot.95thPercentile: 5,
histogram.span.SimpleAsyncTaskExecutor-3.snapshot.median: 32,
histogram.span.message/events.snapshot.max: 17,
histogram.span.MvcAsync8.snapshot.75thPercentile: 1,
histogram.span.http/ingredient/HOP.snapshot.98thPercentile: 14,
histogram.span.calling_presenting_from_maturing.snapshot.stdDev: 255.93521366593652,
histogram.span.MvcAsync7.snapshot.999thPercentile: 0,
histogram.span.MvcAsync10.snapshot.75thPercentile: 1,
histogram.span.inside_ingredients.snapshot.median: 0,
histogram.span.MvcAsync4.snapshot.98thPercentile: 2,
histogram.span.MvcAsync4.snapshot.stdDev: 0,
histogram.span.MvcAsync4.snapshot.max: 2,
histogram.span.MvcAsync7.snapshot.median: 0,
histogram.span.pool-12-thread-1.snapshot.95thPercentile: 90,
histogram.span.http/ingredient/WATER.snapshot.95thPercentile: 13,
histogram.span.http/ingredients.snapshot.stdDev: 2296.9662876456214,
histogram.span.http/ingredient/MALT.count: 2,
histogram.span.MvcAsync10.snapshot.99thPercentile: 1,
histogram.span.http/ingredients.count: 2,
histogram.span.MvcAsync7.snapshot.mean: 0,
histogram.span.http/ingredient/WATER.snapshot.median: 8,
histogram.span.inside_ingredients.snapshot.999thPercentile: 1,
histogram.span.calling_presenting.snapshot.stdDev: 5.998481570295387,
histogram.span.calling_presenting.snapshot.95thPercentile: 18,
histogram.span.http/ingredient/HOP.snapshot.99thPercentile: 14,
histogram.span.http/.snapshot.99thPercentile: 7,
histogram.span.http/.snapshot.95thPercentile: 7,
histogram.span.MvcAsync5.snapshot.max: 1,
histogram.span.MvcAsync4.snapshot.95thPercentile: 2,
histogram.span.calling_presenting.count: 2,
histogram.span.http/ingredient/HOP.snapshot.mean: 10.910026990283539,
histogram.span.calling_presenting_from_maturing.snapshot.75thPercentile: 522,
histogram.span.MvcAsync1.snapshot.median: 4600,
histogram.span.message/events.snapshot.median: 2,
histogram.span.calling_presenting.snapshot.median: 6,
histogram.span.MvcAsync2.snapshot.75thPercentile: 1,
histogram.span.http/ingredient/YEAST.snapshot.95thPercentile: 11,
histogram.span.MvcAsync5.snapshot.999thPercentile: 1,
histogram.span.MvcAsync3.snapshot.stdDev: 0,
normalized.servo.rest.totaltime: 0.11943103333333334,
normalized.servo.rest.count: 0.03333333333333333,
gauge.servo.rest.min: 1.490751,
gauge.servo.rest.max: 5.675110999999999,
counter.servo.zonestats_presenting_unknown_counter: 0,
gauge.servo.zonestats_circuitbreakertrippedcount: 0,
gauge.servo.zonestats_activerequestsperserver: 0,
gauge.servo.zonestats_instancecount: 1,
normalized.servo.presenting_loadbalancerexecutiontimer.totaltime: 4.183265583333333,
normalized.servo.presenting_loadbalancerexecutiontimer.count: 0.1,
gauge.servo.presenting_loadbalancerexecutiontimer.min: 4.578283,
gauge.servo.presenting_loadbalancerexecutiontimer.max: 202.45569,
counter.servo.zuul_reuse: 3,
counter.servo.zuul_createnew: 1,
counter.servo.zuul_request: 4,
counter.servo.zuul_release: 4,
counter.servo.zuul_delete: 1,
normalized.servo.zuul_requestconnectiontimer.totaltime: 0.5908181333333333,
normalized.servo.zuul_requestconnectiontimer.count: 0.06666666666666667,
gauge.servo.zuul_requestconnectiontimer.min: 0.018406,
gauge.servo.zuul_requestconnectiontimer.max: 35.34878,
normalized.servo.zuul_createconnectiontimer.totaltime: 0.5666990333333333,
normalized.servo.zuul_createconnectiontimer.count: 0.016666666666666666,
gauge.servo.zuul_createconnectiontimer.min: 34.001942,
gauge.servo.zuul_createconnectiontimer.max: 34.001942,
gauge.servo.connectioncount: 0,
gauge.servo.lbstats_circuitbreakertrippedcount: 0,
counter.servo.zonestats_zuul_unknown_counter: 0,
gauge.servo.numupdatecyclesmissed: 0,
gauge.servo.numthreads: 2,
counter.servo.loadbalancer_chooseserver: 0,
normalized.servo.httpclient-executetimer-zuul.totaltime: 0,
normalized.servo.httpclient-executetimer-zuul.count: 0,
gauge.servo.httpclient-executetimer-zuul.min: 0,
gauge.servo.httpclient-executetimer-zuul.max: 0,
gauge.servo.httpclient-connectionsinpool: 0,
normalized.servo.zuul_loadbalancerexecutiontimer.totaltime: 1.0930318333333333,
normalized.servo.zuul_loadbalancerexecutiontimer.count: 0.06666666666666667,
gauge.servo.zuul_loadbalancerexecutiontimer.min: 14.681436,
gauge.servo.zuul_loadbalancerexecutiontimer.max: 17.787691,
integration.channel.errorChannel.errorRate.mean: 0,
integration.channel.errorChannel.errorRate.max: 0,
integration.channel.errorChannel.errorRate.min: 0,
integration.channel.errorChannel.errorRate.stdev: 0,
integration.channel.errorChannel.errorRate.count: 0,
integration.channel.errorChannel.sendCount: 0,
integration.channel.errorChannel.sendRate.mean: 0,
integration.channel.errorChannel.sendRate.max: 0,
integration.channel.errorChannel.sendRate.min: 0,
integration.channel.errorChannel.sendRate.stdev: 0,
integration.channel.errorChannel.sendRate.count: 0,
integration.channel.errorChannel.receiveCount: -1,
integration.channel.nullChannel.errorRate.mean: 0,
integration.channel.nullChannel.errorRate.max: 0,
integration.channel.nullChannel.errorRate.min: 0,
integration.channel.nullChannel.errorRate.stdev: 0,
integration.channel.nullChannel.errorRate.count: 0,
integration.channel.nullChannel.sendCount: 0,
integration.channel.nullChannel.sendRate.mean: 0,
integration.channel.nullChannel.sendRate.max: 0,
integration.channel.nullChannel.sendRate.min: 0,
integration.channel.nullChannel.sendRate.stdev: 0,
integration.channel.nullChannel.sendRate.count: 0,
integration.channel.nullChannel.receiveCount: -1,
integration.channel.events.errorRate.mean: 0,
integration.channel.events.errorRate.max: 0,
integration.channel.events.errorRate.min: 0,
integration.channel.events.errorRate.stdev: 0,
integration.channel.events.errorRate.count: 0,
integration.channel.events.sendCount: 8,
integration.channel.events.sendRate.mean: 7.11852779056435,
integration.channel.events.sendRate.max: 3.2405840900093317,
integration.channel.events.sendRate.min: 0.001531714990735054,
integration.channel.events.sendRate.stdev: 15.176172050208898,
integration.channel.events.sendRate.count: 8,
integration.channel.events.receiveCount: -1,
integration.handler.errorLogger.duration.mean: 0,
integration.handler.errorLogger.duration.max: 0,
integration.handler.errorLogger.duration.min: 0,
integration.handler.errorLogger.duration.stdev: 0,
integration.handler.errorLogger.duration.count: 0,
integration.handler.eventListener.handleEvents.serviceActivator.duration.mean: 2.2514490777799465,
integration.handler.eventListener.handleEvents.serviceActivator.duration.max: 14.567186,
integration.handler.eventListener.handleEvents.serviceActivator.duration.min: 0.911885,
integration.handler.eventListener.handleEvents.serviceActivator.duration.stdev: 3.736776121600746,
integration.handler.eventListener.handleEvents.serviceActivator.duration.count: 8,
integration.activeHandlerCount: 0,
integration.handlerCount: 2,
integration.channelCount: 3,
integration.queuedMessageCount: 0,
httpsessions.max: -1,
httpsessions.active: 0
}
```