### PR TITLE
Updates to zipkin-java 0.5

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<brave.version>3.4.0</brave.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.4.4</zipkin-java.version>
+		<zipkin-java.version>0.5.2</zipkin-java.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -62,12 +62,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.4.4</version>
+				<version>0.5.2</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.4.4</version>
+				<version>0.5.2</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
@@ -1,9 +1,9 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.30.2
+  image: openzipkin/zipkin-mysql:1.33.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.4.4
+  image: openzipkin/zipkin-java:0.5.2
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
@@ -16,7 +16,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.30.2
+  image: openzipkin/zipkin-web:1.33.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http

--- a/spring-cloud-sleuth-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-zipkin/docker-compose.yml
@@ -1,9 +1,9 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.30.2
+  image: openzipkin/zipkin-mysql:1.33.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.4.4
+  image: openzipkin/zipkin-java:0.5.2
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
@@ -16,7 +16,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.30.2
+  image: openzipkin/zipkin-web:1.33.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http


### PR DESCRIPTION
This includes better dependency aggregation than before. For example,
you no longer need mysql to view the dependency graph, as the in-memory
server supports aggregation now. Also, if you log "ca" on a root span,
the associated service will show on the dependency graph on the far
left. This allows you to show uninstrumented clients of note. Similarly,
if you log "sa" on a leaf node, the destination will show on the far
right. You'd use "sa" for uninstrumented services like databases, auth
servers or cloud apis.

Here's an example. Note you can now see the database service on the far right.

<img width="735" alt="screen shot 2016-02-10 at 11 28 46 pm" src="https://cloud.githubusercontent.com/assets/64215/12951989/e02a9f76-d04f-11e5-9477-91b6360d55df.png">
