### PR TITLE
[#161] Fixed the way collections are passed between spans

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -63,9 +63,9 @@ public class Span {
 	private final long spanId;
 	private boolean remote = false;
 	private boolean exportable = true;
-	private final Map<String, String> tags = new LinkedHashMap<>();
+	private final Map<String, String> tags;
 	private final String processId;
-	private final List<Log> logs = new ArrayList<>();
+	private final List<Log> logs;
 	private final Span savedSpan;
 
 	public Span(Span current, Span savedSpan) {
@@ -78,8 +78,8 @@ public class Span {
 		this.remote = current.isRemote();
 		this.exportable = current.isExportable();
 		this.processId = current.getProcessId();
-		this.tags.putAll(current.tags());
-		this.logs.addAll(current.logs());
+		this.tags = current.tags;
+		this.logs = current.logs;
 		this.savedSpan = savedSpan;
 	}
 
@@ -102,6 +102,8 @@ public class Span {
 		this.exportable = exportable;
 		this.processId = processId;
 		this.savedSpan = savedSpan;
+		this.tags = new LinkedHashMap<>();
+		this.logs = new ArrayList<>();
 	}
 
 	public static SpanBuilder builder() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SpanMessageHeaders.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SpanMessageHeaders.java
@@ -73,7 +73,7 @@ public class SpanMessageHeaders {
 			if (parentId != null) {
 				addHeader(headers, Span.PARENT_ID_NAME, Span.toHex(parentId));
 			}
-			addHeader(headers, Span.SPAN_NAME_NAME, span.getName().toString());
+			addHeader(headers, Span.SPAN_NAME_NAME, span.getName());
 			addHeader(headers, Span.PROCESS_ID_NAME, span.getProcessId());
 		}
 		else {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceFeignClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceFeignClientAutoConfiguration.java
@@ -127,7 +127,7 @@ public class TraceFeignClientAutoConfiguration {
 					return;
 				}
 				template.header(Span.TRACE_ID_NAME, Span.toHex(span.getTraceId()));
-				setHeader(template, Span.SPAN_NAME_NAME, span.getName().toString());
+				setHeader(template, Span.SPAN_NAME_NAME, span.getName());
 				setHeader(template, Span.SPAN_ID_NAME, Span.toHex(span.getSpanId()));
 				if (!span.isExportable()) {
 					setHeader(template, Span.NOT_SAMPLED_NAME, "true");

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
@@ -69,7 +69,7 @@ public class TracePreZuulFilter extends ZuulFilter
 		try {
 			setHeader(response, Span.SPAN_ID_NAME, span.getSpanId());
 			setHeader(response, Span.TRACE_ID_NAME, span.getTraceId());
-			setHeader(response, Span.SPAN_NAME_NAME, span.getName().toString());
+			setHeader(response, Span.SPAN_NAME_NAME, span.getName());
 			if (!span.isExportable()) {
 				setHeader(response, Span.NOT_SAMPLED_NAME, "true");
 			}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
@@ -104,7 +104,7 @@ public class TraceRestClientRibbonCommandFactory extends RestClientRibbonCommand
 			}
 			setHeader(requestBuilder, Span.TRACE_ID_NAME, Span.toHex(span.getTraceId()));
 			setHeader(requestBuilder, Span.SPAN_ID_NAME, Span.toHex(span.getSpanId()));
-			setHeader(requestBuilder, Span.SPAN_NAME_NAME, span.getName().toString());
+			setHeader(requestBuilder, Span.SPAN_NAME_NAME, span.getName());
 			setHeader(requestBuilder, Span.PARENT_ID_NAME,
 					Span.toHex(getParentId(span)));
 			setHeader(requestBuilder, Span.PROCESS_ID_NAME,


### PR DESCRIPTION
When a span is continued a new one is created from the previous one. We've been copying span collections thus the changes in the continued instance were not reflected in the parent.

Fixes #161