### PR TITLE
[#159] Tagging hystrix events

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Class for gathering and reporting statistics about a block of execution.
@@ -151,10 +152,13 @@ public class Span {
 	}
 
 	/**
-	 * Add a tag or data annotation associated with this span
+	 * Add a tag or data annotation associated with this span. The tag will be
+	 * added only if it has a value.
 	 */
 	public void tag(String key, String value) {
-		this.tags.put(key, value);
+		if (StringUtils.hasText(value)) {
+			this.tags.put(key, value);
+		}
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/TraceKeys.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/TraceKeys.java
@@ -318,6 +318,21 @@ public class TraceKeys {
 		 */
 		private String commandKey = "commandKey";
 
+		/**
+		 * Name of the command group
+		 */
+		private String commandGroup = "commandGroup";
+
+		/**
+		 * Name of the cache key
+		 */
+		private String cacheKey = "cacheKey";
+
+		/**
+		 * Name of the thread pool key
+		 */
+		private String threadPoolKey = "threadPoolKey";
+
 		public String getPrefix() {
 			return this.prefix;
 		}
@@ -326,12 +341,36 @@ public class TraceKeys {
 			return this.commandKey;
 		}
 
+		public String getCommandGroup() {
+			return this.commandGroup;
+		}
+
+		public String getCacheKey() {
+			return this.cacheKey;
+		}
+
+		public String getThreadPoolKey() {
+			return this.threadPoolKey;
+		}
+
 		public void setPrefix(String prefix) {
 			this.prefix = prefix;
 		}
 
 		public void setCommandKey(String commandKey) {
 			this.commandKey = commandKey;
+		}
+
+		public void setCommandGroup(String commandGroup) {
+			this.commandGroup = commandGroup;
+		}
+
+		public void setCacheKey(String cacheKey) {
+			this.cacheKey = cacheKey;
+		}
+
+		public void setThreadPoolKey(String threadPoolKey) {
+			this.threadPoolKey = threadPoolKey;
 		}
 
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/TraceCommand.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/TraceCommand.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.sleuth.instrument.hystrix;
 
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.TraceKeys;
 
 import com.netflix.hystrix.HystrixCommand;
-import org.springframework.cloud.sleuth.instrument.TraceKeys;
 
 /**
  * Abstraction over {@code HystrixCommand} that wraps command execution with Trace setting
@@ -54,6 +54,12 @@ public abstract class TraceCommand<R> extends HystrixCommand<R> {
 		this.tracer.addTag(Span.SPAN_LOCAL_COMPONENT_TAG_NAME, HYSTRIX_COMPONENT);
 		this.tracer.addTag(this.traceKeys.getHystrix().getPrefix() +
 				this.traceKeys.getHystrix().getCommandKey(), commandKeyName);
+		this.tracer.addTag(this.traceKeys.getHystrix().getPrefix() +
+				this.traceKeys.getHystrix().getCommandGroup(), getCommandGroup().name());
+		this.tracer.addTag(this.traceKeys.getHystrix().getPrefix() +
+				this.traceKeys.getHystrix().getCacheKey(), isRequestCachingEnabled() ? getCacheKey() : "");
+		this.tracer.addTag(this.traceKeys.getHystrix().getPrefix() +
+				this.traceKeys.getHystrix().getThreadPoolKey(), getThreadPoolKey().name());
 		try {
 			return doRun();
 		}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/TraceCommandTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/TraceCommandTests.java
@@ -2,10 +2,6 @@ package org.springframework.cloud.sleuth.instrument.hystrix;
 
 import java.util.Random;
 
-import com.netflix.hystrix.HystrixCommandKey;
-import com.netflix.hystrix.HystrixCommandProperties;
-import com.netflix.hystrix.HystrixThreadPoolProperties;
-import com.netflix.hystrix.strategy.HystrixPlugins;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +14,11 @@ import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.context.ApplicationEventPublisher;
+
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.HystrixPlugins;
 
 import static com.netflix.hystrix.HystrixCommand.Setter.withGroupKey;
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey;
@@ -70,8 +71,12 @@ public class TraceCommandTests {
 
 		Span spanFromCommand = whenCommandIsExecuted(command);
 
-		then(spanFromCommand).as("Span from the Hystrix Thread").isNotNull();
-		then(spanFromCommand.getTraceId()).isEqualTo(EXPECTED_TRACE_ID);
+		then(spanFromCommand).as("Span from the Hystrix Thread")
+				.isNotNull()
+				.hasTraceIdEqualTo(EXPECTED_TRACE_ID)
+				.hasATag("commandKey", "traceCommandKey")
+				.hasATag("commandGroup", "group")
+				.hasATag("threadPoolKey", "group");
 	}
 
 	private Span givenATraceIsPresentInTheCurrentThread() {


### PR DESCRIPTION
when a hystrix command was explicitly created we can tag the following values
* command key
* command group
* thread pool key

fixes #159