### PR TITLE
Refactors HTTP SpanReporter tests to use ZipkinRule

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<brave.version>3.4.0</brave.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.5.3</zipkin-java.version>
+		<zipkin-java.version>0.5.5</zipkin-java.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -86,6 +86,11 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>spanstore-jdbc</artifactId>
+				<version>${zipkin-java.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.zipkin.java</groupId>
+				<artifactId>zipkin-junit</artifactId>
 				<version>${zipkin-java.version}</version>
 			</dependency>
 		</dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -62,12 +62,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.5.3</version>
+				<version>0.5.5</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.5.3</version>
+				<version>0.5.5</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -56,9 +56,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>mockwebserver</artifactId>
-			<version>3.0.0</version>
+			<groupId>io.zipkin.java</groupId>
+			<artifactId>zipkin-junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
@@ -1,36 +1,33 @@
 package org.springframework.cloud.sleuth.zipkin;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import okhttp3.mockwebserver.SocketPolicy;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.cloud.sleuth.metric.CounterServiceBasedSpanReporterService;
 import org.springframework.cloud.sleuth.metric.SpanReporterService;
-import zipkin.Codec;
 import zipkin.Span;
 
-import java.util.List;
+import zipkin.junit.HttpFailure;
+import zipkin.junit.ZipkinRule;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class HttpZipkinSpanReporterTest {
 
-	@Rule public final MockWebServer server = new MockWebServer();
+	@Rule public final ZipkinRule zipkin = new ZipkinRule();
 	InMemorySpanCounter inMemorySpanCounter = new InMemorySpanCounter();
 	SpanReporterService spanReporterService = new CounterServiceBasedSpanReporterService("accepted", "dropped",
 			this.inMemorySpanCounter);
 
 	// set flush interval to 0 so that tests can drive flushing explicitly
 	HttpZipkinSpanReporter reporter = new HttpZipkinSpanReporter(
-			this.server.url("").toString(), 0, this.spanReporterService);
+			this.zipkin.httpUrl(), 0, this.spanReporterService);
 
 	@Test 
 	public void reportDoesntDoIO() throws Exception {
 		this.reporter.report(span(1L, "foo"));
 
-		assertThat(this.server.getRequestCount()).isZero();
+		assertThat(this.zipkin.httpRequestCount()).isZero();
 	}
 
 	@Test 
@@ -52,26 +49,23 @@ public class HttpZipkinSpanReporterTest {
 
 	@Test
 	public void postsSpans() throws Exception {
-		this.server.enqueue(new MockResponse());
-
 		this.reporter.report(span(1L, "foo"));
 		this.reporter.report(span(2L, "bar"));
 
 		this.reporter.flush(); // manually flush the spans
 
-		// Ensure a proper request was sent
-		RecordedRequest request = this.server.takeRequest();
-		assertThat(request.getRequestLine()).isEqualTo("POST /api/v1/spans HTTP/1.1");
-		assertThat(request.getHeader("Content-Type")).isEqualTo("application/json");
+		// Ensure only one request was sent
+		assertThat(this.zipkin.httpRequestCount()).isEqualTo(1);
 
-		// Now, let's read back the spans we sent!
-		List<Span> zipkinSpans = Codec.JSON.readSpans(request.getBody().readByteArray());
-		assertThat(zipkinSpans).containsExactly(span(1L, "foo"), span(2L, "bar"));
+		assertThat(this.zipkin.getTraces()).containsExactly(
+				asList(span(1L, "foo")),
+				asList(span(2L, "bar"))
+		);
 	}
 
 	@Test 
 	public void incrementsDroppedSpansWhenServerErrors() throws Exception {
-		this.server.enqueue(new MockResponse().setResponseCode(500));
+		this.zipkin.enqueueFailure(HttpFailure.sendErrorResponse(500, "Ouch"));
 
 		this.reporter.report(span(1L, "foo"));
 		this.reporter.report(span(2L, "bar"));
@@ -83,8 +77,7 @@ public class HttpZipkinSpanReporterTest {
 
 	@Test 
 	public void incrementsDroppedSpansWhenServerDisconnects() throws Exception {
-		this.server.enqueue(new MockResponse()
-				.setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST));
+		this.zipkin.enqueueFailure(HttpFailure.disconnectDuringBody());
 
 		this.reporter.report(span(1L, "foo"));
 		this.reporter.report(span(2L, "bar"));


### PR DESCRIPTION
This replaces direct usage of MockWebServer with ZipkinRule.

See https://github.com/openzipkin/zipkin-java/pull/83