### PR TITLE
Updates to latest zipkin, adding spring.zipkin.compression.enabled flag

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<brave.version>3.4.0</brave.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.5.5</zipkin-java.version>
+		<zipkin-java.version>0.6.0</zipkin-java.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -62,12 +62,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.5.5</version>
+				<version>0.6.0</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.5.5</version>
+				<version>0.6.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
@@ -1,9 +1,9 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.33.2
+  image: openzipkin/zipkin-mysql:1.34.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.5.3
+  image: openzipkin/zipkin-java:0.6.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
@@ -16,7 +16,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.33.2
+  image: openzipkin/zipkin-web:1.34.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/test/java/integration/ZipkinTests.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/test/java/integration/ZipkinTests.java
@@ -102,7 +102,7 @@ public class ZipkinTests extends AbstractIntegrationTest {
 		private ZipkinSpanReporter getSpanCollector(ZipkinProperties zipkin,
 				SpanReporterService spanReporterService) {
 			return new HttpZipkinSpanReporter(zipkin.getBaseUrl(), zipkin.getFlushInterval(),
-					spanReporterService);
+					zipkin.getCompression().isEnabled(), spanReporterService);
 		}
 	}
 

--- a/spring-cloud-sleuth-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-zipkin/docker-compose.yml
@@ -1,9 +1,9 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.33.2
+  image: openzipkin/zipkin-mysql:1.34.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.5.3
+  image: openzipkin/zipkin-java:0.6.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
@@ -16,7 +16,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.33.2
+  image: openzipkin/zipkin-web:1.34.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
@@ -54,7 +54,7 @@ public class ZipkinAutoConfiguration {
 	@ConditionalOnMissingBean(ZipkinSpanReporter.class)
 	public ZipkinSpanReporter reporter(SpanReporterService spanReporterService, ZipkinProperties zipkin) {
 		return new HttpZipkinSpanReporter(zipkin.getBaseUrl(), zipkin.getFlushInterval(),
-				spanReporterService);
+				zipkin.getCompression().isEnabled(), spanReporterService);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
@@ -31,6 +31,7 @@ public class ZipkinProperties {
 	private String baseUrl = "http://localhost:9411/";
 	private boolean enabled = true;
 	private int flushInterval = 1;
+	private Compression compression = new Compression();
 
 	public String getBaseUrl() {
 		return this.baseUrl;
@@ -44,6 +45,10 @@ public class ZipkinProperties {
 		return this.flushInterval;
 	}
 
+	public Compression getCompression() {
+		return this.compression;
+	}
+
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
 	}
@@ -54,5 +59,23 @@ public class ZipkinProperties {
 
 	public void setFlushInterval(int flushInterval) {
 		this.flushInterval = flushInterval;
+	}
+
+	public void setCompression(Compression compression) {
+		this.compression = compression;
+	}
+
+	/** When enabled, spans are gzipped before sent to the zipkin server */
+	public static class Compression {
+
+		private boolean enabled = false;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
 	}
 }


### PR DESCRIPTION
This updates to latest zipkin, adding a flag to gzip spans before
posting them. Note this is set to false by default as it requires servers
to also be latest. We can flip the default once we can assume that.
    
Ex. `spring.zipkin.compression.enabled = true`