### PR TITLE
Fix bad zipkin project link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ badges:
 
 {% capture billboard_description %}
 
-Spring Cloud Sleuth implements a distributed tracing solution for Spring Cloud, borrowing heavily from [Dapper](http://research.google.com/pubs/pub36356.html), [Zipkin](https://github.com/openkipkin/zipkin) and HTrace. For most users Sleuth should be invisible, and all your interactions with external systems should be instrumented automatically. You can capture data simply in logs, or by sending it to a remote collector service.
+Spring Cloud Sleuth implements a distributed tracing solution for Spring Cloud, borrowing heavily from [Dapper](http://research.google.com/pubs/pub36356.html), [Zipkin](https://github.com/openzipkin/zipkin) and HTrace. For most users Sleuth should be invisible, and all your interactions with external systems should be instrumented automatically. You can capture data simply in logs, or by sending it to a remote collector service.
 
 {% endcapture %}
 


### PR DESCRIPTION
Fix typo in url for zipkin https://github.com/openzipkin/zipkin.