### PR TITLE
Updates to latest zipkin 0.7

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<brave.version>3.4.0</brave.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.6.0</zipkin-java.version>
+		<zipkin-java.version>0.7.0</zipkin-java.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -62,12 +62,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.6.0</version>
+				<version>0.7.0</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.6.0</version>
+				<version>0.7.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
@@ -1,9 +1,9 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.34.0
+  image: openzipkin/zipkin-mysql:1.36.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.6.0
+  image: openzipkin/zipkin-java:0.7.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
@@ -16,7 +16,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.34.0
+  image: openzipkin/zipkin-web:1.36.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http

--- a/spring-cloud-sleuth-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-zipkin/docker-compose.yml
@@ -1,9 +1,9 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.34.0
+  image: openzipkin/zipkin-mysql:1.36.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.6.0
+  image: openzipkin/zipkin-java:0.7.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http
@@ -16,7 +16,7 @@ query:
   links:
     - mysql:storage
 web:
-  image: openzipkin/zipkin-web:1.34.0
+  image: openzipkin/zipkin-web:1.36.0
   environment:
     # Remove TRANSPORT_TYPE to disable tracing
     - TRANSPORT_TYPE=http


### PR DESCRIPTION
This is a maintenance update to zipkin which has no api impact.

* zipkin-server supports cassandra now
* zipkin-web is now javascript (even if still hosted on a scala process)