### PR TITLE
Added Trace Headers

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -181,6 +181,13 @@ include::../../../../spring-cloud-sleuth-core/src/test/java/org/springframework/
 
 will lead in creating a span named `calculateTax`.
 
+== Configuring Header Names
+
+Thanks to the `TraceHeaders` class you can configure the names of headers propagated between processes.
+It's enough for you to tweak the `spring.sleuth.headers` properties
+
+IMPORTANT: If you're changing the default values of headers remember to update the `logging.pattern.level` and the
+`spring.cloud.stream.binder` if you're using Spring Cloud Sleuth Stream with your header values.
 
 == Span Data as Messages
 
@@ -191,7 +198,7 @@ adding a Channel Binder implementation
 (e.g. `spring-cloud-starter-stream-rabbit` for RabbitMQ or
 `spring-cloud-starter-stream-kafka` for Kafka). This will
 automatically turn your app into a producer of messages with payload
-type `Spans`. 
+type `Spans`.
 
 === Zipkin Consumer
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -56,14 +56,6 @@ import org.springframework.util.StringUtils;
  */
 public class Span {
 
-	public static final String NOT_SAMPLED_NAME = "X-Not-Sampled";
-	public static final String PROCESS_ID_NAME = "X-Process-Id";
-	public static final String PARENT_ID_NAME = "X-Parent-Id";
-	public static final String TRACE_ID_NAME = "X-Trace-Id";
-	public static final String SPAN_NAME_NAME = "X-Span-Name";
-	public static final String SPAN_ID_NAME = "X-Span-Id";
-	public static final String SPAN_EXPORT_NAME = "X-Span-Export";
-
 	public static final String SPAN_LOCAL_COMPONENT_TAG_NAME = "lc";
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/TraceHeaders.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/TraceHeaders.java
@@ -38,16 +38,64 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("spring.sleuth.headers")
 public class TraceHeaders {
 
-	private Zipkin zipkin;
-	private Sleuth sleuth;
+	public static final String SPAN_SAMPLED = "1";
+	public static final String SPAN_NOT_SAMPLED = "0";
 
-	public Zipkin getZipkin() {
-		return this.zipkin;
+	public static final String ZIPKIN_TRACE_ID_HEADER_NAME = "X-B3-TraceId";
+	public static final String ZIPKIN_SPAN_ID_HEADER_NAME = "X-B3-SpanId";
+	public static final String ZIPKIN_PARENT_SPAN_ID_HEADER_NAME = "X-B3-ParentSpanId";
+	public static final String ZIPKIN_SAMPLED_HEADER_NAME = "X-B3-Sampled";
+	public static final String ZIPKIN_PROCESS_ID_HEADER_NAME = "X-Process-Id";
+
+	private String traceId = ZIPKIN_TRACE_ID_HEADER_NAME;
+	private String spanId = ZIPKIN_SPAN_ID_HEADER_NAME;
+	private String parentSpanId = ZIPKIN_PARENT_SPAN_ID_HEADER_NAME;
+	private String sampled = ZIPKIN_SAMPLED_HEADER_NAME;
+	private String processId = ZIPKIN_PROCESS_ID_HEADER_NAME;
+
+	public String getTraceId() {
+		return this.traceId;
 	}
 
-	public void setZipkin(Zipkin zipkin) {
-		this.zipkin = zipkin;
+	public void setTraceId(String traceId) {
+		this.traceId = traceId;
 	}
+
+	public String getSpanId() {
+		return this.spanId;
+	}
+
+	public void setSpanId(String spanId) {
+		this.spanId = spanId;
+	}
+
+	public String getParentSpanId() {
+		return this.parentSpanId;
+	}
+
+	public void setParentSpanId(String parentSpanId) {
+		this.parentSpanId = parentSpanId;
+	}
+
+	/**
+	 * Header name for the header describing whether the Span should be sampled
+	 * or not.
+	 *
+	 * <ul>
+	 * <li>"1" - should be sampled</li>
+	 * <li>"0" - should NOT be sampled</li>
+	 * </ul>
+	 *
+	 */
+	public String getSampled() {
+		return this.sampled;
+	}
+
+	public void setSampled(String sampled) {
+		this.sampled = sampled;
+	}
+
+	private Sleuth sleuth = new Sleuth();
 
 	public Sleuth getSleuth() {
 		return this.sleuth;
@@ -57,57 +105,21 @@ public class TraceHeaders {
 		this.sleuth = sleuth;
 	}
 
-	private static class Zipkin {
-		private String traceId = "X-B3-TraceId";
-		private String spanId = "X-B3-SpanId";
-		private String parentSpanId = "X-B3-ParentSpanId";
-		private String sampled = "X-B3-Sampled";
-
-		public String getTraceId() {
-			return this.traceId;
-		}
-
-		public void setTraceId(String traceId) {
-			this.traceId = traceId;
-		}
-
-		public String getSpanId() {
-			return this.spanId;
-		}
-
-		public void setSpanId(String spanId) {
-			this.spanId = spanId;
-		}
-
-		public String getParentSpanId() {
-			return this.parentSpanId;
-		}
-
-		public void setParentSpanId(String parentSpanId) {
-			this.parentSpanId = parentSpanId;
-		}
-
-		public String getSampled() {
-			return this.sampled;
-		}
-
-		public void setSampled(String sampled) {
-			this.sampled = sampled;
-		}
+	public String getProcessId() {
+		return this.processId;
 	}
 
-	private static class Sleuth {
-		private String processId = "X-Process-Id";
-		private String spanName = "X-Span-Name";
-		private String exportable = "X-Span-Export";
+	public void setProcessId(String processId) {
+		this.processId = processId;
+	}
 
-		public String getProcessId() {
-			return this.processId;
-		}
+	public static class Sleuth {
 
-		public void setProcessId(String processId) {
-			this.processId = processId;
-		}
+		public static final String SLEUTH_SPAN_NAME_HEADER_NAME = "X-Span-Name";
+		public static final String SLEUTH_EXPORTABLE_HEADER_NAME = "X-Span-Export";
+
+		private String spanName = SLEUTH_SPAN_NAME_HEADER_NAME;
+		private String exportable = SLEUTH_EXPORTABLE_HEADER_NAME;
 
 		public String getSpanName() {
 			return this.spanName;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.cloud.sleuth.SpanReporter;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.log.SpanLogger;
@@ -72,6 +73,12 @@ public class TraceAutoConfiguration {
 	@ConditionalOnMissingBean
 	public TraceKeys traceKeys() {
 		return new TraceKeys();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public TraceHeaders traceHeaders() {
+		return new TraceHeaders();
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
@@ -37,6 +38,9 @@ import org.springframework.core.env.PropertySource;
  *     {@link org.springframework.cloud.sleuth.instrument.scheduling.TraceSchedulingAspect TraceSchedulingAspect}.
  * </ul>
  *
+ * If you're chaning the {@link TraceHeaders} default values remember to change override
+ * the {@code logging.pattern.level} property too.
+ *
  * @author Dave Syer
  * @since 1.0.0
  */
@@ -51,7 +55,9 @@ public class TraceEnvironmentPostProcessor implements EnvironmentPostProcessor {
 		// This doesn't work with all logging systems but it's a useful default so you see
 		// traces in logs without having to configure it.
 		map.put("logging.pattern.level",
-				"%clr(%5p) %clr([${spring.application.name:},%X{X-Trace-Id:-},%X{X-Span-Id:-},%X{X-Span-Export:-}]){yellow}");
+				"%clr(%5p) %clr([${spring.application.name:},%X{" + TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME + ":-},"
+						+ "%X{"+TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME+":-},"
+						+ "%X{"+TraceHeaders.Sleuth.SLEUTH_EXPORTABLE_HEADER_NAME+":-}]){yellow}");
 		map.put("spring.aop.proxyTargetClass", "true");
 		addOrReplace(environment.getPropertySources(), map);
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/AbstractTraceChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/AbstractTraceChannelInterceptor.java
@@ -3,6 +3,7 @@ package org.springframework.cloud.sleuth.instrument.messaging;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanExtractor;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.integration.channel.AbstractMessageChannel;
@@ -33,14 +34,16 @@ abstract class AbstractTraceChannelInterceptor extends ChannelInterceptorAdapter
 
 	private final Tracer tracer;
 	private final TraceKeys traceKeys;
+	private final TraceHeaders traceHeaders;
 	private final SpanExtractor<Message> spanExtractor;
 	private final SpanInjector<MessageBuilder> spanInjector;
 
 	protected AbstractTraceChannelInterceptor(Tracer tracer, TraceKeys traceKeys,
-			SpanExtractor<Message> spanExtractor,
+			TraceHeaders traceHeaders, SpanExtractor<Message> spanExtractor,
 			SpanInjector<MessageBuilder> spanInjector) {
 		this.tracer = tracer;
 		this.traceKeys = traceKeys;
+		this.traceHeaders = traceHeaders;
 		this.spanExtractor = spanExtractor;
 		this.spanInjector = spanInjector;
 	}
@@ -51,6 +54,10 @@ abstract class AbstractTraceChannelInterceptor extends ChannelInterceptorAdapter
 
 	protected TraceKeys getTraceKeys() {
 		return this.traceKeys;
+	}
+
+	protected TraceHeaders getTraceHeaders() {
+		return this.traceHeaders;
 	}
 
 	protected SpanInjector<MessageBuilder> getSpanInjector() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.sleuth.instrument.messaging;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanExtractor;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.sampler.NeverSampler;
@@ -38,9 +39,9 @@ public class TraceChannelInterceptor extends AbstractTraceChannelInterceptor {
 	private static final String SPAN_HEADER = "X-Current-Span";
 
 	public TraceChannelInterceptor(Tracer tracer, TraceKeys traceKeys,
-			SpanExtractor<Message> spanExtractor,
+			TraceHeaders traceHeaders, SpanExtractor<Message> spanExtractor,
 			SpanInjector<MessageBuilder> spanInjector) {
-		super(tracer, traceKeys, spanExtractor, spanInjector);
+		super(tracer, traceKeys, traceHeaders, spanExtractor, spanInjector);
 	}
 
 	@Override
@@ -63,7 +64,8 @@ public class TraceChannelInterceptor extends AbstractTraceChannelInterceptor {
 		if (span != null) {
 			return getTracer().createSpan(name, span);
 		}
-		if (message.getHeaders().containsKey(Span.NOT_SAMPLED_NAME)) {
+		if (TraceHeaders.SPAN_NOT_SAMPLED.equals(
+				message.getHeaders().get(getTraceHeaders().getSampled()))) {
 			return getTracer().createSpan(name, NeverSampler.INSTANCE);
 		}
 		return getTracer().createSpan(name);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.SpanExtractor;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.cloud.sleuth.TraceKeys;
@@ -55,26 +56,26 @@ public class TraceSpringIntegrationAutoConfiguration {
 	@Bean
 	@GlobalChannelInterceptor
 	public TraceChannelInterceptor traceChannelInterceptor(Tracer tracer,
-			TraceKeys traceKeys, Random random,
+			TraceKeys traceKeys, TraceHeaders traceHeaders, Random random,
 			@Qualifier("messagingSpanExtractor") SpanExtractor<Message> spanExtractor,
 			@Qualifier("messagingSpanInjector") SpanInjector<MessageBuilder> spanInjector) {
-		return new TraceChannelInterceptor(tracer, traceKeys, spanExtractor, spanInjector);
+		return new TraceChannelInterceptor(tracer, traceKeys, traceHeaders, spanExtractor, spanInjector);
 	}
 
 	// TODO: Qualifier + ConditionalOnProp cause autowiring generics doesn't work
 	@Bean
 	@Qualifier("messagingSpanExtractor")
 	@ConditionalOnProperty(value = "spring.sleuth.integration.injector.enabled", matchIfMissing = true)
-	public SpanExtractor<Message> messagingSpanExtractor(Random random) {
-		return new MessagingSpanExtractor(random);
+	public SpanExtractor<Message> messagingSpanExtractor(Random random, TraceHeaders traceHeaders) {
+		return new MessagingSpanExtractor(random, traceHeaders);
 	}
 
 	// TODO: Qualifier + ConditionalOnProp cause autowiring generics doesn't work
 	@Bean
 	@Qualifier("messagingSpanInjector")
 	@ConditionalOnProperty(value = "spring.sleuth.integration.injector.enabled", matchIfMissing = true)
-	public SpanInjector<MessageBuilder> messagingSpanInjector(TraceKeys traceKeys) {
-		return new MessagingSpanInjector(traceKeys);
+	public SpanInjector<MessageBuilder> messagingSpanInjector(TraceKeys traceKeys,  TraceHeaders traceHeaders) {
+		return new MessagingSpanInjector(traceKeys, traceHeaders);
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -66,8 +67,8 @@ public class TraceWebClientAutoConfiguration {
 	}
 
 	@Bean
-	public SpanInjector httpRequestInjector() {
-		return new HttpRequestInjector();
+	public SpanInjector httpRequestInjector(TraceHeaders traceHeaders) {
+		return new HttpRequestInjector(traceHeaders);
 	}
 
 	@Configuration

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/RequestContextInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/RequestContextInjector.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.util.StringUtils;
 
 import com.netflix.zuul.context.RequestContext;
@@ -33,21 +34,26 @@ import com.netflix.zuul.context.RequestContext;
  */
 class RequestContextInjector implements SpanInjector<RequestContext> {
 
+	private final TraceHeaders traceHeaders;
+
+	RequestContextInjector(TraceHeaders traceHeaders) {
+		this.traceHeaders = traceHeaders;
+	}
+
 	@Override
 	public void inject(Span span, RequestContext carrier) {
 		Map<String, String> requestHeaders = carrier.getZuulRequestHeaders();
 		if (span == null) {
-			setHeader(requestHeaders, Span.NOT_SAMPLED_NAME, "true");
+			setHeader(requestHeaders, this.traceHeaders.getSampled(), TraceHeaders.SPAN_NOT_SAMPLED);
 			return;
 		}
-		setHeader(requestHeaders, Span.SPAN_ID_NAME, span.getSpanId());
-		setHeader(requestHeaders, Span.TRACE_ID_NAME, span.getTraceId());
-		setHeader(requestHeaders, Span.SPAN_NAME_NAME, span.getName());
-		if (!span.isExportable()) {
-			setHeader(requestHeaders, Span.NOT_SAMPLED_NAME, "true");
-		}
-		setHeader(requestHeaders, Span.PARENT_ID_NAME, getParentId(span));
-		setHeader(requestHeaders, Span.PROCESS_ID_NAME, span.getProcessId());
+		setHeader(requestHeaders, this.traceHeaders.getSpanId(), span.getSpanId());
+		setHeader(requestHeaders, this.traceHeaders.getTraceId(), span.getTraceId());
+		setHeader(requestHeaders, this.traceHeaders.getSleuth().getSpanName(), span.getName());
+		setHeader(requestHeaders, this.traceHeaders.getSampled(), span.isExportable() ?
+				TraceHeaders.SPAN_SAMPLED : TraceHeaders.SPAN_NOT_SAMPLED);
+		setHeader(requestHeaders, this.traceHeaders.getParentSpanId(), getParentId(span));
+		setHeader(requestHeaders, this.traceHeaders.getProcessId(), span.getProcessId());
 	}
 
 	private Long getParentId(Span span) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.sleuth.SpanAccessor;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -68,13 +69,13 @@ public class TraceZuulAutoConfiguration {
 	}
 
 	@Bean
-	SpanInjector<RequestContext> requestContextInjector() {
-		return new RequestContextInjector();
+	SpanInjector<RequestContext> requestContextInjector(TraceHeaders traceHeaders) {
+		return new RequestContextInjector(traceHeaders);
 	}
 
 	@Bean
-	SpanInjector<HttpRequest.Builder> requestBuilderContextInjector() {
-		return new RequestBuilderContextInjector();
+	SpanInjector<HttpRequest.Builder> requestBuilderContextInjector(TraceHeaders traceHeaders) {
+		return new RequestBuilderContextInjector(traceHeaders);
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -55,9 +56,9 @@ public class SleuthLogAutoConfiguration {
 
 		@Bean
 		@ConditionalOnProperty(value = "spring.sleuth.log.slf4j.enabled", matchIfMissing = true)
-		public SpanLogger slf4jSpanLogger() {
-			// Sets up MDC entries X-Trace-Id and X-Span-Id
-			return new Slf4jSpanLogger(this.nameSkipPattern);
+		public SpanLogger slf4jSpanLogger(TraceHeaders traceHeaders) {
+			// Sets up MDC entries X-B3-TraceId and X-B3-SpanId
+			return new Slf4jSpanLogger(this.nameSkipPattern, traceHeaders);
 		}
 
 		@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
@@ -80,7 +80,7 @@ public class DefaultTracer implements Tracer {
 			long id = createId();
 			span = Span.builder().begin(System.currentTimeMillis()).name(name).traceId(id)
 					.spanId(id).build();
-			if (sampler==null) {
+			if (sampler == null) {
 				sampler = this.defaultSampler;
 			}
 			if (!sampler.isSampled(span)) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanInjectorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanInjectorTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.instrument.messaging;
 
 import org.junit.Test;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -35,7 +36,8 @@ import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.asser
 public class MessagingSpanInjectorTests {
 
 	private TraceKeys traceKeys = new TraceKeys();
-	private MessagingSpanInjector messagingSpanInjector = new MessagingSpanInjector(this.traceKeys);
+	private MessagingSpanInjector messagingSpanInjector = new MessagingSpanInjector(this.traceKeys,
+			new TraceHeaders());
 
 	@Test
 	public void spanHeadersAdded() {
@@ -45,7 +47,7 @@ public class MessagingSpanInjectorTests {
 
 		this.messagingSpanInjector.inject(span, messageBuilder);
 
-		assertThat(messageBuilder.build().getHeaders()).containsKey(Span.SPAN_ID_NAME);
+		assertThat(messageBuilder.build().getHeaders()).containsKey(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME);
 	}
 
 	@Test
@@ -56,7 +58,7 @@ public class MessagingSpanInjectorTests {
 		this.messagingSpanInjector.inject(span, messageBuilder);
 
 		assertThat(messageBuilder.build().getHeaders())
-				.containsKeys(Span.SPAN_ID_NAME, "message/payload-type");
+				.containsKeys(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, "message/payload-type");
 		assertThat(span).hasATag("message/payload-type", "java.lang.String");
 	}
 
@@ -86,7 +88,7 @@ public class MessagingSpanInjectorTests {
 				.containsKey(NativeMessageHeaderAccessor.NATIVE_HEADERS);
 		MessageHeaderAccessor natives = NativeMessageHeaderAccessor
 				.getMutableAccessor(message);
-		assertThat(natives.getMessageHeaders()).containsKey(Span.SPAN_ID_NAME);
+		assertThat(natives.getMessageHeaders()).containsKey(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME);
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
@@ -26,11 +26,12 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.Tracer;
-import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
 import org.springframework.cloud.sleuth.instrument.messaging.TraceChannelInterceptorTests.App;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
+import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.channel.DirectChannel;
@@ -94,10 +95,10 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 	@Test
 	public void nonExportableSpanCreation() {
 		this.channel.send(MessageBuilder.withPayload("hi")
-				.setHeader(Span.NOT_SAMPLED_NAME, "true").build());
+				.setHeader(TraceHeaders.ZIPKIN_SAMPLED_HEADER_NAME, "0").build());
 		assertNotNull("message was null", this.message);
 
-		String spanId = this.message.getHeaders().get(Span.SPAN_ID_NAME, String.class);
+		String spanId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, String.class);
 		assertNotNull("spanId was null", spanId);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
 		assertFalse(this.span.isExportable());
@@ -106,14 +107,14 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 	@Test
 	public void parentSpanIncluded() {
 		this.channel.send(MessageBuilder.withPayload("hi")
-				.setHeader(Span.TRACE_ID_NAME, Span.idToHex(10L))
-				.setHeader(Span.SPAN_ID_NAME, Span.idToHex(20L)).build());
+				.setHeader(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, Span.idToHex(10L))
+				.setHeader(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, Span.idToHex(20L)).build());
 		assertNotNull("message was null", this.message);
 
-		String spanId = this.message.getHeaders().get(Span.SPAN_ID_NAME, String.class);
+		String spanId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, String.class);
 		assertNotNull("spanId was null", spanId);
 		long traceId = Span
-				.hexToId(this.message.getHeaders().get(Span.TRACE_ID_NAME, String.class));
+				.hexToId(this.message.getHeaders().get(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, String.class));
 		then(traceId).isEqualTo(10L);
 		then(spanId).isNotEqualTo(20L);
 		assertEquals(1, this.accumulator.getSpans().size());
@@ -124,10 +125,10 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 		this.channel.send(MessageBuilder.withPayload("hi").build());
 		assertNotNull("message was null", this.message);
 
-		String spanId = this.message.getHeaders().get(Span.SPAN_ID_NAME, String.class);
+		String spanId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, String.class);
 		assertNotNull("spanId was null", spanId);
 
-		String traceId = this.message.getHeaders().get(Span.TRACE_ID_NAME, String.class);
+		String traceId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, String.class);
 		assertNotNull("traceId was null", traceId);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
 	}
@@ -139,10 +140,10 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 		this.tracer.close(span);
 		assertNotNull("message was null", this.message);
 
-		String spanId = this.message.getHeaders().get(Span.SPAN_ID_NAME, String.class);
+		String spanId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, String.class);
 		assertNotNull("spanId was null", spanId);
 
-		String traceId = this.message.getHeaders().get(Span.TRACE_ID_NAME, String.class);
+		String traceId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, String.class);
 		assertNotNull("traceId was null", traceId);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
 	}
@@ -155,10 +156,10 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 		this.tracer.close(span);
 		assertNotNull("message was null", this.message);
 
-		String spanId = this.message.getHeaders().get(Span.SPAN_ID_NAME, String.class);
+		String spanId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, String.class);
 		assertNotNull("spanId was null", spanId);
 
-		String traceId = this.message.getHeaders().get(Span.TRACE_ID_NAME, String.class);
+		String traceId = this.message.getHeaders().get(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, String.class);
 		assertNotNull("traceId was null", traceId);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.messaging.TraceContextPropagationChannelInterceptorTests.App;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
@@ -76,15 +77,15 @@ public class TraceContextPropagationChannelInterceptorTests {
 		assertNotNull("message was null", message);
 
 		Long spanId = Span
-				.hexToId(message.getHeaders().get(Span.SPAN_ID_NAME, String.class));
+				.hexToId(message.getHeaders().get(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, String.class));
 		assertNotEquals("spanId was equal to parent's id", expectedSpanId,  spanId);
 
 		long traceId = Span
-				.hexToId(message.getHeaders().get(Span.TRACE_ID_NAME, String.class));
+				.hexToId(message.getHeaders().get(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, String.class));
 		assertNotNull("traceId was null", traceId);
 
 		Long parentId = Span
-				.hexToId(message.getHeaders().get(Span.PARENT_ID_NAME, String.class));
+				.hexToId(message.getHeaders().get(TraceHeaders.ZIPKIN_PARENT_SPAN_ID_HEADER_NAME, String.class));
 		assertEquals("parentId was not equal to parent's id", expectedSpanId,  parentId);
 
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectIntegrationTests.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.instrument.DefaultTestAutoConfiguration;
 import org.springframework.cloud.sleuth.instrument.web.common.AbstractMvcWiremockIntegrationTest;
 import org.springframework.cloud.sleuth.instrument.web.common.HttpMockServer;
@@ -89,7 +89,8 @@ public class RestTemplateTraceAspectIntegrationTests extends AbstractMvcWiremock
 	}
 
 	private void thenTraceIdHasBeenSetOnARequestHeader() {
-		this.wireMock.verifyThat(getRequestedFor(urlMatching(".*")).withHeader(Span.TRACE_ID_NAME, matching("^(?!\\s*$).+")));
+		this.wireMock.verifyThat(getRequestedFor(urlMatching(".*")).withHeader(
+				TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, matching("^(?!\\s*$).+")));
 	}
 
 	private void whenARequestIsSentToAnAsyncEndpoint(String url) throws Exception {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.DefaultTestAutoConfiguration;
@@ -104,15 +105,15 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 	}
 
 	private MvcResult whenSentPingWithTraceId(Long passedTraceId) throws Exception {
-		return sendPingWithTraceId(Span.TRACE_ID_NAME, passedTraceId);
+		return sendPingWithTraceId(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, passedTraceId);
 	}
 
 	private MvcResult whenSentInfoWithTraceId(Long passedTraceId) throws Exception {
-		return sendPingWithTraceId("/additionalContextPath/info", Span.TRACE_ID_NAME, passedTraceId);
+		return sendPingWithTraceId("/additionalContextPath/info", TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, passedTraceId);
 	}
 
 	private MvcResult whenSentFutureWithTraceId(Long passedTraceId) throws Exception {
-		return sendPingWithTraceId("/future", Span.TRACE_ID_NAME, passedTraceId);
+		return sendPingWithTraceId("/future", TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME, passedTraceId);
 	}
 
 	private MvcResult sendPingWithTraceId(String headerName, Long correlationId)
@@ -125,16 +126,16 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 		return this.mockMvc
 				.perform(MockMvcRequestBuilders.get(path).accept(MediaType.TEXT_PLAIN)
 						.header(headerName, Span.idToHex(correlationId))
-						.header(Span.SPAN_ID_NAME, Span.idToHex(new Random().nextLong())))
+						.header(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME, Span.idToHex(new Random().nextLong())))
 				.andReturn();
 	}
 
 	private Long tracingHeaderFrom(MvcResult mvcResult) {
-		return Span.hexToId(mvcResult.getResponse().getHeader(Span.TRACE_ID_NAME));
+		return Span.hexToId(mvcResult.getResponse().getHeader(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME));
 	}
 
 	private boolean notSampledHeaderIsPresent(MvcResult mvcResult) {
-		return mvcResult.getResponse().containsHeader(Span.NOT_SAMPLED_NAME);
+		return mvcResult.getResponse().containsHeader(TraceHeaders.ZIPKIN_SAMPLED_HEADER_NAME);
 	}
 
 	@Configuration

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
 import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.assertions.SleuthAssertions;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
@@ -59,7 +60,8 @@ public class TraceRestTemplateInterceptorIntegrationTests {
 		this.tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
 				new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter());
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
-				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector())));
+				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector(
+						new TraceHeaders()))));
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/AbstractMvcWiremockIntegrationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/AbstractMvcWiremockIntegrationTest.java
@@ -3,6 +3,7 @@ package org.springframework.cloud.sleuth.instrument.web.common;
 import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.sleuth.NoOpSpanReporter;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.instrument.web.TraceFilter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder;
@@ -27,7 +28,7 @@ public abstract class AbstractMvcWiremockIntegrationTest extends AbstractMvcInte
 
 	protected WireMock wireMock;
 	@Autowired protected HttpMockServer httpMockServer;
-
+	@Autowired protected TraceHeaders traceHeaders;
 
 	@Override
 	@Before
@@ -52,6 +53,7 @@ public abstract class AbstractMvcWiremockIntegrationTest extends AbstractMvcInte
 	@Override
 	protected void configureMockMvcBuilder(DefaultMockMvcBuilder mockMvcBuilder) {
 		mockMvcBuilder.addFilters(new TraceFilter(this.tracer, this.traceKeys,
-				new NoOpSpanReporter(), this.spanExtractor, this.spanInjector));
+				new NoOpSpanReporter(), this.spanExtractor, this.spanInjector,
+				this.traceHeaders));
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactoryTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactoryTest.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.netflix.zuul.filters.route.RestClientRibbonComm
 import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.Tracer;
 
 import com.netflix.client.http.HttpRequest;
@@ -44,7 +45,8 @@ public class TraceRestClientRibbonCommandFactoryTest {
 
 	@Mock Tracer tracer;
 	@Mock SpringClientFactory springClientFactory;
-	SpanInjector<HttpRequest.Builder> spanInjector = new RequestBuilderContextInjector();
+	SpanInjector<HttpRequest.Builder> spanInjector = new RequestBuilderContextInjector(
+			new TraceHeaders());
 	TraceRestClientRibbonCommandFactory traceRestClientRibbonCommandFactory;
 
 	@Before
@@ -83,11 +85,11 @@ public class TraceRestClientRibbonCommandFactoryTest {
 		traceRestClientRibbonCommand.customizeRequest(builder);
 
 		HttpRequest httpRequest = builder.build();
-		then(httpRequest.getHttpHeaders().getFirstValue(Span.SPAN_ID_NAME)).isEqualTo("1");
-		then(httpRequest.getHttpHeaders().getFirstValue(Span.TRACE_ID_NAME)).isEqualTo("2");
-		then(httpRequest.getHttpHeaders().getFirstValue(Span.SPAN_NAME_NAME)).isEqualTo("name");
-		then(httpRequest.getHttpHeaders().getFirstValue(Span.PARENT_ID_NAME)).isEqualTo("3");
-		then(httpRequest.getHttpHeaders().getFirstValue(Span.PROCESS_ID_NAME)).isEqualTo("processId");
+		then(httpRequest.getHttpHeaders().getFirstValue(TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME)).isEqualTo("1");
+		then(httpRequest.getHttpHeaders().getFirstValue(TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME)).isEqualTo("2");
+		then(httpRequest.getHttpHeaders().getFirstValue(TraceHeaders.Sleuth.SLEUTH_SPAN_NAME_HEADER_NAME)).isEqualTo("name");
+		then(httpRequest.getHttpHeaders().getFirstValue(TraceHeaders.ZIPKIN_PARENT_SPAN_ID_HEADER_NAME)).isEqualTo("3");
+		then(httpRequest.getHttpHeaders().getFirstValue(TraceHeaders.ZIPKIN_PROCESS_ID_HEADER_NAME)).isEqualTo("processId");
 	}
 
 	private RibbonCommandContext ribbonCommandContext() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Matchers.anyList;
@@ -36,7 +37,8 @@ public class Slf4JSpanLoggerTest {
 	Span spanWithNameNotToBeExcluded = Span.builder().name("Aspect").build();
 	String nameExcludingPattern = "^.*Hystrix.*$";
 	Logger log = Mockito.mock(Logger.class);
-	Slf4jSpanLogger slf4JSpanLogger = new Slf4jSpanLogger(this.nameExcludingPattern, this.log);
+	Slf4jSpanLogger slf4JSpanLogger = new Slf4jSpanLogger(this.nameExcludingPattern, this.log,
+			new TraceHeaders());
 
 	@Test
 	public void should_log_when_start_event_arrived_and_pattern_doesnt_match_span_name() throws Exception {

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/AbstractIntegrationTest.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/AbstractIntegrationTest.java
@@ -27,6 +27,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.trace.IntegrationTestSpanContextHolder;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -54,6 +55,7 @@ public abstract class AbstractIntegrationTest {
 	protected static final int POLL_INTERVAL = 1;
 	protected static final int TIMEOUT = 20;
 	protected RestTemplate restTemplate = new AssertingRestTemplate();
+	protected TraceHeaders traceHeaders = new TraceHeaders();
 
 	@Before
 	public void clearSpanBefore() {
@@ -128,11 +130,13 @@ public abstract class AbstractIntegrationTest {
 	}
 
 	protected Runnable httpMessageWithTraceIdInHeadersIsSuccessfullySent(String endpoint, long traceId) {
-		return new RequestSendingRunnable(this.restTemplate, endpoint, traceId, null);
+		return new RequestSendingRunnable(this.restTemplate, this.traceHeaders, traceId, null,
+				endpoint);
 	}
 
 	protected Runnable httpMessageWithTraceIdInHeadersIsSuccessfullySent(String endpoint, long traceId, Long spanId) {
-		return new RequestSendingRunnable(this.restTemplate, endpoint, traceId, spanId);
+		return new RequestSendingRunnable(this.restTemplate, this.traceHeaders, traceId,
+				spanId, endpoint);
 	}
 
 	protected Runnable allSpansWereRegisteredInZipkinWithTraceIdEqualTo(long traceId) {

--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfiguration.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.sleuth.Sampler;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.metric.SpanMetricReporter;
 import org.springframework.cloud.sleuth.sampler.PercentageBasedSampler;
 import org.springframework.cloud.sleuth.sampler.SamplerProperties;
@@ -64,8 +65,9 @@ public class SleuthStreamAutoConfiguration {
 
 	@Bean
 	@GlobalChannelInterceptor(patterns = SleuthSource.OUTPUT, order = Ordered.HIGHEST_PRECEDENCE)
-	public ChannelInterceptor zipkinChannelInterceptor(SpanMetricReporter spanMetricReporter) {
-		return new TracerIgnoringChannelInterceptor(spanMetricReporter);
+	public ChannelInterceptor zipkinChannelInterceptor(SpanMetricReporter spanMetricReporter,
+			TraceHeaders traceHeaders) {
+		return new TracerIgnoringChannelInterceptor(traceHeaders, spanMetricReporter);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/StreamEnvironmentPostProcessor.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/StreamEnvironmentPostProcessor.java
@@ -25,7 +25,7 @@ import java.util.Properties;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.env.EnvironmentPostProcessor;
-import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
@@ -40,6 +40,9 @@ import org.springframework.core.io.support.PropertiesLoaderUtils;
  * {@link EnvironmentPostProcessor} that sets the default properties for
  * Sleuth Stream.
  *
+ * If you're changing the {@link TraceHeaders} default values you have to override
+ * the appropriate {@code spring.cloud.stream.binder} header values.
+ *
  * @author Dave Syer
  *
  * @since 1.0.0
@@ -47,9 +50,12 @@ import org.springframework.core.io.support.PropertiesLoaderUtils;
 public class StreamEnvironmentPostProcessor implements EnvironmentPostProcessor {
 
 	private static final String PROPERTY_SOURCE_NAME = "defaultProperties";
-	private static String[] headers = new String[] { Span.SPAN_ID_NAME,
-			Span.TRACE_ID_NAME, Span.PARENT_ID_NAME, Span.PROCESS_ID_NAME,
-			Span.NOT_SAMPLED_NAME, Span.SPAN_NAME_NAME };
+	private static String[] headers = new String[] { TraceHeaders.ZIPKIN_SPAN_ID_HEADER_NAME,
+			TraceHeaders.ZIPKIN_TRACE_ID_HEADER_NAME,
+			TraceHeaders.ZIPKIN_PARENT_SPAN_ID_HEADER_NAME,
+			TraceHeaders.ZIPKIN_PROCESS_ID_HEADER_NAME,
+			TraceHeaders.Sleuth.SLEUTH_EXPORTABLE_HEADER_NAME,
+			TraceHeaders.Sleuth.SLEUTH_SPAN_NAME_HEADER_NAME };
 
 	@Override
 	public void postProcessEnvironment(ConfigurableEnvironment environment,

--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/TracerIgnoringChannelInterceptor.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/TracerIgnoringChannelInterceptor.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.sleuth.stream;
 
-import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.metric.SpanMetricReporter;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -31,9 +31,12 @@ import org.springframework.messaging.support.ChannelInterceptorAdapter;
  */
 class TracerIgnoringChannelInterceptor extends ChannelInterceptorAdapter {
 
+	private final TraceHeaders traceHeaders;
 	private final SpanMetricReporter spanMetricReporter;
 
-	public TracerIgnoringChannelInterceptor(SpanMetricReporter spanMetricReporter) {
+	public TracerIgnoringChannelInterceptor(TraceHeaders traceHeaders,
+			SpanMetricReporter spanMetricReporter) {
+		this.traceHeaders = traceHeaders;
 		this.spanMetricReporter = spanMetricReporter;
 	}
 
@@ -43,7 +46,8 @@ class TracerIgnoringChannelInterceptor extends ChannelInterceptorAdapter {
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
 		return MessageBuilder.fromMessage(message)
-				.setHeader(Span.NOT_SAMPLED_NAME, "true").build();
+				.setHeader(this.traceHeaders.getSampled(), TraceHeaders.SPAN_NOT_SAMPLED)
+				.build();
 	}
 
 	@Override

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/TracerIgnoringChannelInterceptorTest.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/TracerIgnoringChannelInterceptorTest.java
@@ -25,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceHeaders;
 import org.springframework.cloud.sleuth.metric.SpanMetricReporter;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
@@ -47,10 +48,11 @@ public class TracerIgnoringChannelInterceptorTest {
 	public void should_attach_not_sampled_header_to_the_message() throws Exception {
 		Message<String> message = MessageBuilder.withPayload("hello").build();
 
-		Message interceptedMessage = this.tracerIgnoringChannelInterceptor.preSend(message, this.messageChannel);
+		Message interceptedMessage = new TracerIgnoringChannelInterceptor(new TraceHeaders(), this.spanMetricReporter).
+				preSend(message, this.messageChannel);
 
 		then(interceptedMessage.getHeaders().containsKey(
-				Span.NOT_SAMPLED_NAME)).isTrue();
+				TraceHeaders.ZIPKIN_SAMPLED_HEADER_NAME)).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
* instead of direct passing of headers `TraceHeaders` is introduced
* by changing one property you can change trace-id to for example 'correlationId'
* updated docs to reflect the change
* defaults to Zipkin headers
* the brewery is working fine (on a branch)
* changed the way we set pass info about sampling spans (until now we had "not-sampled")

fixes #19

cc @spencergibb , @dsyer , @adriancole 