### PR TITLE
Updates to zipkin 0.9

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -14,10 +14,9 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<brave.version>3.4.0</brave.version>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.7.0</zipkin-java.version>
+		<zipkin-java.version>0.9.1</zipkin-java.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -57,11 +56,6 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-sleuth</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.github.kristofa</groupId>
-				<artifactId>brave-core</artifactId>
-				<version>${brave.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.aspectj</groupId>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -62,12 +62,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.7.0</version>
+				<version>0.9.1</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.7.0</version>
+				<version>0.9.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/docker-compose.yml
@@ -1,27 +1,15 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.36.0
+  image: openzipkin/zipkin-mysql:1.38.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.7.0
+  image: openzipkin/zipkin-java:0.9.1
   environment:
-    # Remove TRANSPORT_TYPE to disable tracing
-    - TRANSPORT_TYPE=http
     - STORAGE_TYPE=mysql
-    # - JAVA_OPTS=your jvm params here
-  expose:
-    - 9411
   ports:
+    # Historical port used for the Zipkin HTTP Api
     - 9411:9411
+    # Zipkin UI used to be on a separate process listening on port 8080
+    - 8080:9411
   links:
     - mysql:storage
-web:
-  image: openzipkin/zipkin-web:1.36.0
-  environment:
-    # Remove TRANSPORT_TYPE to disable tracing
-    - TRANSPORT_TYPE=http
-  ports:
-    - 8080:8080
-    - 9990:9990
-  links:
-    - query

--- a/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
@@ -38,7 +38,7 @@ public class ZipkinMessageListenerTests {
 		long start = System.currentTimeMillis();
 		this.span.logEvent("hystrix/retry"); // System.currentTimeMillis
 
-		zipkin.Span result = SamplingZipkinSpanIterator.convert(this.span, this.host);
+		zipkin.Span result = ConvertToZipkinSpanList.convert(this.span, this.host);
 
 		assertThat(result.timestamp)
 				.isEqualTo(this.span.getBegin() * 1000);
@@ -55,7 +55,7 @@ public class ZipkinMessageListenerTests {
 		this.span.logEvent("hystrix/retry");
 		this.span.tag("spring-boot/version", "1.3.1.RELEASE");
 
-		zipkin.Span result = SamplingZipkinSpanIterator.convert(this.span, this.host);
+		zipkin.Span result = ConvertToZipkinSpanList.convert(this.span, this.host);
 
 		assertThat(result.annotations.get(0).endpoint)
 				.isEqualTo(this.endpoint);
@@ -70,7 +70,7 @@ public class ZipkinMessageListenerTests {
 	 */
 	@Test
 	public void spanWithoutAnnotationsLogsComponent() {
-		zipkin.Span result = SamplingZipkinSpanIterator.convert(this.span, this.host);
+		zipkin.Span result = ConvertToZipkinSpanList.convert(this.span, this.host);
 
 		assertThat(result.binaryAnnotations).hasSize(1);
 		assertThat(result.binaryAnnotations.get(0)).isEqualToComparingFieldByField(
@@ -82,7 +82,7 @@ public class ZipkinMessageListenerTests {
 	public void nullProcessIdCoercesToUnknownServiceName() {
 		Span noProcessId = Span.builder().traceId(1L).name("http:parent").remote(true).build();
 
-		zipkin.Span result = SamplingZipkinSpanIterator.convert(noProcessId, this.host);
+		zipkin.Span result = ConvertToZipkinSpanList.convert(noProcessId, this.host);
 
 		assertThat(result.binaryAnnotations)
 				.containsOnly(BinaryAnnotation.create("lc", "unknown", this.endpoint));

--- a/spring-cloud-sleuth-zipkin/docker-compose.yml
+++ b/spring-cloud-sleuth-zipkin/docker-compose.yml
@@ -1,27 +1,15 @@
 mysql:
-  image: openzipkin/zipkin-mysql:1.36.0
+  image: openzipkin/zipkin-mysql:1.38.0
   ports:
     - 3306:3306
 query:
-  image: openzipkin/zipkin-java:0.7.0
+  image: openzipkin/zipkin-java:0.9.1
   environment:
-    # Remove TRANSPORT_TYPE to disable tracing
-    - TRANSPORT_TYPE=http
     - STORAGE_TYPE=mysql
-    # - JAVA_OPTS=your jvm params here
-  expose:
-    - 9411
   ports:
+    # Historical port used for the Zipkin HTTP Api
     - 9411:9411
+    # Zipkin UI used to be on a separate process listening on port 8080
+    - 8080:9411
   links:
     - mysql:storage
-web:
-  image: openzipkin/zipkin-web:1.36.0
-  environment:
-    # Remove TRANSPORT_TYPE to disable tracing
-    - TRANSPORT_TYPE=http
-  ports:
-    - 8080:8080
-    - 9990:9990
-  links:
-    - query


### PR DESCRIPTION
Notably, this removes the "zipkin-web" dependency, as the UI is now
collocated on zipkin-server.

Other notable changes are Cassandra and Kafka support, as well removing
the Brave dependency.