### PR TITLE
Removing entries from MDC

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -144,7 +144,6 @@ public class TraceFilter extends OncePerRequestFilter {
 				} else {
 					spanFromRequest.logEvent(Span.SERVER_SEND);
 				}
-				// Double close to clean up the parent (remote span as well)
 				this.tracer.close(spanFromRequest);
 			}
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jSpanLogger.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jSpanLogger.java
@@ -67,7 +67,7 @@ public class Slf4jSpanLogger implements SpanLogger {
 	@Override
 	public void logStoppedSpan(Span parent, Span span) {
 		log("Stopped span: {}", span);
-		if (parent != null) {
+		if (span != null && parent != null) {
 			log("With parent: {}", parent);
 			MDC.put(Span.SPAN_ID_NAME, Span.idToHex(parent.getSpanId()));
 			MDC.put(Span.SPAN_EXPORT_NAME, String.valueOf(parent.isExportable()));
@@ -80,7 +80,7 @@ public class Slf4jSpanLogger implements SpanLogger {
 	}
 
 	private void log(String text, Span span) {
-		if (this.nameSkipPattern.matcher(span.getName()).matches()) {
+		if (span != null && this.nameSkipPattern.matcher(span.getName()).matches()) {
 			return;
 		}
 		this.log.trace(text, span);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
@@ -115,7 +115,7 @@ public class DefaultTracer implements Tracer {
 			return null;
 		}
 		Span cur = SpanContextHolder.getCurrentSpan();
-		Span savedSpan = span.getSavedSpan();
+		final Span savedSpan = span.getSavedSpan();
 		if (!span.equals(cur)) {
 			ExceptionUtils.warn(
 					"Tried to close span but " + "it is not the current span: " + span
@@ -133,7 +133,11 @@ public class DefaultTracer implements Tracer {
 					this.spanLogger.logStoppedSpan(null, span);
 				}
 			}
-			SpanContextHolder.close();
+			SpanContextHolder.close(new SpanContextHolder.SpanFunction() {
+				@Override public void apply(Span span) {
+					DefaultTracer.this.spanLogger.logStoppedSpan(savedSpan, span);
+				}
+			});
 		}
 		return savedSpan;
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
@@ -7,6 +7,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -79,6 +80,16 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 		MvcResult mvcResult = whenSentPingWithTraceId(expectedTraceId);
 
 		then(tracingHeaderFrom(mvcResult)).isEqualTo(expectedTraceId);
+	}
+
+	@Test
+	public void when_message_is_sent_should_eventually_clear_mdc()
+			throws Exception {
+		Long expectedTraceId = new Random().nextLong();
+
+		whenSentPingWithTraceId(expectedTraceId);
+
+		then(MDC.getCopyOfContextMap()).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
when iterating over saved spans during span closing we can apply a function that should be executed on each iteration.

fixes #248