### PR TITLE
Updates to zipkin 0.14

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -16,8 +16,8 @@
 	<properties>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.13.0</zipkin-java.version>
-		<zipkin-ui.version>1.39.6</zipkin-ui.version>
+		<zipkin-java.version>0.14.0</zipkin-java.version>
+		<zipkin-ui.version>1.39.7</zipkin-ui.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -59,12 +59,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.13.0</version>
+				<version>0.14.0</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.13.0</version>
+				<version>0.14.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
No immediate impact to sleuth, but some notable changes underneath:

* zipkin.Sampler is now extensible to permit dynamic rate adjustments
* self-tracing can now be disabled even if Brave is in the classpath
  * related property: zipkin.self-tracing.enabled
  * brave-spancollector-scribe is no longer an optional dependency

In the world of plugins:

* Elasticsearch bugfix on traces w/ more than 10 spans
* New ZooKeeper adaptive collection-tier sampler