### PR TITLE
Draining from queue instead of clearing it

### DIFF
--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/StreamSpanListenerTests.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/StreamSpanListenerTests.java
@@ -24,6 +24,9 @@ import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.annotation.PostConstruct;
 
@@ -155,7 +158,7 @@ public class StreamSpanListenerTests {
 	@MessageEndpoint
 	protected static class ZipkinTestConfiguration {
 
-		private List<Span> spans = new ArrayList<>();
+		private BlockingQueue<Span> spans = new LinkedBlockingQueue<>();
 
 		@Autowired
 		StreamSpanReporter listener;


### PR DESCRIPTION
now instead of first passing all the spans from the queue to the list and then clearing it we're now draining it contents. If in the meantime any spans will arrive they will be rained at next passing

fixes #259