### PR TITLE
Updates to zipkin 0.15

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.14.0</zipkin-java.version>
+		<zipkin-java.version>0.15.0</zipkin-java.version>
 		<zipkin-ui.version>1.39.7</zipkin-ui.version>
 	</properties>
 	<dependencyManagement>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -59,12 +59,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.14.0</version>
+				<version>0.15.0</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.14.0</version>
+				<version>0.15.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListener.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListener.java
@@ -37,8 +37,8 @@ import zipkin.Annotation;
 import zipkin.AsyncSpanConsumer;
 import zipkin.BinaryAnnotation;
 import zipkin.BinaryAnnotation.Type;
+import zipkin.CollectorSampler;
 import zipkin.Endpoint;
-import zipkin.Sampler;
 import zipkin.Span.Builder;
 import zipkin.StorageComponent;
 
@@ -63,7 +63,7 @@ public class ZipkinMessageListener {
 	/** lazy so transient storage errors don't crash bootstrap */
 	@Lazy
 	@Autowired
-	ZipkinMessageListener(StorageComponent storage, Sampler sampler) {
+	ZipkinMessageListener(StorageComponent storage, CollectorSampler sampler) {
 		this.consumer = storage.asyncSpanConsumer(sampler);
 	}
 
@@ -145,8 +145,8 @@ public class ZipkinMessageListener {
 		float sampleRate = 1.0f;
 
 		@Bean
-		Sampler traceIdSampler() {
-			return Sampler.create(this.sampleRate);
+		CollectorSampler collectorSampler() {
+			return CollectorSampler.create(this.sampleRate);
 		}
 
 		@Bean


### PR DESCRIPTION
Notably, this removes the accidental transient dependency on scala, by
removing the dependency on `zipkin-cassandra-core`. Related classes have
been vendored into `storage-cassandra`.

This also splits out `CollectorSampler` as its own thing and introduces
two options for instrumentation sampling:

* `BoundaryTraceIdSampler` - For high-volume sites, based on Finagle
* `CountingTraceIdSampler` - Trades lower performance for high accuracy