### PR TITLE
Updates to zipkin 0.18

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -16,8 +16,8 @@
 	<properties>
 		<spring-cloud-netflix.version>1.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.17.1</zipkin-java.version>
-		<zipkin-ui.version>1.39.8</zipkin-ui.version>
+		<zipkin-java.version>0.18.0</zipkin-java.version>
+		<zipkin-ui.version>1.40.0</zipkin-ui.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -59,12 +59,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.17.1</version>
+				<version>0.18.0</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.17.1</version>
+				<version>0.18.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
@@ -74,7 +74,7 @@ final class ConvertToZipkinSpanList {
 	 */
 	// VisibleForTesting
 	static zipkin.Span convert(Span span, Host host) {
-		Builder zipkinSpan = new zipkin.Span.Builder();
+		Builder zipkinSpan = zipkin.Span.builder();
 
 		Endpoint ep = Endpoint.create(host.getServiceName(), host.getIpv4(),
 				host.getPort().shortValue());

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListener.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListener.java
@@ -81,7 +81,7 @@ public class ZipkinMessageListener {
 	 */
 	static void addZipkinAnnotations(Builder zipkinSpan, Span span, Endpoint endpoint) {
 		for (Log ta : span.logs()) {
-			Annotation zipkinAnnotation = new Annotation.Builder()
+			Annotation zipkinAnnotation = Annotation.builder()
 					.endpoint(endpoint)
 					.timestamp(ta.getTimestamp() * 1000) // Zipkin is in microseconds
 					.value(ta.getEvent())
@@ -96,7 +96,7 @@ public class ZipkinMessageListener {
 	static void addZipkinBinaryAnnotations(Builder zipkinSpan, Span span,
 			Endpoint endpoint) {
 		for (Map.Entry<String, String> e : span.tags().entrySet()) {
-			BinaryAnnotation.Builder binaryAnn = new BinaryAnnotation.Builder();
+			BinaryAnnotation.Builder binaryAnn = BinaryAnnotation.builder();
 			binaryAnn.type(Type.STRING);
 			binaryAnn.key(e.getKey());
 			try {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
@@ -74,7 +74,7 @@ public class ZipkinSpanListener implements SpanReporter {
 	 */
 	// Visible for testing
 	zipkin.Span convert(Span span) {
-		zipkin.Span.Builder zipkinSpan = new zipkin.Span.Builder();
+		zipkin.Span.Builder zipkinSpan = zipkin.Span.builder();
 
 		// A zipkin span without any annotations cannot be queried, add special "lc" to avoid that.
 		if (notClientOrServer(span)) {
@@ -109,7 +109,7 @@ public class ZipkinSpanListener implements SpanReporter {
 		byte[] processId = span.getProcessId() != null
 				? span.getProcessId().toLowerCase().getBytes(UTF_8)
 				: UNKNOWN_BYTES;
-		BinaryAnnotation component = new BinaryAnnotation.Builder()
+		BinaryAnnotation component = BinaryAnnotation.builder()
 				.type(BinaryAnnotation.Type.STRING)
 				.key("lc") // LOCAL_COMPONENT
 				.value(processId)
@@ -121,7 +121,7 @@ public class ZipkinSpanListener implements SpanReporter {
 		String serviceName = span.tags().containsKey(Span.SPAN_PEER_SERVICE_TAG_NAME) ?
 				span.tags().get(Span.SPAN_PEER_SERVICE_TAG_NAME) : this.endpointLocator.local().serviceName;
 		zipkinSpan.addBinaryAnnotation(BinaryAnnotation.address(Constants.SERVER_ADDR,
-				new Endpoint.Builder(this.endpointLocator.local()).serviceName(serviceName).build()));
+				this.endpointLocator.local().toBuilder().serviceName(serviceName).build()));
 	}
 
 	private boolean notClientOrServer(Span span) {
@@ -148,7 +148,7 @@ public class ZipkinSpanListener implements SpanReporter {
 	private void addZipkinAnnotations(zipkin.Span.Builder zipkinSpan,
 			Span span, Endpoint endpoint) {
 		for (Log ta : span.logs()) {
-			Annotation zipkinAnnotation = new Annotation.Builder()
+			Annotation zipkinAnnotation = Annotation.builder()
 					.endpoint(endpoint)
 					.timestamp(ta.getTimestamp() * 1000) // Zipkin is in microseconds
 					.value(ta.getEvent()).build();
@@ -162,7 +162,7 @@ public class ZipkinSpanListener implements SpanReporter {
 	private void addZipkinBinaryAnnotations(zipkin.Span.Builder zipkinSpan,
 			Span span, Endpoint ep) {
 		for (Map.Entry<String, String> e : span.tags().entrySet()) {
-			BinaryAnnotation binaryAnn = new BinaryAnnotation.Builder()
+			BinaryAnnotation binaryAnn = BinaryAnnotation.builder()
 					.type(BinaryAnnotation.Type.STRING)
 					.key(e.getKey())
 					.value(e.getValue().getBytes(UTF_8))

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
@@ -114,6 +114,6 @@ public class HttpZipkinSpanReporterTest {
 	}
 
 	static Span span(long traceId, String spanName) {
-		return new Span.Builder().traceId(traceId).id(traceId).name(spanName).build();
+		return Span.builder().traceId(traceId).id(traceId).name(spanName).build();
 	}
 }


### PR DESCRIPTION
Relating to sleuth, this is mostly cosmetic with a kafka condition fix.

It might be of interest that `GET /api/v1/traces` no longer requires
parameters.

https://github.com/openzipkin/zipkin-java/releases/tag/0.18.0