### PR TITLE
Moves to zipkin 0.21

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -16,8 +16,7 @@
 	<properties>
 		<spring-cloud-netflix.version>1.1.1.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin-java.version>0.18.0</zipkin-java.version>
-		<zipkin-ui.version>1.40.0</zipkin-ui.version>
+		<zipkin.version>0.21.5</zipkin.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -71,27 +70,27 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>${zipkin-java.version}</version>
+				<version>${zipkin.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>${zipkin-java.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.zipkin</groupId>
-				<artifactId>zipkin-ui</artifactId>
-				<version>${zipkin-ui.version}</version>
+				<version>${zipkin.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
-				<artifactId>zipkin-storage-jdbc</artifactId>
-				<version>${zipkin-java.version}</version>
+				<artifactId>zipkin-autoconfigure-ui</artifactId>
+				<version>${zipkin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.zipkin.java</groupId>
+				<artifactId>zipkin-autoconfigure-storage-mysql</artifactId>
+				<version>${zipkin.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-junit</artifactId>
-				<version>${zipkin-java.version}</version>
+				<version>${zipkin.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -59,12 +59,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>0.18.0</version>
+				<version>0.21.5</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>0.18.0</version>
+				<version>0.21.5</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/README.md
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/README.md
@@ -27,7 +27,7 @@ and test it
 
 ```
 $ curl localhost:9411/api/v1/services
-["zipkin-query"]
+["zipkin-server"]
 ```
 
 ## Instrumenting Apps

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/pom.xml
@@ -54,8 +54,8 @@
 			<artifactId>spring-cloud-sleuth-zipkin-stream</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>io.zipkin</groupId>
-			<artifactId>zipkin-ui</artifactId>
+			<groupId>io.zipkin.java</groupId>
+			<artifactId>zipkin-autoconfigure-ui</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.integration</groupId>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/src/test/java/example/ZipkinServerApplicationTests.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin-stream/src/test/java/example/ZipkinServerApplicationTests.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import zipkin.SpanStore;
+import zipkin.storage.StorageComponent;
 
 import static org.junit.Assert.assertEquals;
 
@@ -18,11 +18,11 @@ import static org.junit.Assert.assertEquals;
 public class ZipkinServerApplicationTests {
 
 	@Autowired
-	private SpanStore store;
+	private StorageComponent storage;
 
 	@Test
 	public void contextLoads() {
-		int count = this.store.getServiceNames().size();
+		int count = this.storage.spanStore().getServiceNames().size();
 		assertEquals(0, count);
 	}
 

--- a/spring-cloud-sleuth-zipkin-stream/README.md
+++ b/spring-cloud-sleuth-zipkin-stream/README.md
@@ -24,7 +24,7 @@ public class ZipkinStreamServerApplication {
 }
 ```
 
-Zipkin has a web UI, which is enabled by default when you depend on `io.zipkin:zipkin-ui`.
+Zipkin has a web UI, which is enabled by default when you depend on `io.zipkin.java:zipkin-autoconfigure-ui`.
 
 Bind to MySQL and the same Stream service that you did in the apps (rabbit, redis, kafka). Set `spring.datasource.initialize=true` the first time you start to initialize the database.
 

--- a/spring-cloud-sleuth-zipkin-stream/pom.xml
+++ b/spring-cloud-sleuth-zipkin-stream/pom.xml
@@ -63,7 +63,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.zipkin.java</groupId>
-			<artifactId>zipkin-storage-jdbc</artifactId>
+			<artifactId>zipkin-autoconfigure-storage-mysql</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinServerApplicationTests.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinServerApplicationTests.java
@@ -13,7 +13,7 @@ import org.springframework.cloud.sleuth.zipkin.stream.ZipkinServerApplicationTes
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import zipkin.SpanStore;
+import zipkin.storage.StorageComponent;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = ZipkinStreamServerApplication.class)
@@ -22,11 +22,11 @@ import zipkin.SpanStore;
 public class ZipkinServerApplicationTests {
 
 	@Autowired
-	private SpanStore store;
+	private StorageComponent storage;
 
 	@Test
 	public void contextLoads() {
-		int count = this.store.getServiceNames().size();
+		int count = this.storage.spanStore().getServiceNames().size();
 		assertEquals(0, count);
 	}
 


### PR DESCRIPTION
This moves to changes made in preparation of zipkin 1.0.

Here are the notables:

* Zipkin has autoconfiguration modules, where maven artifacts have the prefix 'zipkin-autoconfigure-X'
* Zipkin's ui now shares a version with everything else

* Zipkin now namespaces packages and configuration. ex zipkin.storage.X as opposed to zipkin.X
* All autoconfiguration classes are prefixed `Zipkin` to be easier to find

* Zipkin binds components like StorageComponent, as opposed to individual classes like SpanStore.
* Health checks are under the scope "zipkin" and broken down by component

* UI responsiveness is better by conditionally caching names queries for 5 minutes
* New `Collector` class, which makes logging and metrics patterns the same regardless of transport