### PR TITLE
Issues #290 client tags

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
@@ -1,0 +1,55 @@
+package org.springframework.cloud.sleuth.instrument.web;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.springframework.cloud.sleuth.TraceKeys;
+import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.util.StringUtils;
+
+/**
+ * Injects HTTP related keys to the current span.
+ *
+ * @author Marcin Grzejszczak
+ *
+ * @since 1.0.1
+ */
+public class HttpTraceKeysInjector {
+
+	private final Tracer tracer;
+	private final TraceKeys traceKeys;
+
+	public HttpTraceKeysInjector(Tracer tracer, TraceKeys traceKeys) {
+		this.tracer = tracer;
+		this.traceKeys = traceKeys;
+	}
+
+	public void addRequestTags(String url, String host, String path, String method) {
+		this.tracer.addTag(this.traceKeys.getHttp().getUrl(), url);
+		this.tracer.addTag(this.traceKeys.getHttp().getHost(), host);
+		this.tracer.addTag(this.traceKeys.getHttp().getPath(), path);
+		this.tracer.addTag(this.traceKeys.getHttp().getMethod(), method);
+	}
+
+	public void addRequestTags(String url, String host, String path, String method,
+			Map<String, ? extends Collection<String>> headers) {
+		addRequestTags(url, host, path, method);
+		addRequestTagsFromHeaders(headers);
+	}
+
+	private void addRequestTagsFromHeaders(Map<String, ? extends Collection<String>> headers) {
+		for (String name : this.traceKeys.getHttp().getHeaders()) {
+			for (Map.Entry<String, ? extends Collection<String>> entry : headers.entrySet()) {
+				addTagForEntry(name, entry.getValue());
+			}
+		}
+	}
+
+	private void addTagForEntry(String name, Collection<String> list) {
+		String key = this.traceKeys.getHttp().getPrefix() + name.toLowerCase();
+		String value = list.size() == 1 ? list.iterator().next()
+				: StringUtils.collectionToDelimitedString(list, ",", "'", "'");
+		this.tracer.addTag(key, value);
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
@@ -3,6 +3,7 @@ package org.springframework.cloud.sleuth.instrument.web;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.util.StringUtils;
@@ -24,6 +25,9 @@ public class HttpTraceKeysInjector {
 		this.traceKeys = traceKeys;
 	}
 
+	/**
+	 * Adds tags from the HTTP request to the current Span
+	 */
 	public void addRequestTags(String url, String host, String path, String method) {
 		this.tracer.addTag(this.traceKeys.getHttp().getUrl(), url);
 		this.tracer.addTag(this.traceKeys.getHttp().getHost(), host);
@@ -31,10 +35,32 @@ public class HttpTraceKeysInjector {
 		this.tracer.addTag(this.traceKeys.getHttp().getMethod(), method);
 	}
 
+	/**
+	 * Adds tags from the HTTP request to the given Span
+	 */
+	public void addRequestTags(Span span, String url, String host, String path, String method) {
+		tagSpan(span, this.traceKeys.getHttp().getUrl(), url);
+		tagSpan(span, this.traceKeys.getHttp().getHost(), host);
+		tagSpan(span, this.traceKeys.getHttp().getPath(), path);
+		tagSpan(span, this.traceKeys.getHttp().getMethod(), method);
+	}
+
+	/**
+	 * Adds tags from the HTTP request together with headers to the current Span
+	 */
 	public void addRequestTags(String url, String host, String path, String method,
 			Map<String, ? extends Collection<String>> headers) {
 		addRequestTags(url, host, path, method);
 		addRequestTagsFromHeaders(headers);
+	}
+
+	/**
+	 * Add a tag to the given, exportable Span
+	 */
+	public void tagSpan(Span span, String key, String value) {
+		if (span != null && span.isExportable()) {
+			span.tag(key, value);
+		}
 	}
 
 	private void addRequestTagsFromHeaders(Map<String, ? extends Collection<String>> headers) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -76,9 +76,10 @@ public class TraceWebAutoConfiguration {
 	public TraceFilter traceFilter(Tracer tracer, TraceKeys traceKeys,
 			SkipPatternProvider skipPatternProvider, SpanReporter spanReporter,
 			SpanExtractor<HttpServletRequest> spanExtractor,
-			SpanInjector<HttpServletResponse> spanInjector) {
+			SpanInjector<HttpServletResponse> spanInjector,
+			HttpTraceKeysInjector httpTraceKeysInjector) {
 		return new TraceFilter(tracer, traceKeys, skipPatternProvider.skipPattern(),
-				spanReporter, spanExtractor, spanInjector);
+				spanReporter, spanExtractor, spanInjector, httpTraceKeysInjector);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.TraceKeys;
@@ -23,17 +27,11 @@ import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.util.StringUtils;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-
 /**
  * Abstraction over classes that interact with Http requests. Allows you
  * to enrich the request headers with trace related information.
  *
  * @author Marcin Grzejszczak
- *
  * @since 1.0.0
  */
 abstract class AbstractTraceHttpRequestInterceptor {
@@ -43,8 +41,7 @@ abstract class AbstractTraceHttpRequestInterceptor {
 	protected final TraceKeys traceKeys;
 
 	protected AbstractTraceHttpRequestInterceptor(Tracer tracer,
-												SpanInjector<HttpRequest> spanInjector,
-												TraceKeys traceKeys) {
+			SpanInjector<HttpRequest> spanInjector, TraceKeys traceKeys) {
 		this.tracer = tracer;
 		this.spanInjector = spanInjector;
 		this.traceKeys = traceKeys;
@@ -59,6 +56,7 @@ abstract class AbstractTraceHttpRequestInterceptor {
 		String spanName = uriScheme(uri) + ":" + uri.getPath();
 		Span newSpan = this.tracer.createSpan(spanName);
 		this.spanInjector.inject(newSpan, request);
+		addRequestTags(request);
 		newSpan.logEvent(Span.CLIENT_SEND);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncClientHttpRequestFactoryWrapper.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncClientHttpRequestFactoryWrapper.java
@@ -16,9 +16,12 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import java.io.IOException;
+import java.net.URI;
+
 import org.springframework.cloud.sleuth.SpanInjector;
-import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.core.task.AsyncListenableTaskExecutor;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRequest;
@@ -28,9 +31,6 @@ import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-
-import java.io.IOException;
-import java.net.URI;
 
 /**
  * Wrapper that adds trace related headers to the created {@link AsyncClientHttpRequest}
@@ -55,10 +55,11 @@ public class TraceAsyncClientHttpRequestFactoryWrapper extends AbstractTraceHttp
 	 *
 	 * @see org.springframework.web.client.AsyncRestTemplate#AsyncRestTemplate(AsyncClientHttpRequestFactory)
 	 */
-	public TraceAsyncClientHttpRequestFactoryWrapper(Tracer tracer, SpanInjector<HttpRequest> spanInjector,
-													AsyncClientHttpRequestFactory asyncDelegate,
-													TraceKeys traceKeys) {
-		super(tracer, spanInjector, traceKeys);
+	public TraceAsyncClientHttpRequestFactoryWrapper(Tracer tracer,
+			SpanInjector<HttpRequest> spanInjector,
+			AsyncClientHttpRequestFactory asyncDelegate,
+			HttpTraceKeysInjector httpTraceKeysInjector) {
+		super(tracer, spanInjector, httpTraceKeysInjector);
 		this.asyncDelegate = asyncDelegate;
 		this.syncDelegate = asyncDelegate instanceof ClientHttpRequestFactory ?
 				(ClientHttpRequestFactory) asyncDelegate : defaultClientHttpRequestFactory();
@@ -68,17 +69,20 @@ public class TraceAsyncClientHttpRequestFactoryWrapper extends AbstractTraceHttp
 	 * Default implementation that creates a {@link SimpleClientHttpRequestFactory} that
 	 * has a wrapped task executor via the {@link TraceAsyncListenableTaskExecutor}
 	 */
-	public TraceAsyncClientHttpRequestFactoryWrapper(Tracer tracer, SpanInjector<HttpRequest> spanInjector,
-													TraceKeys traceKeys) {
-		super(tracer, spanInjector, traceKeys);
+	public TraceAsyncClientHttpRequestFactoryWrapper(Tracer tracer,
+			SpanInjector<HttpRequest> spanInjector, HttpTraceKeysInjector httpTraceKeysInjector) {
+		super(tracer, spanInjector, httpTraceKeysInjector);
 		SimpleClientHttpRequestFactory simpleClientHttpRequestFactory = defaultClientHttpRequestFactory();
 		this.asyncDelegate = simpleClientHttpRequestFactory;
 		this.syncDelegate = simpleClientHttpRequestFactory;
 	}
 
-	public TraceAsyncClientHttpRequestFactoryWrapper(Tracer tracer, SpanInjector<HttpRequest> spanInjector,
-			AsyncClientHttpRequestFactory asyncDelegate, ClientHttpRequestFactory syncDelegate, TraceKeys traceKeys) {
-		super(tracer, spanInjector, traceKeys);
+	public TraceAsyncClientHttpRequestFactoryWrapper(Tracer tracer,
+			SpanInjector<HttpRequest> spanInjector,
+			AsyncClientHttpRequestFactory asyncDelegate,
+			ClientHttpRequestFactory syncDelegate,
+			HttpTraceKeysInjector httpTraceKeysInjector) {
+		super(tracer, spanInjector, httpTraceKeysInjector);
 		this.asyncDelegate = asyncDelegate;
 		this.syncDelegate = syncDelegate;
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -19,8 +19,8 @@ package org.springframework.cloud.sleuth.instrument.web.client;
 import java.io.IOException;
 
 import org.springframework.cloud.sleuth.SpanInjector;
-import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -40,8 +40,8 @@ public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterc
 		implements ClientHttpRequestInterceptor {
 
 	public TraceRestTemplateInterceptor(Tracer tracer, SpanInjector<HttpRequest> spanInjector,
-										TraceKeys traceKeys) {
-		super(tracer, spanInjector, traceKeys);
+			HttpTraceKeysInjector httpTraceKeysInjector) {
+		super(tracer, spanInjector, httpTraceKeysInjector);
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import java.io.IOException;
+
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
@@ -23,8 +25,6 @@ import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-
-import java.io.IOException;
 
 /**
  * Interceptor that verifies whether the trance and span id has been set on the request
@@ -47,7 +47,6 @@ public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterc
 	@Override
 	public ClientHttpResponse intercept(HttpRequest request, byte[] body,
 			ClientHttpRequestExecution execution) throws IOException {
-		addRequestTags(request);
 		publishStartEvent(request);
 		return response(request, body, execution);
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -16,14 +16,15 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
-import java.io.IOException;
-
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
 
 /**
  * Interceptor that verifies whether the trance and span id has been set on the request
@@ -38,13 +39,15 @@ import org.springframework.http.client.ClientHttpResponse;
 public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterceptor
 		implements ClientHttpRequestInterceptor {
 
-	public TraceRestTemplateInterceptor(Tracer tracer, SpanInjector<HttpRequest> spanInjector) {
-		super(tracer, spanInjector);
+	public TraceRestTemplateInterceptor(Tracer tracer, SpanInjector<HttpRequest> spanInjector,
+										TraceKeys traceKeys) {
+		super(tracer, spanInjector, traceKeys);
 	}
 
 	@Override
 	public ClientHttpResponse intercept(HttpRequest request, byte[] body,
 			ClientHttpRequestExecution execution) throws IOException {
+		addRequestTags(request);
 		publishStartEvent(request);
 		return response(request, body, execution);
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.sleuth.SpanAccessor;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +54,7 @@ import org.springframework.web.client.AsyncRestTemplate;
 public class TraceWebAsyncClientAutoConfiguration {
 
 	@Autowired Tracer tracer;
+	@Autowired TraceKeys traceKeys;
 	@Autowired SpanInjector<HttpRequest> spanInjector;
 	@Autowired(required = false) ClientHttpRequestFactory clientHttpRequestFactory;
 	@Autowired(required = false) AsyncClientHttpRequestFactory asyncClientHttpRequestFactory;
@@ -71,7 +73,7 @@ public class TraceWebAsyncClientAutoConfiguration {
 					(AsyncClientHttpRequestFactory) clientFactory : defaultClientHttpRequestFactory(this.tracer);
 		}
 		return new TraceAsyncClientHttpRequestFactoryWrapper(this.tracer, this.spanInjector,
-				asyncClientFactory, clientFactory);
+				asyncClientFactory, clientFactory, this.traceKeys);
 	}
 
 	private SimpleClientHttpRequestFactory defaultClientHttpRequestFactory(Tracer tracer) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
@@ -24,9 +24,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.sleuth.SpanAccessor;
 import org.springframework.cloud.sleuth.SpanInjector;
-import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -54,7 +54,7 @@ import org.springframework.web.client.AsyncRestTemplate;
 public class TraceWebAsyncClientAutoConfiguration {
 
 	@Autowired Tracer tracer;
-	@Autowired TraceKeys traceKeys;
+	@Autowired HttpTraceKeysInjector httpTraceKeysInjector;
 	@Autowired SpanInjector<HttpRequest> spanInjector;
 	@Autowired(required = false) ClientHttpRequestFactory clientHttpRequestFactory;
 	@Autowired(required = false) AsyncClientHttpRequestFactory asyncClientHttpRequestFactory;
@@ -73,7 +73,7 @@ public class TraceWebAsyncClientAutoConfiguration {
 					(AsyncClientHttpRequestFactory) clientFactory : defaultClientHttpRequestFactory(this.tracer);
 		}
 		return new TraceAsyncClientHttpRequestFactoryWrapper(this.tracer, this.spanInjector,
-				asyncClientFactory, clientFactory, this.traceKeys);
+				asyncClientFactory, clientFactory, this.httpTraceKeysInjector);
 	}
 
 	private SimpleClientHttpRequestFactory defaultClientHttpRequestFactory(Tracer tracer) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -16,11 +16,10 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -32,6 +31,7 @@ import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpRequest;
@@ -56,14 +56,20 @@ public class TraceWebClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public TraceRestTemplateInterceptor traceRestTemplateInterceptor(Tracer tracer,
-																	SpanInjector<HttpRequest> spanInjector,
-																	TraceKeys traceKeys) {
-		return new TraceRestTemplateInterceptor(tracer, spanInjector, traceKeys);
+			SpanInjector<HttpRequest> spanInjector,
+			HttpTraceKeysInjector httpTraceKeysInjector) {
+		return new TraceRestTemplateInterceptor(tracer, spanInjector, httpTraceKeysInjector);
 	}
 
 	@Bean
 	public SpanInjector<HttpRequest> httpRequestSpanInjector() {
 		return new HttpRequestInjector();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public HttpTraceKeysInjector httpTraceKeysInjector(Tracer tracer, TraceKeys traceKeys) {
+		return new HttpTraceKeysInjector(tracer, traceKeys);
 	}
 
 	@Configuration

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -55,8 +56,9 @@ public class TraceWebClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public TraceRestTemplateInterceptor traceRestTemplateInterceptor(Tracer tracer,
-			SpanInjector<HttpRequest> spanInjector) {
-		return new TraceRestTemplateInterceptor(tracer, spanInjector);
+																	SpanInjector<HttpRequest> spanInjector,
+																	TraceKeys traceKeys) {
+		return new TraceRestTemplateInterceptor(tracer, spanInjector, traceKeys);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignBuilder.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignBuilder.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 
 import feign.Feign;
 import feign.hystrix.HystrixFeign;
@@ -34,9 +35,9 @@ final class SleuthFeignBuilder {
 
 	private SleuthFeignBuilder() {}
 
-	static Feign.Builder builder(Tracer tracer) {
+	static Feign.Builder builder(Tracer tracer, HttpTraceKeysInjector keysInjector) {
 		return HystrixFeign.builder()
-				.client(new TraceFeignClient(tracer))
+				.client(new TraceFeignClient(tracer, keysInjector))
 				.retryer(new TraceFeignRetryer(tracer))
 				.decoder(new TraceFeignDecoder(tracer))
 				.errorDecoder(new TraceFeignErrorDecoder(tracer));

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
@@ -38,7 +38,6 @@ import org.springframework.cloud.netflix.feign.FeignContext;
 import org.springframework.cloud.netflix.feign.support.ResponseEntityDecoder;
 import org.springframework.cloud.netflix.feign.support.SpringDecoder;
 import org.springframework.cloud.sleuth.SpanInjector;
-import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.hystrix.SleuthHystrixAutoConfiguration;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
@@ -77,8 +76,8 @@ public class TraceFeignClientAutoConfiguration {
 	@Scope("prototype")
 	@ConditionalOnClass(HystrixCommand.class)
 	@ConditionalOnProperty(name = "feign.hystrix.enabled", matchIfMissing = true)
-	Feign.Builder feignHystrixBuilder(Tracer tracer, TraceKeys traceKeys) {
-		return SleuthFeignBuilder.builder(tracer);
+	Feign.Builder feignHystrixBuilder(Tracer tracer, HttpTraceKeysInjector keysInjector) {
+		return SleuthFeignBuilder.builder(tracer, keysInjector);
 	}
 
 	@Configuration
@@ -125,8 +124,8 @@ public class TraceFeignClientAutoConfiguration {
 	 * an existing one if a retry takes place.
 	 */
 	@Bean
-	RequestInterceptor traceIdRequestInterceptor(Tracer tracer, HttpTraceKeysInjector httpTraceKeysInjector) {
-		return new TraceFeignRequestInterceptor(tracer, feignRequestTemplateInjector(), httpTraceKeysInjector);
+	RequestInterceptor traceIdRequestInterceptor(Tracer tracer) {
+		return new TraceFeignRequestInterceptor(tracer, feignRequestTemplateInjector());
 	}
 
 	@Autowired(required = false)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
@@ -16,14 +16,13 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.netflix.hystrix.HystrixCommand;
-import feign.Client;
-import feign.Feign;
-import feign.FeignException;
-import feign.RequestInterceptor;
-import feign.RequestTemplate;
-import feign.Response;
-import feign.codec.Decoder;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,15 +41,19 @@ import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.hystrix.SleuthHystrixAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
+import feign.Client;
+import feign.Feign;
+import feign.FeignException;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import feign.Response;
+import feign.codec.Decoder;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -86,7 +89,6 @@ public class TraceFeignClientAutoConfiguration {
 		FeignBeanPostProcessor feignBeanPostProcessor(TraceFeignObjectWrapper traceFeignObjectWrapper) {
 			return new FeignBeanPostProcessor(traceFeignObjectWrapper);
 		}
-
 	}
 
 	@Bean
@@ -123,8 +125,8 @@ public class TraceFeignClientAutoConfiguration {
 	 * an existing one if a retry takes place.
 	 */
 	@Bean
-	public RequestInterceptor traceIdRequestInterceptor(Tracer tracer, TraceKeys traceKeys) {
-		return new TraceFeignRequestInterceptor(tracer, feignRequestTemplateInjector(), traceKeys);
+	RequestInterceptor traceIdRequestInterceptor(Tracer tracer, HttpTraceKeysInjector httpTraceKeysInjector) {
+		return new TraceFeignRequestInterceptor(tracer, feignRequestTemplateInjector(), httpTraceKeysInjector);
 	}
 
 	@Autowired(required = false)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
@@ -123,8 +123,8 @@ public class TraceFeignClientAutoConfiguration {
 	 * an existing one if a retry takes place.
 	 */
 	@Bean
-	public RequestInterceptor traceIdRequestInterceptor(Tracer tracer) {
-		return new TraceFeignRequestInterceptor(tracer, feignRequestTemplateInjector());
+	public RequestInterceptor traceIdRequestInterceptor(Tracer tracer, TraceKeys traceKeys) {
+		return new TraceFeignRequestInterceptor(tracer, feignRequestTemplateInjector(), traceKeys);
 	}
 
 	@Autowired(required = false)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignObjectWrapper.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignObjectWrapper.java
@@ -1,11 +1,12 @@
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.cloud.sleuth.Tracer;
+
 import feign.Client;
 import feign.Retryer;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.cloud.sleuth.Tracer;
 
 /**
  * Class that wraps Feign related classes into their Trace representative
@@ -36,7 +37,7 @@ final class TraceFeignObjectWrapper {
 	}
 
 	private Tracer getTracer() {
-		if (this.tracer==null) {
+		if (this.tracer == null) {
 			this.tracer = this.beanFactory.getBean(Tracer.class);
 		}
 		return this.tracer;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignObjectWrapper.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignObjectWrapper.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 
 import feign.Client;
 import feign.Retryer;
@@ -18,6 +19,7 @@ final class TraceFeignObjectWrapper {
 
 	private final BeanFactory beanFactory;
 	private Tracer tracer;
+	private HttpTraceKeysInjector keysInjector;
 
 	TraceFeignObjectWrapper(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
@@ -29,7 +31,7 @@ final class TraceFeignObjectWrapper {
 		} else if (bean instanceof Retryer && !(bean instanceof TraceFeignRetryer)) {
 			return new TraceFeignRetryer(getTracer(), (Retryer) bean);
 		} else if (bean instanceof Client && !(bean instanceof TraceFeignClient)) {
-			return new TraceFeignClient(getTracer(), (Client) bean);
+			return new TraceFeignClient(getTracer(), (Client) bean, getHttpTraceKeysInjector());
 		} else if (bean instanceof ErrorDecoder && !(bean instanceof TraceFeignErrorDecoder)) {
 			return new TraceFeignErrorDecoder(getTracer(), (ErrorDecoder) bean);
 		}
@@ -41,5 +43,12 @@ final class TraceFeignObjectWrapper {
 			this.tracer = this.beanFactory.getBean(Tracer.class);
 		}
 		return this.tracer;
+	}
+
+	private HttpTraceKeysInjector getHttpTraceKeysInjector() {
+		if (this.keysInjector == null) {
+			this.keysInjector = this.beanFactory.getBean(HttpTraceKeysInjector.class);
+		}
+		return this.keysInjector;
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignRequestInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignRequestInterceptor.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.Tracer;
-import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
@@ -39,14 +38,11 @@ final class TraceFeignRequestInterceptor implements RequestInterceptor {
 	private final Tracer tracer;
 	private final SpanInjector<RequestTemplate> spanInjector;
 	private final FeignRequestContext feignRequestContext = FeignRequestContext.getInstance();
-	private final HttpTraceKeysInjector keysInjector;
 
 	TraceFeignRequestInterceptor(Tracer tracer,
-			SpanInjector<RequestTemplate> spanInjector,
-			HttpTraceKeysInjector keysInjector) {
+			SpanInjector<RequestTemplate> spanInjector) {
 		this.tracer = tracer;
 		this.spanInjector = spanInjector;
-		this.keysInjector = keysInjector;
 	}
 
 	@Override
@@ -54,17 +50,7 @@ final class TraceFeignRequestInterceptor implements RequestInterceptor {
 		String spanName = getSpanName(template);
 		Span span = getSpan(spanName);
 		this.spanInjector.inject(span, template);
-		addRequestTags(template);
 		span.logEvent(Span.CLIENT_SEND);
-	}
-
-	/**
-	 * Adds HTTP tags to the client side span
-	 */
-	protected void addRequestTags(RequestTemplate requestTemplate) {
-		URI uri = URI.create(requestTemplate.url());
-		this.keysInjector.addRequestTags(uri.toString(), uri.getHost(), uri.getPath(),
-				requestTemplate.method(), requestTemplate.headers());
 	}
 
 	protected String getSpanName(RequestTemplate template) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignRequestInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignRequestInterceptor.java
@@ -17,10 +17,14 @@
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
 import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
 
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.util.StringUtils;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
@@ -38,11 +42,14 @@ final class TraceFeignRequestInterceptor implements RequestInterceptor {
 	private final Tracer tracer;
 	private final SpanInjector<RequestTemplate> spanInjector;
 	private final FeignRequestContext feignRequestContext = FeignRequestContext.getInstance();
+	private final TraceKeys traceKeys;
 
 	TraceFeignRequestInterceptor(Tracer tracer,
-			SpanInjector<RequestTemplate> spanInjector) {
+								SpanInjector<RequestTemplate> spanInjector,
+								TraceKeys traceKeys) {
 		this.tracer = tracer;
 		this.spanInjector = spanInjector;
+		this.traceKeys = traceKeys;
 	}
 
 	@Override
@@ -50,7 +57,29 @@ final class TraceFeignRequestInterceptor implements RequestInterceptor {
 		String spanName = getSpanName(template);
 		Span span = getSpan(spanName);
 		this.spanInjector.inject(span, template);
+		addRequestTags(template);
 		span.logEvent(Span.CLIENT_SEND);
+	}
+
+	/**
+	 * Adds HTTP tags to the client side span
+	 */
+	protected void addRequestTags(RequestTemplate requestTemplate) {
+		URI uri = URI.create(requestTemplate.url());
+		this.tracer.addTag(this.traceKeys.getHttp().getUrl(), uri.toString());
+		this.tracer.addTag(this.traceKeys.getHttp().getHost(), uri.getHost());
+		this.tracer.addTag(this.traceKeys.getHttp().getPath(), uri.getPath());
+		this.tracer.addTag(this.traceKeys.getHttp().getMethod(), requestTemplate.method());
+		for (String name : this.traceKeys.getHttp().getHeaders()) {
+			Map<String, Collection<String>> values = requestTemplate.headers();
+			for (Map.Entry<String, Collection<String>> entry : values.entrySet()) {
+				String key = this.traceKeys.getHttp().getPrefix() + name.toLowerCase();
+				Collection<String> list = entry.getValue();
+				String value = list.size() == 1 ? list.iterator().next()
+						: StringUtils.collectionToDelimitedString(list, ",", "'", "'");
+				this.tracer.addTag(key, value);
+			}
+		}
 	}
 
 	protected String getSpanName(RequestTemplate template) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SpanAssert.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SpanAssert.java
@@ -88,12 +88,7 @@ public class SpanAssert extends AbstractAssert<SpanAssert, Span> {
 
 	public SpanAssert hasATag(String tagKey, String tagValue) {
 		isNotNull();
-		if (!this.actual.tags().containsKey(tagKey)) {
-			String message = String.format("Expected span to have the tag with key <%s>. "
-					+ "Found tags are <%s>", tagKey, this.actual.tags());
-			log.error(message);
-			failWithMessage(message);
-		}
+		assertThatTagIsPresent(tagKey);
 		String foundTagValue = this.actual.tags().get(tagKey);
 		if (!foundTagValue.equals(tagValue)) {
 			String message = String.format("Expected span to have the tag with key <%s> and value <%s>. "
@@ -102,6 +97,28 @@ public class SpanAssert extends AbstractAssert<SpanAssert, Span> {
 			failWithMessage(message);
 		}
 		return this;
+	}
+
+	public SpanAssert matchesATag(String tagKey, String tagRegex) {
+		isNotNull();
+		assertThatTagIsPresent(tagKey);
+		String foundTagValue = this.actual.tags().get(tagKey);
+		if (!foundTagValue.matches(tagRegex)) {
+			String message = String.format("Expected span to have the tag with key <%s> and match a regex <%s>. "
+					+ "Found value for that tag is <%s>", tagKey, tagRegex, foundTagValue);
+			log.error(message);
+			failWithMessage(message);
+		}
+		return this;
+	}
+
+	private void assertThatTagIsPresent(String tagKey) {
+		if (!this.actual.tags().containsKey(tagKey)) {
+			String message = String.format("Expected span to have the tag with key <%s>. "
+					+ "Found tags are <%s>", tagKey, this.actual.tags());
+			log.error(message);
+			failWithMessage(message);
+		}
 	}
 
 	public SpanAssert hasLoggedAnEvent(String event) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.messaging.TraceChannelInterceptorTests.App;
@@ -193,6 +194,11 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 		@Bean
 		public MessagingTemplate messagingTemplate() {
 			return new MessagingTemplate(channel());
+		}
+
+		@Bean
+		Sampler alwaysSampler() {
+			return new AlwaysSampler();
 		}
 
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.messaging.TraceContextPropagationChannelInterceptorTests.App;
@@ -98,5 +99,9 @@ public class TraceContextPropagationChannelInterceptorTests {
 			return new QueueChannel();
 		}
 
+		@Bean
+		Sampler testSampler() {
+			return new AlwaysSampler();
+		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/websocket/TraceWebSocketAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/websocket/TraceWebSocketAutoConfigurationTest.java
@@ -16,14 +16,15 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging.websocket;
 
-import static org.assertj.core.api.BDDAssertions.then;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.instrument.messaging.TraceChannelInterceptor;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -31,6 +32,8 @@ import org.springframework.web.socket.config.annotation.AbstractWebSocketMessage
 import org.springframework.web.socket.config.annotation.DelegatingWebSocketMessageBrokerConfiguration;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+
+import static org.assertj.core.api.BDDAssertions.then;
 
 /**
  * @author Marcin Grzejszczak
@@ -66,6 +69,10 @@ public class TraceWebSocketAutoConfigurationTest {
 		@Override
 		public void registerStompEndpoints(StompEndpointRegistry registry) {
 			registry.addEndpoint("/hello").withSockJS();
+		}
+
+		@Bean Sampler testSampler() {
+			return new AlwaysSampler();
 		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectIntegrationTests.java
@@ -1,12 +1,5 @@
 package org.springframework.cloud.sleuth.instrument.web;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
@@ -16,8 +9,10 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.instrument.DefaultTestAutoConfiguration;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
@@ -36,6 +31,13 @@ import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.request.async.WebAsyncTask;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringApplicationConfiguration(classes = {
 		RestTemplateTraceAspectIntegrationTests.Config.class })
@@ -118,6 +120,11 @@ public class RestTemplateTraceAspectIntegrationTests {
 		@Bean
 		public RestTemplate restTemplate() {
 			return new RestTemplate();
+		}
+
+		@Bean
+		Sampler alwaysSampler() {
+			return new AlwaysSampler();
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterAlwaysSamplerIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterAlwaysSamplerIntegrationTests.java
@@ -59,7 +59,8 @@ public class TraceFilterAlwaysSamplerIntegrationTests extends AbstractMvcIntegra
 	@Override
 	protected void configureMockMvcBuilder(DefaultMockMvcBuilder mockMvcBuilder) {
 		mockMvcBuilder.addFilters(new TraceFilter(this.tracer, this.traceKeys,
-				new NoOpSpanReporter(), this.spanExtractor, this.spanInjector));
+				new NoOpSpanReporter(), this.spanExtractor, this.spanInjector,
+				this.httpTraceKeysInjector));
 	}
 
 	private MvcResult whenSentPingWithTraceIdAndNotSampling(Long traceId)

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterCustomExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterCustomExtractorTests.java
@@ -16,17 +16,13 @@
 
 package org.springframework.cloud.sleuth.instrument.web;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
-
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,9 +31,11 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanExtractor;
 import org.springframework.cloud.sleuth.SpanInjector;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
@@ -53,19 +51,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(TraceFilterCustomExtractorTests.Config.class)
 @WebIntegrationTest(randomPort = true)
 @DirtiesContext
 public class TraceFilterCustomExtractorTests {
-	@Autowired
-	Random random;
-	@Autowired
-	RestTemplate restTemplate;
-	@Autowired
-	Config config;
-	@Autowired
-	CustomRestController customRestController;
+	@Autowired Random random;
+	@Autowired RestTemplate restTemplate;
+	@Autowired Config config;
+	@Autowired CustomRestController customRestController;
 
 	@Test
 	@SuppressWarnings("unchecked")
@@ -125,6 +122,11 @@ public class TraceFilterCustomExtractorTests {
 		@Bean
 		CustomRestController customRestController() {
 			return new CustomRestController();
+		}
+
+		@Bean
+		Sampler alwaysSampler() {
+			return new AlwaysSampler();
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
@@ -16,10 +16,12 @@ import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.DefaultTestAutoConfiguration;
 import org.springframework.cloud.sleuth.instrument.web.common.AbstractMvcIntegrationTest;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
@@ -164,6 +166,11 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 				managementServerProperties.setContextPath("/additionalContextPath");
 				return managementServerProperties;
 			}
+		}
+
+		@Bean
+		Sampler alwaysSampler() {
+			return new AlwaysSampler();
 		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
@@ -50,6 +50,7 @@ public class TraceFilterMockChainIntegrationTests {
 			new Random(), new DefaultSpanNamer(),
 			new NoOpSpanLogger(), new NoOpSpanReporter());
 	private TraceKeys traceKeys = new TraceKeys();
+	private HttpTraceKeysInjector keysInjector = new HttpTraceKeysInjector(this.tracer, this.traceKeys);
 
 	private MockHttpServletRequest request;
 	private MockHttpServletResponse response;
@@ -73,7 +74,7 @@ public class TraceFilterMockChainIntegrationTests {
 	public void startsNewTrace() throws Exception {
 		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, new NoOpSpanReporter(),
 				new HttpServletRequestExtractor(new Random(), Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN)),
-				new HttpServletResponseInjector());
+				new HttpServletResponseInjector(), keysInjector);
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
 	}
@@ -85,7 +86,7 @@ public class TraceFilterMockChainIntegrationTests {
 				.header(Span.TRACE_ID_NAME, generator.nextLong()).buildRequest(new MockServletContext());
 		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, new NoOpSpanReporter(),
 				new HttpServletRequestExtractor(new Random(), Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN)),
-				new HttpServletResponseInjector());
+				new HttpServletResponseInjector(), keysInjector);
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.assertions.SleuthAssertions;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
@@ -60,7 +61,8 @@ public class TraceRestTemplateInterceptorIntegrationTests {
 		this.tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
 				new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter());
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
-				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector(), new TraceKeys())));
+				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector(),
+						new HttpTraceKeysInjector(this.tracer, new TraceKeys()))));
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
 import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.assertions.SleuthAssertions;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
@@ -59,7 +60,7 @@ public class TraceRestTemplateInterceptorIntegrationTests {
 		this.tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
 				new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter());
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
-				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector())));
+				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector(), new TraceKeys())));
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 
@@ -68,7 +69,7 @@ public class TraceRestTemplateInterceptorIntegrationTests {
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 
-	// issue #198
+	// Issue #198
 	@Test
 	public void spanRemovedFromThreadUponException() throws IOException {
 		this.mockWebServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
@@ -69,7 +70,8 @@ public class TraceRestTemplateInterceptorTests {
 		this.tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
 				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator);
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
-				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector(), new TraceKeys())));
+				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector(),
+						new HttpTraceKeysInjector(this.tracer, new TraceKeys()))));
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.instrument.web.client;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -26,12 +27,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
-import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
+import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.test.web.client.MockMvcClientHttpRequestFactory;
@@ -60,12 +62,14 @@ public class TraceRestTemplateInterceptorTests {
 
 	private DefaultTracer tracer;
 
+	private ArrayListSpanAccumulator spanAccumulator = new ArrayListSpanAccumulator();
+
 	@Before
 	public void setup() {
 		this.tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter());
+				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator);
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
-				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector())));
+				new TraceRestTemplateInterceptor(this.tracer, new HttpRequestInjector(), new TraceKeys())));
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 
@@ -93,6 +97,21 @@ public class TraceRestTemplateInterceptorTests {
 		then(Span.hexToId(headers.get(Span.TRACE_ID_NAME))).isEqualTo(1L);
 		then(Span.hexToId(headers.get(Span.SPAN_ID_NAME))).isNotEqualTo(2L);
 		then(Span.hexToId(headers.get(Span.PARENT_ID_NAME))).isEqualTo(2L);
+	}
+
+	// Issue #290
+	@Test
+	public void requestHeadersAddedWhenTracing() {
+		this.tracer.continueSpan(Span.builder().traceId(1L).spanId(2L).parent(3L).build());
+
+		this.template.getForEntity("/foo?a=b", Map.class);
+
+		List<Span> spans = spanAccumulator.getSpans();
+		then(spans).isNotEmpty();
+		then(spans.get(0))
+				.hasATag("http.url", "/foo?a=b")
+				.hasATag("http.path", "/foo")
+				.hasATag("http.method", "GET");
 	}
 
 	@Test
@@ -143,6 +162,10 @@ public class TraceRestTemplateInterceptorTests {
 			addHeaders(map, headers, Span.SPAN_ID_NAME, Span.TRACE_ID_NAME,
 					Span.PARENT_ID_NAME, Span.SAMPLED_NAME);
 			return map;
+		}
+
+		@RequestMapping("/foo")
+		public void foo() {
 		}
 
 		@RequestMapping("/exception")

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientDiscoveryExceptionTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientDiscoveryExceptionTests.java
@@ -16,10 +16,6 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
 import java.io.IOException;
 import java.util.Map;
 
@@ -37,9 +33,11 @@ import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.assertions.SleuthAssertions;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +49,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.client.RestTemplate;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = {
 		WebClientDiscoveryExceptionTests.TestConfiguration.class })
@@ -59,13 +61,9 @@ import org.springframework.web.client.RestTemplate;
 @DirtiesContext
 public class WebClientDiscoveryExceptionTests {
 
-	@Autowired
-	TestFeignInterfaceWithException testFeignInterfaceWithException;
-	@Autowired
-	@LoadBalanced
-	RestTemplate template;
-	@Autowired
-	Tracer tracer;
+	@Autowired TestFeignInterfaceWithException testFeignInterfaceWithException;
+	@Autowired @LoadBalanced RestTemplate template;
+	@Autowired Tracer tracer;
 
 	@Before
 	public void open() {
@@ -127,6 +125,11 @@ public class WebClientDiscoveryExceptionTests {
 		@Bean
 		public RestTemplate restTemplate() {
 			return new RestTemplate();
+		}
+
+		@Bean
+		Sampler alwaysSampler() {
+			return new AlwaysSampler();
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientExceptionTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientExceptionTests.java
@@ -16,14 +16,13 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
-import static junitparams.JUnitParamsRunner.$;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+
+import com.netflix.loadbalancer.BaseLoadBalancer;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -40,9 +39,11 @@ import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.assertions.SleuthAssertions;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.context.annotation.Bean;
@@ -54,12 +55,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.client.RestTemplate;
 
-import com.netflix.loadbalancer.BaseLoadBalancer;
-import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.Server;
-
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+
+import static junitparams.JUnitParamsRunner.$;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 @SpringApplicationConfiguration(classes = {
@@ -73,13 +75,9 @@ public class WebClientExceptionTests {
 	@Rule
 	public final SpringMethodRule springMethodRule = new SpringMethodRule();
 
-	@Autowired
-	TestFeignInterfaceWithException testFeignInterfaceWithException;
-	@Autowired
-	@LoadBalanced
-	RestTemplate template;
-	@Autowired
-	Tracer tracer;
+	@Autowired TestFeignInterfaceWithException testFeignInterfaceWithException;
+	@Autowired @LoadBalanced RestTemplate template;
+	@Autowired Tracer tracer;
 
 	@Before
 	public void open() {
@@ -138,6 +136,11 @@ public class WebClientExceptionTests {
 		@Bean
 		public RestTemplate restTemplate() {
 			return new RestTemplate();
+		}
+
+		@Bean
+		Sampler alwaysSampler() {
+			return new AlwaysSampler();
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignClientServerErrorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignClientServerErrorTests.java
@@ -16,12 +16,15 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import com.netflix.loadbalancer.BaseLoadBalancer;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
-import feign.codec.Decoder;
-import feign.codec.ErrorDecoder;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,9 +40,11 @@ import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
+import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -53,9 +58,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import feign.codec.Decoder;
+import feign.codec.ErrorDecoder;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -167,6 +171,10 @@ public class FeignClientServerErrorTests {
 		@Bean
 		public RestTemplate restTemplate() {
 			return new RestTemplate();
+		}
+
+		@Bean Sampler testSampler() {
+			return new AlwaysSampler();
 		}
 
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/AbstractMvcIntegrationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/AbstractMvcIntegrationTest.java
@@ -9,6 +9,7 @@ import org.springframework.cloud.sleuth.SpanExtractor;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -36,6 +37,7 @@ public abstract class AbstractMvcIntegrationTest {
 	@Autowired protected TraceKeys traceKeys;
 	@Autowired protected SpanExtractor<HttpServletRequest> spanExtractor;
 	@Autowired protected SpanInjector<HttpServletResponse> spanInjector;
+	@Autowired protected HttpTraceKeysInjector httpTraceKeysInjector;
 
 	@Before
 	public void setup() {


### PR DESCRIPTION
This PR introduces additional tags on the HTTP client side. Before sending a request we're tagging the client side with HTTP Trace Keys so that if the other side is not working / not instrumented (e.g. call to an external service) then the debugging information remains.

Feign Client Side:
<img width="885" alt="feign" src="https://cloud.githubusercontent.com/assets/3297437/15646931/cdaa0c3a-2660-11e6-8b7c-eeb4b2c15467.png">

Rest Template Client Side:
<img width="897" alt="client_side" src="https://cloud.githubusercontent.com/assets/3297437/15646941/ddc96412-2660-11e6-9f7a-28c8a3de5a56.png">

Server Side:
<img width="885" alt="server_side" src="https://cloud.githubusercontent.com/assets/3297437/15646946/e4e456bc-2660-11e6-8925-61326a388938.png">

Related to #290 
CC @dsyer @adriancole 