### PR TITLE
Fixed the issues with Zuul exception handling

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -27,12 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Class for gathering and reporting statistics about a block of execution.
@@ -377,7 +377,11 @@ public class Span {
 	@Override
 	public String toString() {
 		return "[Trace: " + idToHex(this.traceId) + ", Span: " + idToHex(this.spanId)
-				+ ", exportable=" + this.exportable + "]";
+				+ ", Parent: " + getParentIdIfPresent() + ", exportable=" + this.exportable + "]";
+	}
+
+	private String getParentIdIfPresent() {
+		return this.getParents().isEmpty() ? "null" : idToHex(this.getParents().get(0));
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersHook.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersHook.java
@@ -56,12 +56,14 @@ class SleuthRxJavaSchedulersHook extends RxJavaSchedulersHook {
 
 	private void logCurrentStateOfRxJavaPlugins(RxJavaErrorHandler errorHandler,
 		RxJavaObservableExecutionHook observableExecutionHook) {
-		log.debug("Current RxJava plugins configuration is ["
-			+ "schedulersHook [" + this.delegate + "],"
-			+ "errorHandler [" + errorHandler + "],"
-			+ "observableExecutionHook [" + observableExecutionHook + "],"
-			+ "]");
-		log.debug("Registering Sleuth RxJava Schedulers Hook.");
+		if (log.isDebugEnabled()) {
+			log.debug("Current RxJava plugins configuration is ["
+					+ "schedulersHook [" + this.delegate + "],"
+					+ "errorHandler [" + errorHandler + "],"
+					+ "observableExecutionHook [" + observableExecutionHook + "],"
+					+ "]");
+			log.debug("Registering Sleuth RxJava Schedulers Hook.");
+		}
 	}
 
 	@Override
@@ -102,9 +104,11 @@ class SleuthRxJavaSchedulersHook extends RxJavaSchedulersHook {
 			for (String threadToIgnore : this.threadsToIgnore) {
 				String threadName = Thread.currentThread().getName();
 				if (threadName.matches(threadToIgnore)) {
-					log.trace(String.format(
-							"Thread with name [%s] matches the regex [%s]. A span will not be created for this Thread.",
-							threadName, threadToIgnore));
+					if (log.isTraceEnabled()) {
+						log.trace(String.format(
+								"Thread with name [%s] matches the regex [%s]. A span will not be created for this Thread.",
+								threadName, threadToIgnore));
+					}
 					this.actual.call();
 					return;
 				}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
@@ -1,5 +1,6 @@
 package org.springframework.cloud.sleuth.instrument.web;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
 
@@ -43,6 +44,13 @@ public class HttpTraceKeysInjector {
 		tagSpan(span, this.traceKeys.getHttp().getHost(), host);
 		tagSpan(span, this.traceKeys.getHttp().getPath(), path);
 		tagSpan(span, this.traceKeys.getHttp().getMethod(), method);
+	}
+
+	/**
+	 * Adds tags from the HTTP request to the given Span
+	 */
+	public void addRequestTags(Span span, URI uri, String method) {
+		addRequestTags(span, uri.toString(), uri.getHost(), uri.getPath(), method);
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -119,7 +119,7 @@ public class TraceFilter extends GenericFilterBean {
 	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
 			FilterChain filterChain) throws IOException, ServletException {
 		if (!(servletRequest instanceof HttpServletRequest) || !(servletResponse instanceof HttpServletResponse)) {
-			throw new ServletException("OncePerRequestFilter just supports HTTP requests");
+			throw new ServletException("Filter just supports HTTP requests");
 		}
 		HttpServletRequest request = (HttpServletRequest) servletRequest;
 		HttpServletResponse response = (HttpServletResponse) servletResponse;
@@ -184,7 +184,7 @@ public class TraceFilter extends GenericFilterBean {
 					this.tracer.close(spanFromRequest);
 				} else if (errorAlreadyHandled(request)) {
 					log.debug("Won't detach the span since error has already been handled");
-				} else if (!errorAlreadyHandled(request)) {
+				} else {
 					log.debug("Detaching the span " + spanFromRequest + " since the response was unsuccessful");
 					this.tracer.detach(spanFromRequest);
 				}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -115,7 +115,8 @@ public class TraceFilter extends GenericFilterBean {
 		this.httpTraceKeysInjector = httpTraceKeysInjector;
 	}
 
-	@Override public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
 			FilterChain filterChain) throws IOException, ServletException {
 		if (!(servletRequest instanceof HttpServletRequest) || !(servletResponse instanceof HttpServletResponse)) {
 			throw new ServletException("OncePerRequestFilter just supports HTTP requests");

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
@@ -59,7 +59,9 @@ abstract class AbstractTraceHttpRequestInterceptor {
 		this.spanInjector.inject(newSpan, request);
 		addRequestTags(request);
 		newSpan.logEvent(Span.CLIENT_SEND);
-		log.debug("Starting new client span [" + newSpan + "]");
+		if (log.isTraceEnabled()) {
+			log.trace("Starting new client span [" + newSpan + "]");
+		}
 	}
 
 	private String uriScheme(URI uri) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
@@ -16,8 +16,11 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.Tracer;
@@ -31,6 +34,8 @@ import org.springframework.http.HttpRequest;
  * @since 1.0.0
  */
 abstract class AbstractTraceHttpRequestInterceptor {
+
+	protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	protected final Tracer tracer;
 	protected final SpanInjector<HttpRequest> spanInjector;
@@ -54,6 +59,7 @@ abstract class AbstractTraceHttpRequestInterceptor {
 		this.spanInjector.inject(newSpan, request);
 		addRequestTags(request);
 		newSpan.logEvent(Span.CLIENT_SEND);
+		log.debug("Starting new client span [" + newSpan + "]");
 	}
 
 	private String uriScheme(URI uri) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -56,7 +56,9 @@ public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterc
 		try {
 			return new TraceHttpResponse(this, execution.execute(request, body));
 		} catch (Exception e) {
-			log.debug("Exception occurred while trying to execute the request", e);
+			if (log.isTraceEnabled()) {
+				log.trace("Exception occurred while trying to execute the request", e);
+			}
 			this.tracer.close(currentSpan());
 			throw e;
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -56,6 +56,7 @@ public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterc
 		try {
 			return new TraceHttpResponse(this, execution.execute(request, body));
 		} catch (Exception e) {
+			log.debug("Exception occurred while trying to execute the request", e);
 			this.tracer.close(currentSpan());
 			throw e;
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
@@ -19,15 +19,13 @@ package org.springframework.cloud.sleuth.instrument.zuul;
 import java.lang.invoke.MethodHandles;
 
 import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
-import org.springframework.http.HttpStatus;
 
-/**
+/**8
  * A post request {@link ZuulFilter} that publishes an event upon start of the filtering
  *
  * @author Dave Syer
@@ -36,7 +34,6 @@ import org.springframework.http.HttpStatus;
 public class TracePostZuulFilter extends ZuulFilter {
 
 	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
-	private static final String ERROR_STATUS_CODE = "error.status_code";
 
 	private final Tracer tracer;
 
@@ -52,23 +49,10 @@ public class TracePostZuulFilter extends ZuulFilter {
 	@Override
 	public Object run() {
 		// TODO: the client sent event should come from the client not the filter!
-		setErrorStatusCodeIfMissing();
 		getCurrentSpan().logEvent(Span.CLIENT_RECV);
 		log.debug("Closing current client span " + getCurrentSpan() + "");
 		this.tracer.close(getCurrentSpan());
 		return null;
-	}
-
-	// TODO: Remove this once new version of Netflix gets released
-	// we want to enforce the SendErrorFilter to process the error
-	private void setErrorStatusCodeIfMissing() {
-		RequestContext ctx = RequestContext.getCurrentContext();
-		HttpStatus httpStatus = HttpStatus.valueOf(ctx.getResponseStatusCode());
-		if (httpStatus.is4xxClientError() || httpStatus.is5xxServerError()) {
-			if (!ctx.containsKey(ERROR_STATUS_CODE)) {
-				ctx.set(ERROR_STATUS_CODE, ctx.getResponseStatusCode());
-			}
-		}
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
@@ -16,10 +16,14 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import org.springframework.cloud.sleuth.Span;
-import org.springframework.cloud.sleuth.Tracer;
+import java.lang.invoke.MethodHandles;
 
 import com.netflix.zuul.ZuulFilter;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.Tracer;
 
 /**
  * A post request {@link ZuulFilter} that publishes an event upon start of the filtering
@@ -28,6 +32,8 @@ import com.netflix.zuul.ZuulFilter;
  * @since 1.0.0
  */
 public class TracePostZuulFilter extends ZuulFilter {
+
+	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	private final Tracer tracer;
 
@@ -45,6 +51,7 @@ public class TracePostZuulFilter extends ZuulFilter {
 		// TODO: the client sent event should come from the client not the filter!
 		getCurrentSpan().logEvent(Span.CLIENT_RECV);
 		this.tracer.close(getCurrentSpan());
+		TracePreZuulFilter.logSpan(getCurrentSpan());
 		return null;
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
@@ -50,7 +50,9 @@ public class TracePostZuulFilter extends ZuulFilter {
 	public Object run() {
 		// TODO: the client sent event should come from the client not the filter!
 		getCurrentSpan().logEvent(Span.CLIENT_RECV);
-		log.debug("Closing current client span " + getCurrentSpan() + "");
+		if (log.isTraceEnabled()) {
+			log.trace("Closing current client span " + getCurrentSpan() + "");
+		}
 		this.tracer.close(getCurrentSpan());
 		return null;
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
@@ -59,6 +59,7 @@ public class TracePostZuulFilter extends ZuulFilter {
 		return null;
 	}
 
+	// TODO: Remove this once new version of Netflix gets released
 	// we want to enforce the SendErrorFilter to process the error
 	private void setErrorStatusCodeIfMissing() {
 		RequestContext ctx = RequestContext.getCurrentContext();

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
@@ -19,11 +19,13 @@ package org.springframework.cloud.sleuth.instrument.zuul;
 import java.lang.invoke.MethodHandles;
 
 import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.http.HttpStatus;
 
 /**
  * A post request {@link ZuulFilter} that publishes an event upon start of the filtering
@@ -34,6 +36,7 @@ import org.springframework.cloud.sleuth.Tracer;
 public class TracePostZuulFilter extends ZuulFilter {
 
 	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+	private static final String ERROR_STATUS_CODE = "error.status_code";
 
 	private final Tracer tracer;
 
@@ -49,10 +52,22 @@ public class TracePostZuulFilter extends ZuulFilter {
 	@Override
 	public Object run() {
 		// TODO: the client sent event should come from the client not the filter!
+		setErrorStatusCodeIfMissing();
 		getCurrentSpan().logEvent(Span.CLIENT_RECV);
+		log.debug("Closing current client span " + getCurrentSpan() + "");
 		this.tracer.close(getCurrentSpan());
-		TracePreZuulFilter.logSpan(getCurrentSpan());
 		return null;
+	}
+
+	// we want to enforce the SendErrorFilter to process the error
+	private void setErrorStatusCodeIfMissing() {
+		RequestContext ctx = RequestContext.getCurrentContext();
+		HttpStatus httpStatus = HttpStatus.valueOf(ctx.getResponseStatusCode());
+		if (httpStatus.is4xxClientError() || httpStatus.is5xxServerError()) {
+			if (!ctx.containsKey(ERROR_STATUS_CODE)) {
+				ctx.set(ERROR_STATUS_CODE, ctx.getResponseStatusCode());
+			}
+		}
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
@@ -65,16 +65,24 @@ public class TracePreZuulFilter extends ZuulFilter {
 	public ZuulFilterResult runFilter() {
 		RequestContext ctx = RequestContext.getCurrentContext();
 		Span span = getCurrentSpan();
-		log.debug("Current span is " + span + "");
+		if (log.isTraceEnabled()) {
+			log.trace("Current span is " + span + "");
+		}
 		Span newSpan = this.tracer.createSpan(span.getName(), span);
 		newSpan.tag(Span.SPAN_LOCAL_COMPONENT_TAG_NAME, ZUUL_COMPONENT);
 		this.spanInjector.inject(newSpan, ctx);
-		log.debug("New Zuul Span is " + newSpan + "");
+		if (log.isTraceEnabled()) {
+			log.trace("New Zuul Span is " + newSpan + "");
+		}
 		ZuulFilterResult result = super.runFilter();
-		log.debug("Result of Zuul filter is [" + result.getStatus() + "]");
+		if (log.isTraceEnabled()) {
+			log.trace("Result of Zuul filter is [" + result.getStatus() + "]");
+		}
 		if (ExecutionStatus.SUCCESS != result.getStatus()) {
-			log.debug("The result of Zuul filter execution was not successful thus "
-					+ "will close the current span " + newSpan);
+			if (log.isTraceEnabled()) {
+				log.trace("The result of Zuul filter execution was not successful thus "
+						+ "will close the current span " + newSpan);
+			}
 			this.tracer.close(newSpan);
 		}
 		return result;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
@@ -101,7 +101,9 @@ public class TraceRestClientRibbonCommandFactory extends RestClientRibbonCommand
 			this.spanInjector.inject(span, requestBuilder);
 			this.httpTraceKeysInjector.addRequestTags(span, getUri(), getVerb().verb());
 			span.logEvent(Span.CLIENT_SEND);
-			log.debug("Span is " + span + "");
+			if (log.isTraceEnabled()) {
+				log.trace("Span is " + span);
+			}
 		}
 
 		private Span getCurrentSpan() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
@@ -101,7 +101,7 @@ public class TraceRestClientRibbonCommandFactory extends RestClientRibbonCommand
 			this.spanInjector.inject(span, requestBuilder);
 			this.httpTraceKeysInjector.addRequestTags(span, getUri(), getVerb().verb());
 			span.logEvent(Span.CLIENT_SEND);
-			TracePreZuulFilter.logSpan(span);
+			log.debug("Span is " + span + "");
 		}
 
 		private Span getCurrentSpan() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactory.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.sleuth.instrument.zuul;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 
+import com.netflix.client.http.HttpRequest;
+import com.netflix.niws.client.http.RestClient;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
@@ -28,10 +31,8 @@ import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.util.MultiValueMap;
-
-import com.netflix.client.http.HttpRequest;
-import com.netflix.niws.client.http.RestClient;
 
 /**
  * Propagates traces downstream via http headers that contain trace metadata.
@@ -45,12 +46,15 @@ public class TraceRestClientRibbonCommandFactory extends RestClientRibbonCommand
 
 	private final Tracer tracer;
 	private final SpanInjector<HttpRequest.Builder> spanInjector;
+	private final HttpTraceKeysInjector httpTraceKeysInjector;
 
 	public TraceRestClientRibbonCommandFactory(SpringClientFactory clientFactory,
-			Tracer tracer, SpanInjector<HttpRequest.Builder> spanInjector) {
+			Tracer tracer, SpanInjector<HttpRequest.Builder> spanInjector,
+			HttpTraceKeysInjector httpTraceKeysInjector) {
 		super(clientFactory);
 		this.tracer = tracer;
 		this.spanInjector = spanInjector;
+		this.httpTraceKeysInjector = httpTraceKeysInjector;
 	}
 
 	@Override
@@ -62,7 +66,7 @@ public class TraceRestClientRibbonCommandFactory extends RestClientRibbonCommand
 			return new TraceRestClientRibbonCommand(context.getServiceId(), restClient,
 					getVerb(context.getVerb()), context.getUri(), context.getRetryable(),
 					context.getHeaders(), context.getParams(), context.getRequestEntity(),
-					this.tracer, this.spanInjector);
+					this.tracer, this.spanInjector, this.httpTraceKeysInjector);
 		}
 		catch (URISyntaxException e) {
 			log.error("Exception occurred while trying to create the TraceRestClientRibbonCommand", e);
@@ -74,25 +78,30 @@ public class TraceRestClientRibbonCommandFactory extends RestClientRibbonCommand
 
 		private final Tracer tracer;
 		private final SpanInjector<HttpRequest.Builder> spanInjector;
+		private final HttpTraceKeysInjector httpTraceKeysInjector;
 
 		@SuppressWarnings("deprecation")
 		public TraceRestClientRibbonCommand(String commandKey, RestClient restClient,
 				HttpRequest.Verb verb, String uri, Boolean retryable,
 				MultiValueMap<String, String> headers,
 				MultiValueMap<String, String> params, InputStream requestEntity,
-				Tracer tracer, SpanInjector<HttpRequest.Builder> spanInjector)
+				Tracer tracer, SpanInjector<HttpRequest.Builder> spanInjector,
+				HttpTraceKeysInjector httpTraceKeysInjector)
 						throws URISyntaxException {
 			super(commandKey, restClient, verb, uri, retryable, headers, params,
 					requestEntity);
 			this.tracer = tracer;
 			this.spanInjector = spanInjector;
+			this.httpTraceKeysInjector = httpTraceKeysInjector;
 		}
 
 		@Override
 		protected void customizeRequest(HttpRequest.Builder requestBuilder) {
 			Span span = getCurrentSpan();
 			this.spanInjector.inject(span, requestBuilder);
+			this.httpTraceKeysInjector.addRequestTags(span, getUri(), getVerb().verb());
 			span.logEvent(Span.CLIENT_SEND);
+			TracePreZuulFilter.logSpan(span);
 		}
 
 		private Span getCurrentSpan() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -56,8 +57,9 @@ public class TraceZuulAutoConfiguration {
 
 	@Bean
 	public TraceRestClientRibbonCommandFactory traceRestClientRibbonCommandFactory(SpringClientFactory factory,
-			Tracer tracer, SpanInjector<HttpRequest.Builder> spanInjector) {
-		return new TraceRestClientRibbonCommandFactory(factory, tracer, spanInjector);
+			Tracer tracer, SpanInjector<HttpRequest.Builder> spanInjector, HttpTraceKeysInjector httpTraceKeysInjector) {
+		return new TraceRestClientRibbonCommandFactory(factory, tracer, spanInjector,
+				httpTraceKeysInjector);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jSpanLogger.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jSpanLogger.java
@@ -83,7 +83,9 @@ public class Slf4jSpanLogger implements SpanLogger {
 		if (span != null && this.nameSkipPattern.matcher(span.getName()).matches()) {
 			return;
 		}
-		this.log.trace(text, span);
+		if (this.log.isTraceEnabled()) {
+			this.log.trace(text, span);
+		}
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -19,10 +19,10 @@ package org.springframework.cloud.sleuth;
 import java.io.IOException;
 import java.util.Collections;
 
-import org.junit.Test;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -31,7 +31,7 @@ import static org.assertj.core.api.BDDAssertions.then;
  * @author Rob Winch
  * @author Spencer Gibb
  */
-public class SpanTest {
+public class SpanTests {
 
 	@Test
 	public void should_convert_long_to_hex_string() throws Exception {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpans.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpans.java
@@ -1,0 +1,17 @@
+package org.springframework.cloud.sleuth.assertions;
+
+import java.util.List;
+
+import org.springframework.cloud.sleuth.Span;
+
+/**
+ * @author Marcin Grzejszczak
+ */
+public class ListOfSpans {
+
+	public final List<Span> spans;
+
+	public ListOfSpans(List<Span> spans) {
+		this.spans = spans;
+	}
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpans.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpans.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.sleuth.assertions;
 
 import java.util.List;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.assertions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.springframework.cloud.sleuth.Span;
+
+public class ListOfSpansAssert extends AbstractAssert<ListOfSpansAssert, ListOfSpans> {
+
+	private static final Log log = LogFactory.getLog(ListOfSpansAssert.class);
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	public ListOfSpansAssert(ListOfSpans actual) {
+		super(actual, ListOfSpansAssert.class);
+	}
+
+	public static ListOfSpansAssert then(ListOfSpans actual) {
+		return new ListOfSpansAssert(actual);
+	}
+
+	public ListOfSpansAssert thereIsOnlyOneServerAndClientSideSpanWhoseParentIdIsEqualTo(long traceId) {
+		isNotNull();
+		printSpans();
+		List<Span> spansWithParentSpanAsRootSpan = this.actual.spans.stream().filter(span -> span.getParents().contains(traceId)).collect(Collectors.toList());
+		Assertions.assertThat(spansWithParentSpanAsRootSpan).hasSize(2).extracting("spanId").containsOnly(spansWithParentSpanAsRootSpan.get(0).getSpanId());
+		return this;
+	}
+
+	public ListOfSpansAssert everyParentIdHasItsCorrespondingSpan() {
+		isNotNull();
+		printSpans();
+		List<Long> parentSpanIds = this.actual.spans.stream().flatMap(span -> span.getParents().stream())
+				.distinct().collect(Collectors.toList());
+		List<Long> spanIds = this.actual.spans.stream()
+				.map(Span::getSpanId).distinct()
+				.collect(Collectors.toList());
+		List<Long> difference = new ArrayList<>(parentSpanIds);
+		difference.removeAll(spanIds);
+		log.info("Difference between parent ids and span ids " +
+				difference.stream().map(span -> "id as long [" + span + "] and as hex [" + Span.idToHex(span) + "]").collect(Collectors.joining("\n")));
+		Assertions.assertThat(spanIds).containsAll(parentSpanIds);
+		return this;
+	}
+
+	private void printSpans() {
+		try {
+			log.info("Stored spans " + this.objectMapper.writeValueAsString(this.actual.spans));
+		}
+		catch (JsonProcessingException e) {
+		}
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SleuthAssertions.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SleuthAssertions.java
@@ -13,4 +13,13 @@ public class SleuthAssertions extends BDDAssertions {
 		return new SpanAssert(actual);
 	}
 
+
+	public static ListOfSpansAssert then(ListOfSpans actual) {
+		return assertThat(actual);
+	}
+
+	public static ListOfSpansAssert assertThat(ListOfSpans actual) {
+		return new ListOfSpansAssert(actual);
+	}
+
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -192,6 +192,22 @@ public class TraceFilterTests {
 	}
 
 	@Test
+	public void doesntDetachASpanIfStatusCodeNotSuccessfulAndRequestWasProcessed() throws Exception {
+		Span span = this.tracer.createSpan("http:foo");
+		this.request.setAttribute(TraceFilter.TRACE_REQUEST_ATTR, span);
+		this.request.setAttribute(TraceFilter.TRACE_ERROR_HANDLED_REQUEST_ATTR, true);
+		this.response.setStatus(404);
+		// It should have been removed from the thread local context so simulate that
+		TestSpanContextHolder.removeCurrentSpan();
+
+		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, this.spanReporter,
+				this.spanExtractor, this.spanInjector, this.httpTraceKeysInjector);
+		filter.doFilter(this.request, this.response, this.filterChain);
+
+		then(TestSpanContextHolder.getCurrentSpan()).isNull();
+	}
+
+	@Test
 	public void continuesSpanFromHeaders() throws Exception {
 		this.request = builder().header(Span.SPAN_ID_NAME, 10L)
 				.header(Span.TRACE_ID_NAME, 20L).buildRequest(new MockServletContext());

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -172,6 +172,23 @@ public class TraceFilterTests {
 		filter.doFilter(this.request, this.response, this.filterChain);
 
 		then(TestSpanContextHolder.getCurrentSpan()).isNull();
+		then(this.request.getAttribute(TraceFilter.TRACE_ERROR_HANDLED_REQUEST_ATTR)).isNull();
+	}
+
+	@Test
+	public void closesSpanInRequestAttrIfStatusCodeNotSuccessful() throws Exception {
+		Span span = this.tracer.createSpan("http:foo");
+		this.request.setAttribute(TraceFilter.TRACE_REQUEST_ATTR, span);
+		this.response.setStatus(404);
+		// It should have been removed from the thread local context so simulate that
+		TestSpanContextHolder.removeCurrentSpan();
+
+		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, this.spanReporter,
+				this.spanExtractor, this.spanInjector, this.httpTraceKeysInjector);
+		filter.doFilter(this.request, this.response, this.filterChain);
+
+		then(TestSpanContextHolder.getCurrentSpan()).isNull();
+		then(this.request.getAttribute(TraceFilter.TRACE_ERROR_HANDLED_REQUEST_ATTR)).isNotNull();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientTests.java
@@ -58,7 +58,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactoryTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceRestClientRibbonCommandFactoryTest.java
@@ -16,10 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import com.netflix.client.http.HttpRequest;
+import com.netflix.niws.client.http.RestClient;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -32,9 +30,12 @@ import org.springframework.cloud.netflix.zuul.filters.route.RibbonCommandContext
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 
-import com.netflix.client.http.HttpRequest;
-import com.netflix.niws.client.http.RestClient;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 
 /**
  * @author Marcin Grzejszczak
@@ -42,18 +43,18 @@ import com.netflix.niws.client.http.RestClient;
 @RunWith(MockitoJUnitRunner.class)
 public class TraceRestClientRibbonCommandFactoryTest {
 
-	@Mock
-	Tracer tracer;
-	@Mock
-	SpringClientFactory springClientFactory;
+	@Mock Tracer tracer;
+	@Mock SpringClientFactory springClientFactory;
 	SpanInjector<HttpRequest.Builder> spanInjector = new RequestBuilderContextInjector();
+	@Mock HttpTraceKeysInjector httpTraceKeysInjector;
 	TraceRestClientRibbonCommandFactory traceRestClientRibbonCommandFactory;
 
 	@Before
 	@SuppressWarnings({ "deprecation", "unchecked" })
 	public void setup() {
 		this.traceRestClientRibbonCommandFactory = new TraceRestClientRibbonCommandFactory(
-				this.springClientFactory, this.tracer, this.spanInjector);
+				this.springClientFactory, this.tracer, this.spanInjector,
+				httpTraceKeysInjector);
 		given(this.springClientFactory.getClient(anyString(), any(Class.class)))
 				.willReturn(new RestClient());
 		Span span = Span.builder().name("name").spanId(1L).traceId(2L).parent(3L)

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
@@ -1,0 +1,157 @@
+package org.springframework.cloud.sleuth.instrument.zuul;
+
+import java.io.IOException;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.filters.discovery.DiscoveryClientRouteLocator;
+import org.springframework.cloud.sleuth.Sampler;
+import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.SpanReporter;
+import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.assertions.ListOfSpans;
+import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
+import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = SampleZuulProxyApplication.class)
+@WebAppConfiguration
+@IntegrationTest({ "server.port: 0", "zuul.routes.simple: /simple/**"})
+@DirtiesContext
+public class TraceZuulIntegrationTests {
+
+	@Value("${local.server.port}")
+	private int port;
+	@Autowired Tracer tracer;
+	@Autowired ArrayListSpanAccumulator spanAccumulator;
+	@Autowired RestTemplate restTemplate;
+
+	@Before
+	public void cleanup() {
+		this.spanAccumulator.getSpans().clear();
+	}
+
+	@Test
+	public void should_close_span_when_routing_to_service_via_discovery() {
+		Span span = this.tracer.createSpan("new_span");
+		ResponseEntity<String> result = this.restTemplate.exchange(
+				"http://localhost:" + this.port + "/simple/", HttpMethod.GET,
+				new HttpEntity<>((Void) null), String.class);
+
+		this.tracer.close(span);
+
+		then(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		then(result.getBody()).isEqualTo("Hello world");
+		then(this.tracer.getCurrentSpan()).isNull();
+		then(new ListOfSpans(this.spanAccumulator.getSpans()))
+				.thereIsOnlyOneServerAndClientSideSpanWhoseParentIdIsEqualTo(span.getTraceId());
+	}
+
+	@Test
+	public void should_close_span_when_routing_to_service_via_discovery_to_a_non_existent_url() {
+		Span span = this.tracer.createSpan("new_span");
+		ResponseEntity<String> result = this.restTemplate.exchange(
+				"http://localhost:" + this.port + "/simple/nonExistentUrl", HttpMethod.GET,
+				new HttpEntity<>((Void) null), String.class);
+
+		this.tracer.close(span);
+
+		then(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+		then(this.tracer.getCurrentSpan()).isNull();
+		then(new ListOfSpans(this.spanAccumulator.getSpans()))
+				.thereIsOnlyOneServerAndClientSideSpanWhoseParentIdIsEqualTo(span.getTraceId())
+				.everyParentIdHasItsCorrespondingSpan();
+	}
+}
+
+// Don't use @SpringBootApplication because we don't want to component scan
+@Configuration
+@EnableAutoConfiguration
+@RestController
+@EnableZuulProxy
+@RibbonClient(name = "simple", configuration = SimpleRibbonClientConfiguration.class)
+class SampleZuulProxyApplication {
+
+
+	@RequestMapping("/")
+	public String home() {
+		return "Hello world";
+	}
+
+	@RequestMapping("/exception")
+	public String exception() {
+		throw new RuntimeException();
+	}
+
+	@Bean RouteLocator routeLocator(DiscoveryClient discoveryClient, ZuulProperties zuulProperties) {
+		return new MyRouteLocator("/", discoveryClient, zuulProperties);
+	}
+
+	@Bean SpanReporter testSpanReporter() {
+		return new ArrayListSpanAccumulator();
+	}
+
+	@Bean RestTemplate restTemplate() {
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
+			@Override public void handleError(ClientHttpResponse response)
+					throws IOException {
+
+			}
+		});
+		return restTemplate;
+	}
+
+	@Bean Sampler alwaysSampler() {
+		return new AlwaysSampler();
+	}
+}
+
+class MyRouteLocator extends DiscoveryClientRouteLocator {
+
+	public MyRouteLocator(String servletPath, DiscoveryClient discovery, ZuulProperties properties) {
+		super(servletPath, discovery, properties);
+	}
+}
+
+// Load balancer with fixed server list for "simple" pointing to localhost
+@Configuration
+class SimpleRibbonClientConfiguration {
+
+	@Value("${local.server.port}") private int port;
+
+	@Bean public ServerList<Server> ribbonServerList() {
+		return new StaticServerList<>(new Server("localhost", this.port));
+	}
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
@@ -47,7 +47,7 @@ import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = SampleZuulProxyApplication.class)
 @WebAppConfiguration
-@IntegrationTest({ "server.port: 0", "zuul.routes.simple: /simple/**"})
+@IntegrationTest({ "server.port: 0", "zuul.routes.simple: /simple/**", "hystrix.command.default.execution.isolation.strategy: SEMAPHORE"})
 @DirtiesContext
 public class TraceZuulIntegrationTests {
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
@@ -16,11 +16,13 @@
 
 package org.springframework.cloud.sleuth.log;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.springframework.cloud.sleuth.Span;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
@@ -37,6 +39,11 @@ public class Slf4JSpanLoggerTest {
 	String nameExcludingPattern = "^.*Hystrix.*$";
 	Logger log = Mockito.mock(Logger.class);
 	Slf4jSpanLogger slf4JSpanLogger = new Slf4jSpanLogger(this.nameExcludingPattern, this.log);
+
+	@Before
+	public void setup() {
+		given(log.isTraceEnabled()).willReturn(true);
+	}
 
 	@Test
 	public void should_log_when_start_event_arrived_and_pattern_doesnt_match_span_name() throws Exception {

--- a/spring-cloud-sleuth-core/src/test/resources/application.yml
+++ b/spring-cloud-sleuth-core/src/test/resources/application.yml
@@ -11,4 +11,4 @@ exceptionService.ribbon:
 
 spring.sleuth.scheduled.skipPattern: "^org.*TestBeanWithScheduledMethodToBeIgnored$"
 # comma separated list of matchers
-spring.sleuth.rxjava.schedulers.ignoredthreads: HystixMetricPoller,^MyCustomThread.*$
+spring.sleuth.rxjava.schedulers.ignoredthreads: HystixMetricPoller,^MyCustomThread.*$,^RxComputation.*$

--- a/spring-cloud-sleuth-core/src/test/resources/logback.xml
+++ b/spring-cloud-sleuth-core/src/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 	<include resource="org/springframework/boot/logging/logback/base.xml"/>
-	<logger name="org.springframework.cloud.sleuth" level="DEBUG"/>
+	<logger name="org.springframework.cloud.sleuth" level="TRACE"/>
 	<logger name="org.springframework.boot" level="DEBUG"/>
 	<logger name="org.springframework.web" level="DEBUG"/>
 	<root level="INFO">

--- a/spring-cloud-sleuth-core/src/test/resources/logback.xml
+++ b/spring-cloud-sleuth-core/src/test/resources/logback.xml
@@ -2,6 +2,9 @@
 <configuration>
 	<include resource="org/springframework/boot/logging/logback/base.xml"/>
 	<logger name="org.springframework.cloud.sleuth" level="TRACE"/>
+	<logger name="org.springframework.cloud.sleuth.log" level="DEBUG"/>
+	<logger name="org.springframework.cloud.sleuth.trace" level="DEBUG"/>
+	<logger name="org.springframework.cloud.sleuth.instrument.rxjava" level="DEBUG"/>
 	<logger name="org.springframework.boot" level="DEBUG"/>
 	<logger name="org.springframework.web" level="DEBUG"/>
 	<root level="INFO">

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<spring-cloud-netflix.version>1.1.1.BUILD-SNAPSHOT</spring-cloud-netflix.version>
+		<spring-cloud-netflix.version>1.1.2.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
 		<zipkin.version>1.1.1</zipkin.version>
 	</properties>


### PR DESCRIPTION
- `TraceFilter` no longer is a `OncePerRequestFilter`
- `TraceFilter` processes the request that is executed upon `ERROR` dispatch (the logs will be present there)
- Altered the logic in `TraceFilter` that an already processed request will not be detached (which resulted in an exception)
- Added some debugging to instrumentation
- Added assertion over a list of spans
- Bumped up SC-Netflix to 1.1.2.BUILD-SNAPSHOT
- Added Zuul integration tests
- Added Http keys injection to Zuul client call