### PR TITLE
Throwing exception when tracing is malformed

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -374,7 +374,7 @@ public class Span {
 		try {
 			return new BigInteger(hexString, 16).longValue();
 		} catch (NumberFormatException e) {
-			throw new IllegalArgumentException("Malformed id", e);
+			throw new IllegalArgumentException("Malformed id [" + hexString + "]", e);
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -371,7 +371,11 @@ public class Span {
 	 */
 	public static long hexToId(String hexString) {
 		Assert.hasText(hexString, "Can't convert empty hex string to long");
-		return new BigInteger(hexString, 16).longValue();
+		try {
+			return new BigInteger(hexString, 16).longValue();
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Malformed id", e);
+		}
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractor.java
@@ -16,11 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
-import java.lang.invoke.MethodHandles;
 import java.util.Random;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Span.SpanBuilder;
 import org.springframework.cloud.sleuth.SpanExtractor;
@@ -33,8 +30,6 @@ import org.springframework.messaging.Message;
  * @since 1.0.0
  */
 public class MessagingSpanExtractor implements SpanExtractor<Message<?>> {
-
-	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	private final Random random;
 
@@ -86,11 +81,7 @@ public class MessagingSpanExtractor implements SpanExtractor<Message<?>> {
 			return Span
 					.hexToId(getHeader(carrier, Span.TRACE_ID_NAME));
 		} catch (Exception e) {
-			long id = this.random.nextLong();
-			log.warn("Exception occurred while trying to retrieve the trace "
-					+ "id from headers. Will set id to value ["
-					+ Span.idToHex(id) + "]", e);
-			return id;
+			throw new IllegalStateException("Malformed id", e);
 		}
 	}
 	private void setParentIdIfApplicable(Message<?> carrier, SpanBuilder spanBuilder) {
@@ -100,7 +91,7 @@ public class MessagingSpanExtractor implements SpanExtractor<Message<?>> {
 				spanBuilder.parent(Span.hexToId(parentId));
 			}
 		} catch (Exception e) {
-			log.warn("Exception occurred while trying to set parentId", e);
+			throw new IllegalStateException("Malformed id", e);
 		}
 	}
 
@@ -109,11 +100,7 @@ public class MessagingSpanExtractor implements SpanExtractor<Message<?>> {
 			return Span
 					.hexToId(getHeader(carrier, Span.SPAN_ID_NAME));
 		} catch (Exception e) {
-			long id = this.random.nextLong();
-			log.warn("Exception occurred while trying to retrieve the span "
-					+ "id from headers. Will set id to value ["
-					+ Span.idToHex(id) + "]", e);
-			return id;
+			throw new IllegalStateException("Malformed id", e);
 		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractor.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.sleuth.instrument.web;
 
 import javax.servlet.http.HttpServletRequest;
 import java.lang.invoke.MethodHandles;
-import java.util.Random;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
@@ -42,13 +41,11 @@ class HttpServletRequestExtractor implements SpanExtractor<HttpServletRequest> {
 	private static final String HTTP_COMPONENT = "http";
 
 	private final Pattern skipPattern;
-	private final Random random;
 
 	private UrlPathHelper urlPathHelper = new UrlPathHelper();
 
-	public HttpServletRequestExtractor(Pattern skipPattern, Random random) {
+	public HttpServletRequestExtractor(Pattern skipPattern) {
 		this.skipPattern = skipPattern;
-		this.random = random;
 	}
 
 	@Override
@@ -70,11 +67,7 @@ class HttpServletRequestExtractor implements SpanExtractor<HttpServletRequest> {
 			return Span
 					.hexToId(carrier.getHeader(Span.TRACE_ID_NAME));
 		} catch (Exception e) {
-			long id = this.random.nextLong();
-			log.warn("Exception occurred while trying to retrieve the trace "
-					+ "id from headers. Will set id to value ["
-					+ Span.idToHex(id) + "]", e);
-			return id;
+			throw new IllegalStateException("Malformed id", e);
 		}
 	}
 
@@ -88,11 +81,7 @@ class HttpServletRequestExtractor implements SpanExtractor<HttpServletRequest> {
 			try {
 				return Span.hexToId(spanId);
 			} catch (Exception e) {
-				long id = this.random.nextLong();
-				log.warn("Exception occurred while trying to retrieve the span id "
-						+ "from request headers. Will set id to value ["
-						+ Span.idToHex(id) + "]", e);
-				return id;
+				throw new IllegalStateException("Malformed id", e);
 			}
 		}
 	}
@@ -126,7 +115,7 @@ class HttpServletRequestExtractor implements SpanExtractor<HttpServletRequest> {
 			span.parent(Span
 					.hexToId(carrier.getHeader(Span.PARENT_ID_NAME)));
 		} catch (Exception e) {
-			log.warn("Exception occurred while trying to set parent id", e);
+			throw new IllegalStateException("Malformed id", e);
 		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -154,9 +154,10 @@ public class TraceFilter extends GenericFilterBean {
 		String name = HTTP_COMPONENT + ":" + uri;
 		try {
 			spanFromRequest = createSpan(request, skip, spanFromRequest, name);
-		} catch (IllegalStateException e) {
+		} catch (IllegalArgumentException e) {
 			filterChain.doFilter(request, response);
-			response.sendError(HttpStatus.BAD_REQUEST.value(), "Tracing data is malformed");
+			response.sendError(HttpStatus.BAD_REQUEST.value(),
+					"Exception tracing request [" + e.getMessage() + "]");
 			return;
 		}
 		Throwable exception = null;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -152,7 +152,13 @@ public class TraceFilter extends GenericFilterBean {
 		}
 		addToResponseIfNotPresent(response, Span.SAMPLED_NAME, skip ? Span.SPAN_NOT_SAMPLED : Span.SPAN_SAMPLED);
 		String name = HTTP_COMPONENT + ":" + uri;
-		spanFromRequest = createSpan(request, skip, spanFromRequest, name);
+		try {
+			spanFromRequest = createSpan(request, skip, spanFromRequest, name);
+		} catch (IllegalStateException e) {
+			filterChain.doFilter(request, response);
+			response.sendError(HttpStatus.BAD_REQUEST.value(), "Tracing data is malformed");
+			return;
+		}
 		Throwable exception = null;
 		try {
 			this.spanInjector.inject(spanFromRequest, response);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.sleuth.instrument.web;
 
-import java.util.Random;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
@@ -101,8 +100,8 @@ public class TraceWebAutoConfiguration {
 
 	@Bean
 	public SpanExtractor<HttpServletRequest> httpServletRequestSpanExtractor(
-			SkipPatternProvider skipPatternProvider, Random random) {
-		return new HttpServletRequestExtractor(skipPatternProvider.skipPattern(), random);
+			SkipPatternProvider skipPatternProvider) {
+		return new HttpServletRequestExtractor(skipPatternProvider.skipPattern());
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -109,4 +109,9 @@ public class SpanTests {
 		then(deserialized.tags())
 				.isEqualTo(span.tags());
 	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void should_throw_exception_when_converting_invalid_hex_value() {
+		Span.hexToId("invalid");
+	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
@@ -27,6 +27,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StringUtils;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
@@ -47,10 +48,12 @@ public class MessagingSpanExtractorTests {
 		Message message = MessageBuilder.createMessage("", 
 				headers("invalid", randomId()));
 
-		Span span = this.extractor.joinTrace(message);
-
-		then(span).isNotNull();
-		then(span.getTraceId()).isNotZero();
+		try {
+			this.extractor.joinTrace(message);
+			fail("should throw an exception");
+		} catch (IllegalStateException e) {
+			then(e).hasMessageContaining("Malformed id");
+		}
 	}
 
 	@Test
@@ -58,11 +61,12 @@ public class MessagingSpanExtractorTests {
 		Message message = MessageBuilder.createMessage("",
 				headers(randomId(), "invalid"));
 
-		Span span = this.extractor.joinTrace(message);
-
-		then(span).isNotNull();
-		then(span.getTraceId()).isNotZero();
-		then(span.getSpanId()).isNotZero();
+		try {
+			this.extractor.joinTrace(message);
+			fail("should throw an exception");
+		} catch (IllegalStateException e) {
+			then(e).hasMessageContaining("Malformed id");
+		}
 	}
 
 	@Test
@@ -70,12 +74,12 @@ public class MessagingSpanExtractorTests {
 		Message message = MessageBuilder.createMessage("",
 				headers(randomId(), randomId(), "invalid"));
 
-		Span span = this.extractor.joinTrace(message);
-
-		then(span).isNotNull();
-		then(span.getTraceId()).isNotZero();
-		then(span.getSpanId()).isNotZero();
-		then(span.getParents()).isEmpty();
+		try {
+			this.extractor.joinTrace(message);
+			fail("should throw an exception");
+		} catch (IllegalStateException e) {
+			then(e).hasMessageContaining("Malformed id");
+		}
 	}
 
 	private MessageHeaders headers() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
@@ -51,7 +51,7 @@ public class MessagingSpanExtractorTests {
 		try {
 			this.extractor.joinTrace(message);
 			fail("should throw an exception");
-		} catch (IllegalStateException e) {
+		} catch (IllegalArgumentException e) {
 			then(e).hasMessageContaining("Malformed id");
 		}
 	}
@@ -64,7 +64,7 @@ public class MessagingSpanExtractorTests {
 		try {
 			this.extractor.joinTrace(message);
 			fail("should throw an exception");
-		} catch (IllegalStateException e) {
+		} catch (IllegalArgumentException e) {
 			then(e).hasMessageContaining("Malformed id");
 		}
 	}
@@ -77,7 +77,7 @@ public class MessagingSpanExtractorTests {
 		try {
 			this.extractor.joinTrace(message);
 			fail("should throw an exception");
-		} catch (IllegalStateException e) {
+		} catch (IllegalArgumentException e) {
 			then(e).hasMessageContaining("Malformed id");
 		}
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.cloud.sleuth.Span;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,7 +36,7 @@ public class HttpServletRequestExtractorTests {
 
 	@Mock HttpServletRequest request;
 	HttpServletRequestExtractor extractor = new HttpServletRequestExtractor(
-			Pattern.compile(""), new Random());
+			Pattern.compile(""));
 
 	@Before
 	public void setup() {
@@ -53,10 +54,12 @@ public class HttpServletRequestExtractorTests {
 		BDDMockito.given(this.request.getHeader(Span.TRACE_ID_NAME))
 				.willReturn("invalid");
 
-		Span span = this.extractor.joinTrace(this.request);
-
-		then(span).isNotNull();
-		then(span.getTraceId()).isNotZero();
+		try {
+			this.extractor.joinTrace(this.request);
+			fail("should throw an exception");
+		} catch (IllegalStateException e) {
+			then(e).hasMessageContaining("Malformed id");
+		}
 	}
 
 	@Test
@@ -66,11 +69,12 @@ public class HttpServletRequestExtractorTests {
 		BDDMockito.given(this.request.getHeader(Span.SPAN_ID_NAME))
 				.willReturn("invalid");
 
-		Span span = this.extractor.joinTrace(this.request);
-
-		then(span).isNotNull();
-		then(span.getTraceId()).isNotZero();
-		then(span.getSpanId()).isNotZero();
+		try {
+			this.extractor.joinTrace(this.request);
+			fail("should throw an exception");
+		} catch (IllegalStateException e) {
+			then(e).hasMessageContaining("Malformed id");
+		}
 	}
 
 	@Test
@@ -82,11 +86,11 @@ public class HttpServletRequestExtractorTests {
 		BDDMockito.given(this.request.getHeader(Span.PARENT_ID_NAME))
 				.willReturn("invalid");
 
-		Span span = this.extractor.joinTrace(this.request);
-
-		then(span).isNotNull();
-		then(span.getTraceId()).isNotZero();
-		then(span.getSpanId()).isNotZero();
-		then(span.getParents()).isEmpty();
+		try {
+			this.extractor.joinTrace(this.request);
+			fail("should throw an exception");
+		} catch (IllegalStateException e) {
+			then(e).hasMessageContaining("Malformed id");
+		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
@@ -57,7 +57,7 @@ public class HttpServletRequestExtractorTests {
 		try {
 			this.extractor.joinTrace(this.request);
 			fail("should throw an exception");
-		} catch (IllegalStateException e) {
+		} catch (IllegalArgumentException e) {
 			then(e).hasMessageContaining("Malformed id");
 		}
 	}
@@ -72,7 +72,7 @@ public class HttpServletRequestExtractorTests {
 		try {
 			this.extractor.joinTrace(this.request);
 			fail("should throw an exception");
-		} catch (IllegalStateException e) {
+		} catch (IllegalArgumentException e) {
 			then(e).hasMessageContaining("Malformed id");
 		}
 	}
@@ -89,7 +89,7 @@ public class HttpServletRequestExtractorTests {
 		try {
 			this.extractor.joinTrace(this.request);
 			fail("should throw an exception");
-		} catch (IllegalStateException e) {
+		} catch (IllegalArgumentException e) {
 			then(e).hasMessageContaining("Malformed id");
 		}
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
@@ -73,8 +73,7 @@ public class TraceFilterMockChainIntegrationTests {
 	@Test
 	public void startsNewTrace() throws Exception {
 		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, new NoOpSpanReporter(),
-				new HttpServletRequestExtractor(Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN),
-						new Random()),
+				new HttpServletRequestExtractor(Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN)),
 				new HttpServletResponseInjector(), keysInjector);
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
@@ -86,8 +85,7 @@ public class TraceFilterMockChainIntegrationTests {
 		this.request = builder().header(Span.SPAN_ID_NAME, generator.nextLong())
 				.header(Span.TRACE_ID_NAME, generator.nextLong()).buildRequest(new MockServletContext());
 		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, new NoOpSpanReporter(),
-				new HttpServletRequestExtractor(Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN),
-						new Random()),
+				new HttpServletRequestExtractor(Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN)),
 				new HttpServletResponseInjector(), keysInjector);
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TestSpanContextHolder.getCurrentSpan());


### PR DESCRIPTION
with this change we will throw an IllegalStateException when the malformed tracing data are sent. In TraceFilter we're catching it and sending back 400 response. In case of messaging the exception gets propagated

fixed #306