### PR TITLE
Renaming child server span

### DIFF
--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
@@ -61,7 +61,10 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 		MvcResult mvcResult = whenSentPingWithoutTracingData();
 
 		then(tracingHeaderFrom(mvcResult)).isNotNull();
-		then(TraceFilterIntegrationTests.span).hasLoggedAnEvent(Span.SERVER_RECV)
+		Span parentSpan = this.spanAccumulator.getSpans().stream().filter(
+				span -> span.getSpanId() == TraceFilterIntegrationTests.span.getParents().get(0))
+				.findFirst().get();
+		then(parentSpan).hasLoggedAnEvent(Span.SERVER_RECV)
 				.hasLoggedAnEvent(Span.SERVER_SEND);
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.sleuth.instrument.web.client;
 
 import javax.servlet.http.HttpServletRequest;
+import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -29,6 +30,7 @@ import com.netflix.loadbalancer.BaseLoadBalancer;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
 
+import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -81,6 +83,8 @@ import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 @WebIntegrationTest(value = { "spring.application.name=fooservice" }, randomPort = true)
 @DirtiesContext
 public class WebClientTests {
+
+	private static final org.apache.commons.logging.Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	@ClassRule public static final SpringClassRule SCR = new SpringClassRule();
 	@Rule public final SpringMethodRule springMethodRule = new SpringMethodRule();
@@ -220,6 +224,7 @@ public class WebClientTests {
 				.forEach(span -> {
 					int initialSize = span.logs().size();
 					int distinctSize = span.logs().stream().map(Log::getEvent).distinct().collect(Collectors.toList()).size();
+					log.info("logs " + span.logs());
 					then(initialSize).as("there are no duplicate log entries").isEqualTo(distinctSize);
 				});
 		then(this.testErrorController.getSpan()).isNotNull();

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+import com.netflix.zuul.context.RequestContext;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
@@ -36,6 +40,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -43,10 +48,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
-
-import com.netflix.loadbalancer.Server;
-import com.netflix.loadbalancer.ServerList;
-import com.netflix.zuul.context.RequestContext;
 
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
@@ -154,7 +155,9 @@ class SampleZuulProxyApplication {
 	}
 
 	@Bean RestTemplate restTemplate() {
-		RestTemplate restTemplate = new RestTemplate();
+		HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+		factory.setReadTimeout(5000);
+		RestTemplate restTemplate = new RestTemplate(factory);
 		restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
 			@Override public void handleError(ClientHttpResponse response)
 					throws IOException {

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/AbstractIntegrationTest.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/AbstractIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package tools;
 
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,6 +23,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.jayway.awaitility.Awaitility;
+import com.jayway.awaitility.core.ConditionFactory;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -35,9 +39,6 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import com.jayway.awaitility.Awaitility;
-import com.jayway.awaitility.core.ConditionFactory;
-
 import zipkin.Codec;
 import zipkin.Span;
 
@@ -49,7 +50,7 @@ import static org.assertj.core.api.BDDAssertions.then;
  */
 public abstract class AbstractIntegrationTest {
 
-	private static final Log log = LogFactory.getLog(AbstractIntegrationTest.class);
+	protected static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	protected static final int POLL_INTERVAL = 1;
 	protected static final int TIMEOUT = 20;


### PR DESCRIPTION
The change results in converting the artificial span spawned from the first http server span into a span that is generated from an aspect that wraps a controller that processes the request.

cc @dsyer 