### PR TITLE
Add basic auth support to HttpZipkinSpanReporter

### DIFF
--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/test/java/integration/ZipkinTests.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/test/java/integration/ZipkinTests.java
@@ -123,7 +123,9 @@ public class ZipkinTests extends AbstractIntegrationTest {
 
 		private ZipkinSpanReporter getSpanCollector(ZipkinProperties zipkin,
 				SpanMetricReporter spanMetricReporter) {
-			return new HttpZipkinSpanReporter(zipkin.getBaseUrl(), zipkin.getFlushInterval(),
+			return new HttpZipkinSpanReporter(zipkin.getBaseUrl(),
+					zipkin.isBasicAuthenticated(), zipkin.getUsername(),
+					zipkin.getPassword(), zipkin.getFlushInterval(),
 					zipkin.getCompression().isEnabled(), spanMetricReporter);
 		}
 	}

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.context.annotation.Configuration;
  * {@link PercentageBasedSampler}.
  *
  * @author Spencer Gibb
+ * @author Brock Overcash
  * @since 1.0.0
  */
 @Configuration
@@ -52,9 +53,12 @@ public class ZipkinAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public ZipkinSpanReporter reporter(SpanMetricReporter spanMetricReporter, ZipkinProperties zipkin) {
-		return new HttpZipkinSpanReporter(zipkin.getBaseUrl(), zipkin.getFlushInterval(),
-				zipkin.getCompression().isEnabled(), spanMetricReporter);
+	public ZipkinSpanReporter reporter(SpanMetricReporter spanMetricReporter,
+			ZipkinProperties zipkin) {
+		return new HttpZipkinSpanReporter(zipkin.getBaseUrl(),
+				zipkin.isBasicAuthenticated(), zipkin.getUsername(), zipkin.getPassword(),
+				zipkin.getFlushInterval(), zipkin.getCompression().isEnabled(),
+				spanMetricReporter);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Zipkin settings
  *
  * @author Spencer Gibb
+ * @author Brock Overcash
  * @since 1.0.0
  */
 @ConfigurationProperties("spring.zipkin")
@@ -29,6 +30,9 @@ public class ZipkinProperties {
 	/** URL of the zipkin query server instance. */
 	private String baseUrl = "http://localhost:9411/";
 	private boolean enabled = true;
+	private boolean basicAuthenticated = false;
+	private String username = "admin";
+	private String password = "password";
 	private int flushInterval = 1;
 	private Compression compression = new Compression();
 
@@ -39,6 +43,12 @@ public class ZipkinProperties {
 	public boolean isEnabled() {
 		return this.enabled;
 	}
+
+	public boolean isBasicAuthenticated() { return this.basicAuthenticated; }
+
+	public String getUsername() { return this.username; }
+
+	public String getPassword() { return this.password; }
 
 	public int getFlushInterval() {
 		return this.flushInterval;
@@ -55,6 +65,12 @@ public class ZipkinProperties {
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
 	}
+
+	public void setBasicAuthenticated(boolean basicAuthenticated) { this.basicAuthenticated = basicAuthenticated; }
+
+	public void setUsername(String username) { this.username = username; }
+
+	public void getPassword(String password) { this.password = password; }
 
 	public void setFlushInterval(int flushInterval) {
 		this.flushInterval = flushInterval;

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
@@ -21,6 +21,9 @@ public class HttpZipkinSpanReporterTest {
 
 	HttpZipkinSpanReporter reporter = new HttpZipkinSpanReporter(
 			this.zipkin.httpUrl(),
+			false,
+			"",
+			"",
 			0, // so that tests can drive flushing explicitly
 			false, // disable compression
 			this.spanMetricReporter
@@ -70,6 +73,9 @@ public class HttpZipkinSpanReporterTest {
 	public void postsCompressedSpans() throws Exception {
 		this.reporter = new HttpZipkinSpanReporter(
 				this.zipkin.httpUrl(),
+				false,
+				"",
+				"",
 				0, // so that tests can drive flushing explicitly
 				false, // enable compression
 				this.spanMetricReporter


### PR DESCRIPTION
I would like to use Basic Auth to make my Zipkin server a little more secure and needed to implement this into the SpanReporter. This is definitely a simple solution and I see some potential for refactoring the Auth element into a class so that things like " Basic b64token" string only has to be created once. I'll update the PR if I do that.