### PR TITLE
Exposes getAccumulatedMicros for more precise Span duration

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
@@ -77,7 +77,7 @@ public class DefaultTracer implements Tracer {
 		}
 		else {
 			long id = createId();
-			span = Span.builder().begin(System.currentTimeMillis()).name(name).traceId(id)
+			span = Span.builder().name(name).traceId(id)
 					.spanId(id).build();
 			if (sampler==null) {
 				sampler = this.defaultSampler;
@@ -141,7 +141,7 @@ public class DefaultTracer implements Tracer {
 	protected Span createChild(Span parent, String name) {
 		long id = createId();
 		if (parent == null) {
-			Span span = Span.builder().begin(System.currentTimeMillis()).name(name)
+			Span span = Span.builder().name(name)
 					.traceId(id).spanId(id).build();
 			span = sampledSpan(name, id, span, this.defaultSampler);
 			this.spanLogger.logStartedSpan(null, span);
@@ -151,7 +151,7 @@ public class DefaultTracer implements Tracer {
 			if (!isTracing()) {
 				SpanContextHolder.push(parent, true);
 			}
-			Span span = Span.builder().begin(System.currentTimeMillis()).name(name)
+			Span span = Span.builder().name(name)
 					.traceId(parent.getTraceId()).parent(parent.getSpanId()).spanId(id)
 					.processId(parent.getProcessId()).savedSpan(parent)
 					.exportable(parent.isExportable()).build();

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
@@ -90,7 +90,9 @@ final class ConvertToZipkinSpanList {
 			ensureServerAddr(span, zipkinSpan, ep);
 		}
 		zipkinSpan.timestamp(span.getBegin() * 1000);
-		zipkinSpan.duration(span.getAccumulatedMillis() * 1000);
+		if (!span.isRunning()) { // duration is authoritative, only write when the span stopped
+			zipkinSpan.duration(span.getAccumulatedMicros());
+		}
 		zipkinSpan.traceId(span.getTraceId());
 		if (span.getParents().size() > 0) {
 			if (span.getParents().size() > 1) {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
@@ -86,7 +86,9 @@ public class ZipkinSpanListener implements SpanReporter {
 			ensureServerAddr(span, zipkinSpan);
 		}
 		zipkinSpan.timestamp(span.getBegin() * 1000L);
-		zipkinSpan.duration(span.getAccumulatedMillis() * 1000L);
+		if (!span.isRunning()) { // duration is authoritative, only write when the span stopped
+			zipkinSpan.duration(span.getAccumulatedMicros());
+		}
 		zipkinSpan.traceId(span.getTraceId());
 		if (span.getParents().size() > 0) {
 			if (span.getParents().size() > 1) {


### PR DESCRIPTION
Formerly, `Span.getAccumulatedMillis()` worked, but could returns
imprecise measurements, particularly local spans. This changes the
internals of Span to keep track of a start tick. Using this, it can
return a more precise `Span.getAccumulatedMicros()`.

To ensure this precision isn't lost in serialization, this adds a
json field `durationMicros`, which is only set when the span is stopped.
This is set instead of start tick because `System.nanoTime()` is JVM
specific and so cannot be used across the network. `durationMicros` uses
null instead of zero comparisons because nano time can be negative.

Fixes #312

Example cold trace from https://github.com/adriancole/sleuth-webmvc-example/
<img width="984" alt="screen shot 2016-06-29 at 12 13 57 pm" src="https://cloud.githubusercontent.com/assets/64215/16440313/5af866be-3df3-11e6-87d0-b97545f254dd.png">


Example warm trace from https://github.com/adriancole/sleuth-webmvc-example/
<img width="987" alt="screen shot 2016-06-29 at 12 14 23 pm" src="https://cloud.githubusercontent.com/assets/64215/16440320/617590de-3df3-11e6-9187-39ca5f1f8b60.png">
