### PR TITLE
Added PollerMetadata for StreamSpanReporter

### DIFF
--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/SleuthStreamProperties.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/SleuthStreamProperties.java
@@ -28,6 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SleuthStreamProperties {
 	private boolean enabled = true;
 	private String group = SleuthSink.INPUT;
+	private Poller poller = new Poller();
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -43,5 +44,37 @@ public class SleuthStreamProperties {
 
 	public void setGroup(String group) {
 		this.group = group;
+	}
+
+	public Poller getPoller() {
+		return this.poller;
+	}
+
+	public static class Poller {
+		/**
+		 * Fixed delay (ms). Default: 1000
+		 */
+		private long fixedDelay = 1000L;
+
+		/**
+		 * Max messages per poll. Default: -1 (unbounded)
+		 */
+		private int maxMessagesPerPoll = -1;
+
+		public long getFixedDelay() {
+			return this.fixedDelay;
+		}
+
+		public int getMaxMessagesPerPoll() {
+			return this.maxMessagesPerPoll;
+		}
+
+		public void setFixedDelay(long fixedDelay) {
+			this.fixedDelay = fixedDelay;
+		}
+
+		public void setMaxMessagesPerPoll(int maxMessagesPerPoll) {
+			this.maxMessagesPerPoll = maxMessagesPerPoll;
+		}
 	}
 }

--- a/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/StreamSpanReporter.java
+++ b/spring-cloud-sleuth-stream/src/main/java/org/springframework/cloud/sleuth/stream/StreamSpanReporter.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.metric.SpanMetricReporter;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.MessageEndpoint;
-
+import org.springframework.integration.annotation.Poller;
 
 /**
  * A message source for spans. Also handles RPC flavoured annotations.
@@ -37,6 +37,13 @@ import org.springframework.integration.annotation.MessageEndpoint;
  */
 @MessageEndpoint
 public class StreamSpanReporter implements SpanReporter {
+
+	/**
+	 * Bean name for the
+	 * {@link org.springframework.integration.scheduling.PollerMetadata
+	 * PollerMetadata}
+	 */
+	public static final String POLLER = "streamSpanReporterPoller";
 
 	private BlockingQueue<Span> queue = new LinkedBlockingQueue<>();
 	private final HostLocator endpointLocator;
@@ -51,7 +58,7 @@ public class StreamSpanReporter implements SpanReporter {
 		this.queue = queue;
 	}
 
-	@InboundChannelAdapter(value = SleuthSource.OUTPUT)
+	@InboundChannelAdapter(value = SleuthSource.OUTPUT, poller = @Poller(POLLER))
 	public Spans poll() {
 		List<Span> result = new LinkedList<>();
 		this.queue.drainTo(result);

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfigurationTest.java
@@ -1,0 +1,142 @@
+package org.springframework.cloud.sleuth.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
+import org.springframework.cloud.sleuth.log.SpanLogger;
+import org.springframework.cloud.sleuth.metric.TraceMetricsAutoConfiguration;
+import org.springframework.cloud.stream.config.ChannelBindingAutoConfiguration;
+import org.springframework.cloud.stream.test.binder.TestSupportBinderAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.scheduling.PollerMetadata;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
+import org.springframework.scheduling.support.PeriodicTrigger;
+import org.springframework.scheduling.support.SimpleTriggerContext;
+
+public class SleuthStreamAutoConfigurationTest {
+
+	private AnnotationConfigApplicationContext ctx;
+	private static DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+	private static final String TEST_SCHEDULED = "2016-01-01 12:00:00";
+	private static final String TEST_COMPLETION = "2016-01-01 12:00:02";
+	private static Date LAST_SCHEDULED_DATE;
+	private static Date LAST_EXECUTED_DATE;
+	private static Date LAST_COMPLETED_DATE;
+
+	@BeforeClass
+	public static void setupTests() throws ParseException {
+		LAST_SCHEDULED_DATE = dateFormat.parse(TEST_SCHEDULED);
+		LAST_EXECUTED_DATE = new Date(LAST_SCHEDULED_DATE.getTime());
+		LAST_COMPLETED_DATE = dateFormat.parse(TEST_COMPLETION);
+	}
+
+	@After
+	public void cleanup() {
+		if (ctx != null) {
+			ctx.close();
+		}
+	}
+
+	@Test
+	public void shouldUseDefaultPollerConfiguration() {
+		ctx = createContext();
+		ctx.refresh();
+
+		PollerMetadata poller = ctx.getBean(StreamSpanReporter.POLLER,
+				PollerMetadata.class);
+		assertThat(poller).isNotNull();
+		assertPollerConfigurationUsingConfigurationProperties(poller);
+	}
+
+	@Test
+	public void shouldUseCustomPollerConfiguration() {
+		ctx = createContext();
+		EnvironmentTestUtils.addEnvironment(ctx,
+				"spring.sleuth.stream.poller.fixed-delay=5000",
+				"spring.sleuth.stream.poller.max-messages-per-poll=100");
+		ctx.refresh();
+
+		PollerMetadata poller = ctx.getBean(StreamSpanReporter.POLLER,
+				PollerMetadata.class);
+		assertThat(poller).isNotNull();
+		assertPollerConfigurationUsingConfigurationProperties(poller);
+	}
+
+	@Test
+	public void shouldUseCustomPollerBean() {
+		ctx = createContext(CustomPollerConfiguration.class);
+		ctx.refresh();
+
+		PollerMetadata poller = ctx.getBean(StreamSpanReporter.POLLER,
+				PollerMetadata.class);
+		assertThat(poller).isNotNull();
+		assertPollerConfiguration(poller, 500L, 5000L);
+	}
+
+	private void assertPollerConfigurationUsingConfigurationProperties(
+			PollerMetadata poller) {
+		SleuthStreamProperties sleuth = ctx.getBean(SleuthStreamProperties.class);
+		assertPollerConfiguration(poller, sleuth.getPoller().getMaxMessagesPerPoll(),
+				sleuth.getPoller().getFixedDelay());
+	}
+
+	private void assertPollerConfiguration(PollerMetadata poller,
+			long expectedMaxMessages, long expectedFixedDelay) {
+		assertThat(poller.getMaxMessagesPerPoll()).isEqualTo(expectedMaxMessages);
+		Trigger trigger = poller.getTrigger();
+		assertThat(trigger).isInstanceOf(PeriodicTrigger.class);
+		TriggerContext triggerContext = new SimpleTriggerContext(LAST_SCHEDULED_DATE,
+				LAST_EXECUTED_DATE, LAST_COMPLETED_DATE);
+		Date nextExecution = trigger.nextExecutionTime(triggerContext);
+		assertThat(nextExecution.getTime())
+				.isEqualTo(LAST_COMPLETED_DATE.getTime() + expectedFixedDelay);
+	}
+
+	public AnnotationConfigApplicationContext createContext(Class<?>... classes) {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		if (classes != null && classes.length > 0) {
+			context.register(classes);
+		}
+		context.register(BaseConfiguration.class);
+		return context;
+	}
+
+	@Configuration
+	@Import({ SleuthStreamAutoConfiguration.class, TraceMetricsAutoConfiguration.class,
+			TestSupportBinderAutoConfiguration.class,
+			ChannelBindingAutoConfiguration.class, TraceAutoConfiguration.class,
+			PropertyPlaceholderAutoConfiguration.class })
+	public static class BaseConfiguration {
+		@Bean
+		SpanLogger spanLogger() {
+			return new NoOpSpanLogger();
+		}
+	}
+
+	@Configuration
+	public static class CustomPollerConfiguration {
+
+		@Bean(name = StreamSpanReporter.POLLER)
+		PollerMetadata customPoller() {
+			PollerMetadata poller = new PollerMetadata();
+			poller.setMaxMessagesPerPoll(500);
+			poller.setTrigger(new PeriodicTrigger(5000L));
+			return poller;
+		}
+	}
+}

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/StreamSpanListenerTests.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/StreamSpanListenerTests.java
@@ -33,7 +33,8 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
-import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanReporter;
@@ -59,16 +60,22 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Dave Syer
  *
  */
-@SpringApplicationConfiguration(classes = TestConfiguration.class)
+@SpringBootTest(classes = TestConfiguration.class, webEnvironment = WebEnvironment.NONE)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class StreamSpanListenerTests {
 
-	@Autowired Tracer tracer;
-	@Autowired ApplicationContext application;
-	@Autowired ZipkinTestConfiguration test;
-	@Autowired StreamSpanReporter listener;
-	@Autowired CounterService counterService;
-	@Autowired SpanReporter spanReporter;
+	@Autowired
+	Tracer tracer;
+	@Autowired
+	ApplicationContext application;
+	@Autowired
+	ZipkinTestConfiguration test;
+	@Autowired
+	StreamSpanReporter listener;
+	@Autowired
+	CounterService counterService;
+	@Autowired
+	SpanReporter spanReporter;
 
 	@PostConstruct
 	public void init() {
@@ -149,7 +156,8 @@ public class StreamSpanListenerTests {
 			TraceMetricsAutoConfiguration.class, TestSupportBinderAutoConfiguration.class,
 			ChannelBindingAutoConfiguration.class, TraceAutoConfiguration.class,
 			PropertyPlaceholderAutoConfiguration.class })
-	protected static class TestConfiguration {}
+	protected static class TestConfiguration {
+	}
 
 	@Configuration
 	@MessageEndpoint
@@ -160,7 +168,7 @@ public class StreamSpanListenerTests {
 		@Autowired
 		StreamSpanReporter listener;
 
-		@ServiceActivator(inputChannel=SleuthSource.OUTPUT)
+		@ServiceActivator(inputChannel = SleuthSource.OUTPUT)
 		public void handle(Message<?> msg) {
 		}
 
@@ -174,7 +182,8 @@ public class StreamSpanListenerTests {
 			return new AlwaysSampler();
 		}
 
-		@Bean CounterService counterService() {
+		@Bean
+		CounterService counterService() {
 			return Mockito.mock(CounterService.class);
 		}
 


### PR DESCRIPTION
Added configurable PollerMetadata bean to be used with the Inbound
Channel Adapter in the StreamSpanReporter. Fixed delay and max messages
per poll are configurable via configuration properties. Implementors can
provide a bean of type PollerMetadata and name
StreamSpanReporter.POLLER to take full control of the poller.

Fixes: gh-338