### PR TITLE
Fixing config properties for Zipkin Consumer

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -309,7 +309,7 @@ spring:
     host: ${RABBIT_HOST:localhost}
   datasource:
     schema: classpath:/mysql.sql
-    url: jdbc:mysql://${MYSQL_HOST:localhost}/test
+    url: jdbc:mysql://localhost:3306/zipkin
     username: root
     password: root
 # Switch this on to create the schema on startup:
@@ -319,7 +319,10 @@ spring:
     enabled: false
 zipkin:
   storage:
-    type: mysql
+    type: 
+      mysql:
+        username: root
+        password: root
 ----
 
 NOTE: The `@EnableZipkinStreamServer` is also annotated with


### PR DESCRIPTION
Using the e.g properties from Zipkin Consumer gives the following error when loading the zipkin-server ui:

```
ERROR: cannot load service names: zipkin/storage/mysql/internal/generated/tables/ZipkinAnnotations
ERROR: cannot load span names: zipkin/storage/mysql/internal/generated/tables/ZipkinSpans
```

So to fix it you have to explicitly add username and password for the mysql storage. This is because in zipkin-sever the  [zipkin-server.yml](https://github.com/openzipkin/zipkin/blob/master/zipkin-server/src/main/resources/zipkin-server.yml) does not have default values for username and password at mysql storage type.