### PR TITLE
Deploying documentation to proper folder

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -13,6 +13,8 @@
 	<description>Spring Sleuth Docs</description>
 	<properties>
 		<docs.main>spring-cloud-sleuth</docs.main>
+		<!-- Comma separated list of whitelisted branches -->
+		<docs.whitelisted.branches>1.0.x</docs.whitelisted.branches>
 		<main.basedir>${basedir}/..</main.basedir>
 	</properties>
 	<profiles>

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -25,6 +25,9 @@ fi
 # Retrieve properties
 ###################################################################
 
+# Prop that will let commit the changes
+COMMIT_CHANGES="no"
+
 # Get the name of the `docs.main` property
 MAIN_ADOC_VALUE=$(mvn -q \
     -Dexec.executable="echo" \
@@ -37,8 +40,9 @@ echo "Extracted 'main.adoc' from Maven build [${MAIN_ADOC_VALUE}]"
 WHITELISTED_BRANCHES_VALUE=$(mvn -q \
     -Dexec.executable="echo" \
     -Dexec.args='${docs.whitelisted.branches}' \
-    --non-recursive \
-    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+    org.codehaus.mojo:exec-maven-plugin:1.3.1:exec \
+    -P docs \
+    -pl docs)
 echo "Extracted 'docs.whitelisted.branches' from Maven build [${WHITELISTED_BRANCHES_VALUE}]"
 
 # Code getting the name of the current branch. For master we want to publish as we did until now
@@ -72,6 +76,7 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             git add -A ${ROOT_FOLDER}/$file
         fi
     done
+    COMMIT_CHANGES="yes"
 else
     echo -e "Current branch is [${CURRENT_BRANCH}]"
     # http://stackoverflow.com/questions/29300806/a-bash-script-to-check-if-a-string-is-present-in-a-comma-separated-list-of-strin
@@ -93,18 +98,21 @@ else
                 fi
             fi
         done
+        COMMIT_CHANGES="yes"
     else
         echo -e "Branch [${CURRENT_BRANCH}] is no ton the whitelist! Won't do anything about this..."
     fi
 fi
 
-git commit -a -m "Sync docs from ${CURRENT_BRANCH} to gh-pages"
+if [[ "${COMMIT_CHANGES}" == "yes" ]] ; then
+    git commit -a -m "Sync docs from ${CURRENT_BRANCH} to gh-pages"
 
-# Uncomment the following push if you want to auto push to
-# the gh-pages branch whenever you commit to master locally.
-# This is a little extreme. Use with care!
-###################################################################
-git push origin gh-pages
+    # Uncomment the following push if you want to auto push to
+    # the gh-pages branch whenever you commit to master locally.
+    # This is a little extreme. Use with care!
+    ###################################################################
+    git push origin gh-pages
+fi
 
 # Finally, switch back to the master branch and exit block
 git checkout ${CURRENT_BRANCH}

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -26,7 +26,7 @@ fi
 ###################################################################
 
 # Get the name of the `docs.main` property
-MAIN_ADOC_VALUE=MVN_VERSION=$(mvn -q \
+MAIN_ADOC_VALUE=$(mvn -q \
     -Dexec.executable="echo" \
     -Dexec.args='${docs.main}' \
     --non-recursive \

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -25,9 +25,9 @@ fi
 # Retrieve version number, name of the main adoc and name of the current branch
 ###################################################################
 
-# Code grepping for the 2nd presence of "version>" in pom.xml.
-# First one is parent, second project version.
-VERSION_NODE=`awk '/version>/{i++}i==2{print; exit}' $ROOT_FOLDER/pom.xml`
+# Code grepping for the 1st presence of "version>" in pom.xml.
+# First one is project version, second parent version.
+VERSION_NODE=`awk '/version>/{i++}i==1{print; exit}' $ROOT_FOLDER/pom.xml`
 # Extract the contents of the version node
 VERSION_VALUE=$(sed -ne '/version/{s/.*<version>\(.*\)<\/version>.*/\1/p;q;}' <<< "$VERSION_NODE")
 echo "Extracted version from root pom.xml is [${VERSION_VALUE}]"

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -70,7 +70,7 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.adoc index.html)
+                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.html index.html)
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A $file
@@ -85,7 +85,7 @@ else
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.adoc index.html)
+                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.html index.html)
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -70,7 +70,7 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.html index.html)
+                cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A $file
@@ -83,12 +83,16 @@ else
         file=${f#docs/target/generated-docs/*}
         if ! git ls-files -i -o --exclude-standard --directory | grep -q ^$file$; then
             # Not ignored...
-            cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
+            # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.html index.html)
+                # We don't want to copy the spring-cloud-sleuth.html
+                # we want it to be converted to index.html
+                cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
+            else
+                cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
+                git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file
             fi
-            git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file
         fi
     done
 fi

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -69,7 +69,7 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             cp -rf $f ${ROOT_FOLDER}/
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
-            if [[ "${file}" == "${MAIN_ADOC_VALUE}" ]] ; then
+            if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
                 ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/index.html ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
@@ -84,7 +84,7 @@ else
         if ! git ls-files -i -o --exclude-standard --directory | grep -q ^$file$; then
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
-            if [[ "${file}" == "${MAIN_ADOC_VALUE}" ]] ; then
+            if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
                 ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/index.html ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -57,7 +57,7 @@ if [ "$dirty" != "0" ]; then git stash; fi
 git checkout gh-pages
 git pull origin gh-pages
 
-# For all branches copy the generated docs to proper project version subfolder
+# Add git branches
 ###################################################################
 mkdir -p ${ROOT_FOLDER}/${VERSION_VALUE}
 if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
@@ -83,17 +83,6 @@ else
         fi
     done
 fi
-
-# Add git branches
-###################################################################
-for f in docs/target/generated-docs/*; do
-    file=${f#docs/target/generated-docs/*}
-    if ! git ls-files -i -o --exclude-standard --directory | grep -q ^$file$; then
-        # Not ignored...
-        cp -rf $f .
-        git add -A $file
-    fi
-done
 
 git commit -a -m "Sync docs from ${CURRENT_BRANCH} to gh-pages"
 

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -36,8 +36,8 @@ echo "Extracted version from root pom.xml is [${VERSION_VALUE}]"
 # First one is parent, second project version.
 MAIN_ADOC_NODE=`awk '/docs.main/{i++}i==1{print; exit}' $ROOT_FOLDER/docs/pom.xml`
 # Extract the contents of the version node
-MAIN_ADOC=$(sed -ne '/docs.main/{s/.*<docs.main>\(.*\)<\/docs.main>.*/\1/p;q;}' <<< "$MAIN_ADOC_NODE")
-echo "Extracted version from docs pom.xml is [${MAIN_ADOC}]"
+MAIN_ADOC_VALUE=$(sed -ne '/docs.main/{s/.*<docs.main>\(.*\)<\/docs.main>.*/\1/p;q;}' <<< "$MAIN_ADOC_NODE")
+echo "Extracted version from docs pom.xml is [${MAIN_ADOC_VALUE}]"
 
 # Code getting the name of the current branch. For master we want to publish as we did until now
 # http://stackoverflow.com/questions/1593051/how-to-programmatically-determine-the-current-checked-out-git-branch
@@ -68,6 +68,11 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
+            # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
+            if [[ "${file}" == "${MAIN_ADOC_VALUE}" ]] ; then
+                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/index.html ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc
+                git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
+            fi
             git add -A $file
             git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file
         fi
@@ -79,6 +84,10 @@ else
         if ! git ls-files -i -o --exclude-standard --directory | grep -q ^$file$; then
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
+            if [[ "${file}" == "${MAIN_ADOC_VALUE}" ]] ; then
+                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/index.html ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc
+                git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
+            fi
             git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file
         fi
     done

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -37,13 +37,14 @@ MAIN_ADOC_VALUE=$(mvn -q \
 echo "Extracted 'main.adoc' from Maven build [${MAIN_ADOC_VALUE}]"
 
 # Get whitelisted branches - assumes that a `docs` module is available under `docs` profile
+WHITELIST_PROPERTY="docs.whitelisted.branches"
 WHITELISTED_BRANCHES_VALUE=$(mvn -q \
     -Dexec.executable="echo" \
-    -Dexec.args='${docs.whitelisted.branches}' \
+    -Dexec.args="\${${WHITELIST_PROPERTY}}" \
     org.codehaus.mojo:exec-maven-plugin:1.3.1:exec \
     -P docs \
     -pl docs)
-echo "Extracted 'docs.whitelisted.branches' from Maven build [${WHITELISTED_BRANCHES_VALUE}]"
+echo "Extracted '${WHITELIST_PROPERTY}' from Maven build [${WHITELISTED_BRANCHES_VALUE}]"
 
 # Code getting the name of the current branch. For master we want to publish as we did until now
 # http://stackoverflow.com/questions/1593051/how-to-programmatically-determine-the-current-checked-out-git-branch
@@ -100,7 +101,8 @@ else
         done
         COMMIT_CHANGES="yes"
     else
-        echo -e "Branch [${CURRENT_BRANCH}] is not on the whitelist! Won't do anything about this..."
+        echo -e "Branch [${CURRENT_BRANCH}] is not on the white list! Check out the Maven [${WHITELIST_PROPERTY}] property in
+         [docs] module available under [docs] profile. Won't commit any changes to gh-pages for this branch."
     fi
 fi
 

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -100,7 +100,7 @@ else
         done
         COMMIT_CHANGES="yes"
     else
-        echo -e "Branch [${CURRENT_BRANCH}] is no ton the whitelist! Won't do anything about this..."
+        echo -e "Branch [${CURRENT_BRANCH}] is not on the whitelist! Won't do anything about this..."
     fi
 fi
 

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -85,7 +85,7 @@ else
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/index.html ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc
+                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -70,7 +70,7 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
+                ln -s ${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A $file
@@ -85,7 +85,7 @@ else
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
+                ln -s ${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -70,7 +70,7 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                ln -s ${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
+                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.adoc index.html)
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A $file
@@ -85,7 +85,7 @@ else
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                ln -s ${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
+                (cd ${VERSION_VALUE}/; ln -s ${MAIN_ADOC_VALUE}.adoc index.html)
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -69,16 +69,17 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             cp -rf $f ${ROOT_FOLDER}/
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             git add -A $file
+            git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file
         fi
     done
 else
-    echo -e "Current branch is master - will copy the current docs ONLY to [${VERSION_VALUE}] folder"
+    echo -e "Current branch is [${CURRENT_BRANCH}] - will copy the current docs ONLY to [${VERSION_VALUE}] folder"
     for f in docs/target/generated-docs/*; do
         file=${f#docs/target/generated-docs/*}
         if ! git ls-files -i -o --exclude-standard --directory | grep -q ^$file$; then
             # Not ignored...
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
-            git add -A $file
+            git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/$file
         fi
     done
 fi
@@ -103,7 +104,7 @@ git commit -a -m "Sync docs from ${CURRENT_BRANCH} to gh-pages"
 git push origin gh-pages
 
 # Finally, switch back to the master branch and exit block
-git checkout master
+git checkout ${CURRENT_BRANCH}
 if [ "$dirty" != "0" ]; then git stash pop; fi
 
 exit 0

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -36,7 +36,7 @@ MAIN_ADOC_VALUE=$(mvn -q \
     org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
 echo "Extracted 'main.adoc' from Maven build [${MAIN_ADOC_VALUE}]"
 
-# Get whitelisted branches
+# Get whitelisted branches - assumes that a `docs` module is available under `docs` profile
 WHITELISTED_BRANCHES_VALUE=$(mvn -q \
     -Dexec.executable="echo" \
     -Dexec.args='${docs.whitelisted.branches}' \

--- a/docs/src/main/asciidoc/ghpages.sh
+++ b/docs/src/main/asciidoc/ghpages.sh
@@ -70,7 +70,7 @@ if [[ "${CURRENT_BRANCH}" == "master" ]] ; then
             cp -rf $f ${ROOT_FOLDER}/${VERSION_VALUE}
             # We want users to access 1.0.0.RELEASE/ instead of 1.0.0.RELEASE/spring-cloud.sleuth.html
             if [[ "${file}" == "${MAIN_ADOC_VALUE}.html" ]] ; then
-                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/index.html ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc
+                ln -s ${ROOT_FOLDER}/${VERSION_VALUE}/${MAIN_ADOC_VALUE}.adoc ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
                 git add -A ${ROOT_FOLDER}/${VERSION_VALUE}/index.html
             fi
             git add -A $file

--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -7,6 +7,9 @@
 Spring Cloud Sleuth
 ====================
 Adrian Cole, Spencer Gibb, Marcin Grzejszczak, Dave Syer
+
+*{spring-cloud-version}*
+
 :doctype: book
 
 include::intro.adoc[]


### PR DESCRIPTION
What we're missing ATM is different documentation versions for different application versions. WIth changing the gh-script what I've managed to achieve is:

- presenting the version of the application in the docs
- checking out the Git branch (e.g. 1.0.x)
- checking out the application version from pom  (e.g. 1.0.5.BUILD-SNAPSHOT)
- checking out what is the name of the main adoc file (e.g. spring-cloud-sleuth)
- pulling the changes from gh-pages after checkout (we're missing that everywhere IMO...)
- in gh-pages creating a folder with name of the version (e.g. /1.0.5.BUILD-SNAPSHOT)
- copying all the `docs/target/generated-docs/` to that folder
  - if the branch from which we're calling the script is NOT master then I'm changing the `spring-cloud-sleuth.html` to `index.html` so that it's easier to access the docs (e.g. http://cloud.spring.io/spring-cloud-sleuth/1.0.5.BUILD-SNAPSHOT/)
  - if it's master then I'm both copying the target docs to proper version subfolder, but also I'm doing things as we did until now. E.g. if master is 1.1.0.BUILD-SNAPSHOT then (e.g. http://cloud.spring.io/spring-cloud-sleuth/1.1.0.BUILD-SNAPSHOT/ and http://cloud.spring.io/spring-cloud-sleuth/spring-cloud-sleuth.html will get updated)

The good thing is that we'll be able to do the same for all releases and milestones. It will be enough to update the contents of this script on a branch / milestone and we're ready to go... Also it will be much easier to copy the release train documentation since the docs will be in their respective version folders.

Example of execution: https://github.com/marcingrzejszczak/spring-cloud-sleuth/tree/gh-pages
Example of a deployed docs: http://toomuchcoding.com/spring-cloud-sleuth/
Example of a deployed docs from master: http://toomuchcoding.com/spring-cloud-sleuth/spring-cloud-sleuth.html
Example of a deployed docs from a branch: http://toomuchcoding.com/spring-cloud-sleuth/1.1.0.BUILD-SNAPSHOT/

cc @dsyer @ryanjbaxter @spencergibb @adriancole 