### PR TITLE
Updates to Zipkin 1.8.4

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<spring-cloud-netflix.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
-		<zipkin.version>1.8.2</zipkin.version>
+		<zipkin.version>1.8.4</zipkin.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -59,12 +59,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>1.8.2</version>
+				<version>1.8.4</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>1.8.2</version>
+				<version>1.8.4</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Luckily, someone reported a bug where if unprintable characters were in
the json, the UI would hose. This version fixes that.