### PR TITLE
Tolerate reads of 128 bit X-B3-TraceId

### DIFF
--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -53,6 +53,16 @@ public class SpanTests {
 		then(someLong).isEqualTo(123123L);
 	}
 
+	@Test
+	public void should_convert_lower_64bits_of_hex_string_to_long() throws Exception {
+		String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
+		String lower64Bits = "48485a3953bb6124";
+
+		long someLong = Span.hexToId(hex128Bits);
+
+		then(someLong).isEqualTo(Span.hexToId(lower64Bits));
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void should_throw_exception_when_null_string_is_to_be_converted_to_long() throws Exception {
 		Span.hexToId(null);

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
@@ -276,6 +276,20 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 		then(TestSpanContextHolder.getCurrentSpan()).isNull();
 	}
 
+	@Test
+	public void downgrades128bitIdsByDroppingHighBits() {
+		String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
+		String lower64Bits = "48485a3953bb6124";
+		this.tracedChannel.send(MessageBuilder.withPayload("hi")
+				.setHeader(Span.TRACE_ID_NAME, hex128Bits)
+				.setHeader(Span.SPAN_ID_NAME, Span.idToHex(20L)).build());
+		then(this.message).isNotNull();
+
+		long traceId = Span.hexToId(this.message.getHeaders()
+				.get(TraceMessageHeaders.TRACE_ID_NAME, String.class));
+		then(traceId).isEqualTo(Span.hexToId(lower64Bits));
+	}
+
 	@Configuration
 	@EnableAutoConfiguration
 	static class App {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
@@ -93,4 +93,19 @@ public class HttpServletRequestExtractorTests {
 			then(e).hasMessageContaining("Malformed id");
 		}
 	}
+
+	@Test
+	public void should_downgrade_128bit_trace_id_by_dropping_high_bits() {
+		String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
+		String lower64Bits = "48485a3953bb6124";
+
+		BDDMockito.given(this.request.getHeader(Span.TRACE_ID_NAME))
+				.willReturn(hex128Bits);
+		BDDMockito.given(this.request.getHeader(Span.SPAN_ID_NAME))
+				.willReturn(lower64Bits);
+
+		Span span = this.extractor.joinTrace(this.request);
+
+		then(span.getTraceId()).isEqualTo(Span.hexToId(lower64Bits));
+	}
 }


### PR DESCRIPTION
The first step of transitioning to 128bit `X-B3-TraceId` is tolerantly reading 32 character long ids by throwing away the high bits (any characters left of 16 characters). This allows the tracing system to more flexibly introduce 128bit trace id support in the future.

Ex. when `X-B3-TraceId: 463ac35c9f6413ad48485a3953bb6124` is received, parse the lower 64 bits (right most 16 characters ex48485a3953bb6124) as the trace id.

See https://github.com/openzipkin/b3-propagation/issues/6