### PR TITLE
Updates to adjust for reporter metrics drift

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -17,7 +17,7 @@
 		<spring-cloud-netflix.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<aspectj.version>1.8.4</aspectj.version>
 		<zipkin.version>1.11.1</zipkin.version>
-		<zipkin-reporter.version>0.4.3</zipkin-reporter.version>
+		<zipkin-reporter.version>0.5.0</zipkin-reporter.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ReporterMetricsAdapter.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ReporterMetricsAdapter.java
@@ -12,16 +12,11 @@ final class ReporterMetricsAdapter implements ReporterMetrics {
 	}
 
 	@Override
-	public ReporterMetrics forTransport(String transport) {
-		return this;
-	}
-
-	@Override
 	public void incrementMessages() {
 	}
 
 	@Override
-	public void incrementMessagesDropped() {
+	public void incrementMessagesDropped(Throwable throwable) {
 	}
 
 	@Override
@@ -37,7 +32,16 @@ final class ReporterMetricsAdapter implements ReporterMetrics {
 	public void incrementMessageBytes(int i) {
 	}
 
-	@Override public void incrementSpansDropped(int i) {
+	@Override
+	public void incrementSpansDropped(int i) {
 		this.spanMetricReporter.incrementDroppedSpans(i);
+	}
+
+	@Override
+	public void updateQueuedSpans(int i) {
+	}
+
+	@Override
+	public void updateQueuedBytes(int i) {
 	}
 }


### PR DESCRIPTION
while we don't send this info, AsyncSpanReporter has backlog metrics now.

aside: we could make an actuate module to expose all of these, if we wanted