### PR TITLE
Updates to latest Zipkin and avoids Endpoint factory method

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -14,8 +14,8 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<zipkin.version>1.11.1</zipkin.version>
-		<zipkin-reporter.version>0.5.0</zipkin-reporter.version>
+		<zipkin.version>1.13.1</zipkin.version>
+		<zipkin-reporter.version>0.6.1</zipkin-reporter.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -59,12 +59,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>1.11.1</version>
+				<version>1.13.1</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>1.11.1</version>
+				<version>1.13.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
@@ -18,14 +18,12 @@ package org.springframework.cloud.sleuth.zipkin.stream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.commons.logging.Log;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.stream.Host;
 import org.springframework.cloud.sleuth.stream.SleuthSink;
 import org.springframework.cloud.sleuth.stream.Spans;
 import org.springframework.util.StringUtils;
-
 import zipkin.BinaryAnnotation;
 import zipkin.Constants;
 import zipkin.Endpoint;
@@ -76,8 +74,10 @@ final class ConvertToZipkinSpanList {
 	static zipkin.Span convert(Span span, Host host) {
 		Builder zipkinSpan = zipkin.Span.builder();
 
-		Endpoint ep = Endpoint.create(host.getServiceName(), host.getIpv4(),
-				host.getPort().shortValue());
+		Endpoint ep = Endpoint.builder()
+				.serviceName(host.getServiceName())
+				.ipv4(host.getIpv4())
+				.port(host.getPort() != null ? host.getPort() : 0).build();
 
 		// A zipkin span without any annotations cannot be queried, add special "lc" to
 		// avoid that.
@@ -125,8 +125,7 @@ final class ConvertToZipkinSpanList {
 			Endpoint ep) {
 		String serviceName = span.tags().containsKey(Span.SPAN_PEER_SERVICE_TAG_NAME)
 				? span.tags().get(Span.SPAN_PEER_SERVICE_TAG_NAME) : ep.serviceName;
-		Endpoint endpoint = ep.port == null ? Endpoint.create(serviceName, ep.ipv4)
-				: Endpoint.create(serviceName, ep.ipv4, ep.port);
+		Endpoint endpoint = ep.toBuilder().serviceName(serviceName).build();
 		zipkinSpan.addBinaryAnnotation(
 				BinaryAnnotation.address(Constants.SERVER_ADDR, endpoint));
 	}

--- a/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/test/java/org/springframework/cloud/sleuth/zipkin/stream/ZipkinMessageListenerTests.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.sleuth.zipkin.stream;
 
 import java.util.Collections;
-
 import org.junit.Test;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.stream.Host;
@@ -30,7 +29,10 @@ public class ZipkinMessageListenerTests {
 	Span span = new Span(1, 3, "http:name", 1L, Collections.<Long>emptyList(), 2L, true, true,
 			"process");
 	Host host = new Host("myservice", "1.2.3.4", 8080);
-	Endpoint endpoint = Endpoint.create("myservice", 1 << 24 | 2 << 16 | 3 << 8 | 4, 8080);
+	Endpoint endpoint = Endpoint.builder()
+			.serviceName("myservice")
+			.ipv4(1 << 24 | 2 << 16 | 3 << 8 | 4)
+			.port(8080).build();
 
 	/** Sleuth timestamps are millisecond granularity while zipkin is microsecond. */
 	@Test

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocator.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.sleuth.zipkin;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.commons.util.InetUtils;
-
 import zipkin.Endpoint;
 
 /**
@@ -43,7 +42,10 @@ public class DiscoveryClientEndpointLocator implements EndpointLocator {
 		if (instance == null) {
 			throw new NoServiceInstanceAvailableException();
 		}
-		return Endpoint.create(instance.getServiceId(), getIpAddress(instance), instance.getPort());
+		return Endpoint.builder()
+				.serviceName(instance.getServiceId())
+				.ipv4(getIpAddress(instance))
+				.port(instance.getPort()).build();
 	}
 
 	private int getIpAddress(ServiceInstance instance) {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
@@ -48,9 +48,11 @@ public class ServerPropertiesEndpointLocator implements EndpointLocator {
 
 	@Override
 	public Endpoint local() {
-		int address = getAddress();
-		Integer port = getPort();
-		return Endpoint.create(this.appName, address, port);
+		return Endpoint.builder()
+				.serviceName(this.appName)
+				.ipv4(getAddress())
+				.port(getPort())
+				.build();
 	}
 
 	@EventListener(EmbeddedServletContainerInitializedEvent.class)

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocatorTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocatorTests.java
@@ -15,7 +15,8 @@ public class FallbackHavingEndpointLocatorTests {
 
 	@Mock DiscoveryClientEndpointLocator discoveryClientEndpointLocator;
 	@Mock ServerPropertiesEndpointLocator serverPropertiesEndpointLocator;
-	Endpoint expectedEndpoint = Endpoint.create("my-tomcat", 127 << 24 | 1, 8080);
+	Endpoint expectedEndpoint = Endpoint.builder()
+			.serviceName("my-tomcat").ipv4(127 << 24 | 1).port(8080).build();
 
 	@Test
 	public void should_use_system_property_locator_if_discovery_client_locator_is_not_present() {


### PR DESCRIPTION
Now that Endpoint has ipv6, the factory method is even worse than it
was before. This switches to a builder instead.

Note: Endpoint now has a nice toString which should help debugging.