### PR TITLE
Ensure message headers are still mutable after interceptor is called

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
@@ -37,6 +37,7 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Marcin Grzejszczak
  * @since 1.0.10
  */
+@SuppressWarnings("serial")
 public class LazyTraceThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 
 	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
@@ -81,6 +82,17 @@ public class LazyTraceThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 	@Override
 	public <T> ListenableFuture<T> submitListenable(Callable<T> task) {
 		return this.delegate.submitListenable(new SpanContinuingTraceCallable<>(tracer(), traceKeys(), spanNamer(), task));
+	}
+
+	public void destroy() {
+		this.delegate.destroy();
+		super.destroy();
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		this.delegate.afterPropertiesSet();
+		super.afterPropertiesSet();
 	}
 
 	private Tracer tracer() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
@@ -26,7 +26,9 @@ import org.springframework.cloud.sleuth.sampler.NeverSampler;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 
 /**
  * A channel interceptor that automatically starts / continues / closes and detaches
@@ -84,7 +86,9 @@ public class TraceChannelInterceptor extends AbstractTraceChannelInterceptor {
 			messageBuilder.setHeader(TraceMessageHeaders.MESSAGE_SENT_FROM_CLIENT, true);
 		}
 		getSpanInjector().inject(span, messageBuilder);
-		return messageBuilder.build();
+		MessageHeaderAccessor headers = MessageHeaderAccessor.getMutableAccessor(message);
+		headers.copyHeaders(messageBuilder.build().getHeaders());
+		return new GenericMessage<Object>(message.getPayload(), headers.getMessageHeaders());
 	}
 
 	private Span startSpan(Span span, String name, Message<?> message) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptorTests.java
@@ -44,6 +44,7 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -115,6 +116,15 @@ public class TraceChannelInterceptorTests implements MessageHandler {
 		then(spanId).isNotNull();
 		then(TestSpanContextHolder.getCurrentSpan()).isNull();
 		then(this.span.isExportable()).isFalse();
+	}
+
+	@Test
+	public void messageHeadersStillMutable() {
+		this.tracedChannel.send(MessageBuilder.withPayload("hi")
+				.setHeader(Span.SAMPLED_NAME, Span.SPAN_NOT_SAMPLED).build());
+		assertNotNull("message was null", this.message);
+		MessageHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(this.message, MessageHeaderAccessor.class);
+		assertNotNull("Message header accessor should be still available", accessor);
 	}
 
 	@Test


### PR DESCRIPTION
Some components in Spring assume (perhaps wrongly) that a channel
interceptor will not convert a mutable message into an immutable one, and
they continue to modify the headers dowstream. We can dosge the issue of
whether this is right or wrong by keeping the message headers mutable, just
in case.