### PR TITLE
Updates to zipkin 1.14.4

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -14,8 +14,8 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<zipkin.version>1.13.1</zipkin.version>
-		<zipkin-reporter.version>0.6.1</zipkin-reporter.version>
+		<zipkin.version>1.14.4</zipkin.version>
+		<zipkin-reporter.version>0.6.6</zipkin-reporter.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -59,12 +59,12 @@
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>1.13.1</version>
+				<version>1.14.4</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin-server</artifactId>
-				<version>1.13.1</version>
+				<version>1.14.4</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
* Support for MySQL 5.7 with SQL_MODE=ONLY_FULL_GROUP_BY
* Includes support to store 128-bit trace ID (not yet implemented here)

See https://github.com/openzipkin/b3-propagation/issues/6