### PR TITLE
Disable Feign Retry

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/NeverRetry.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/NeverRetry.java
@@ -1,0 +1,23 @@
+package org.springframework.cloud.sleuth.instrument.web.client.feign;
+
+import feign.RetryableException;
+import feign.Retryer;
+
+/**
+ * This is essentially the same implementation of a Retryer that is in newer versions of
+ * Feign. For the 1.0.x stream we add it here.
+ * @author Ryan Baxter
+ */
+public class NeverRetry implements Retryer {
+	@Override
+	public void continueOrPropagate(RetryableException e) {
+		throw e;
+	}
+
+	@Override
+	public Retryer clone() {
+		return this;
+	}
+
+	public static final NeverRetry INSTANCE = new NeverRetry();
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignBuilder.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignBuilder.java
@@ -16,9 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
-import org.springframework.beans.factory.BeanFactory;
-
 import feign.Feign;
+import org.springframework.beans.factory.BeanFactory;
 
 /**
  * Contains {@link feign.Feign.Builder} implementation with tracing components
@@ -33,7 +32,7 @@ final class SleuthFeignBuilder {
 	private SleuthFeignBuilder() {}
 
 	static Feign.Builder builder(BeanFactory beanFactory) {
-		return Feign.builder()
+		return Feign.builder().retryer(NeverRetry.INSTANCE)
 				.client(new TraceFeignClient(beanFactory));
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthHystrixFeignBuilder.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthHystrixFeignBuilder.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
-import org.springframework.beans.factory.BeanFactory;
-
 import feign.Feign;
 import feign.hystrix.HystrixFeign;
+import org.springframework.beans.factory.BeanFactory;
 
 /**
  * Contains {@link Feign.Builder} implementation that delegates execution
@@ -35,7 +34,7 @@ final class SleuthHystrixFeignBuilder {
 	private SleuthHystrixFeignBuilder() {}
 
 	static Feign.Builder builder(BeanFactory beanFactory) {
-		return HystrixFeign.builder()
+		return HystrixFeign.builder().retryer(NeverRetry.INSTANCE)
 				.client(new TraceFeignClient(beanFactory));
 	}
 }


### PR DESCRIPTION
This is needed to make the changes in spring-cloud/spring-cloud-netflix#1457 work when Sleuth is on the classpath.  Do not merge until that pull request is merged into Netflix.

Also changes will need to be made in the 1.1.x branch.  But for that branch we can use the `NEVER_RETRY` class from OpenFeign since a more recent version is in that branch.