### PR TITLE
Propagates logs and reports 128-bit trace IDs (1.1.x)

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractor.java
@@ -76,12 +76,14 @@ class MessagingSpanExtractor implements SpanExtractor<Message<?>> {
 	private Span extractSpanFromHeaders(Message<?> carrier, SpanBuilder spanBuilder,
 			String traceIdHeader, String spanIdHeader, String spanSampledHeader,
 			String spanProcessIdHeader, String spanNameHeader, String spanParentIdHeader) {
-		long traceId = Span
-				.hexToId(getHeader(carrier, traceIdHeader));
+		String traceId = getHeader(carrier, traceIdHeader);
+		spanBuilder.traceIdHigh(traceId.length() == 32 ? Span.hexToId(traceId, 0) : 0);
+		spanBuilder.traceId(Span.hexToId(traceId));
+
 		long spanId = hasHeader(carrier, spanIdHeader)
 				? Span.hexToId(getHeader(carrier, spanIdHeader))
 				: this.random.nextLong();
-		spanBuilder = spanBuilder.traceId(traceId).spanId(spanId);
+		spanBuilder = spanBuilder.spanId(spanId);
 		spanBuilder.exportable(
 				Span.SPAN_SAMPLED.equals(getHeader(carrier, spanSampledHeader)));
 		String processId = getHeader(carrier, spanProcessIdHeader);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanInjector.java
@@ -95,7 +95,7 @@ class MessagingSpanInjector implements SpanInjector<MessageBuilder<?>> {
 			MessageHeaderAccessor accessor, Map<String, String> headers, String traceIdHeader,
 			String spanIdHeader, String parentIdHeader, String spanNameHeader, String processIdHeader,
 			String spanSampledHeader, String spanHeader) {
-		addHeader(headers, traceIdHeader, Span.idToHex(span.getTraceId()));
+		addHeader(headers, traceIdHeader, span.traceIdString());
 		addHeader(headers, spanIdHeader, Span.idToHex(span.getSpanId()));
 		if (span.isExportable()) {
 			addAnnotations(this.traceKeys, initialMessage, span);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpRequestInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpRequestInjector.java
@@ -32,7 +32,7 @@ class HttpRequestInjector implements SpanInjector<HttpRequest> {
 
 	@Override
 	public void inject(Span span, HttpRequest carrier) {
-		setIdHeader(carrier, Span.TRACE_ID_NAME, span.getTraceId());
+		setHeader(carrier, Span.TRACE_ID_NAME, span.traceIdString());
 		setIdHeader(carrier, Span.SPAN_ID_NAME, span.getSpanId());
 		setHeader(carrier, Span.SAMPLED_NAME, span.isExportable() ? Span.SPAN_SAMPLED : Span.SPAN_NOT_SAMPLED);
 		setHeader(carrier, Span.SPAN_NAME_NAME, span.getName());

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/RequestContextInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/RequestContextInjector.java
@@ -41,7 +41,7 @@ class RequestContextInjector implements SpanInjector<RequestContext> {
 			return;
 		}
 		setHeader(requestHeaders, Span.SPAN_ID_NAME, span.getSpanId());
-		setHeader(requestHeaders, Span.TRACE_ID_NAME, span.getTraceId());
+		setHeader(requestHeaders, Span.TRACE_ID_NAME, span.traceIdString());
 		setHeader(requestHeaders, Span.SPAN_NAME_NAME, span.getName());
 		setHeader(requestHeaders, Span.SAMPLED_NAME, span.isExportable() ?
 				Span.SPAN_SAMPLED : Span.SPAN_NOT_SAMPLED);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jSpanLogger.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jSpanLogger.java
@@ -49,7 +49,7 @@ public class Slf4jSpanLogger implements SpanLogger {
 	public void logStartedSpan(Span parent, Span span) {
 		MDC.put(Span.SPAN_ID_NAME, Span.idToHex(span.getSpanId()));
 		MDC.put(Span.SPAN_EXPORT_NAME, String.valueOf(span.isExportable()));
-		MDC.put(Span.TRACE_ID_NAME, Span.idToHex(span.getTraceId()));
+		MDC.put(Span.TRACE_ID_NAME, span.traceIdString());
 		log("Starting span: {}", span);
 		if (parent != null) {
 			log("With parent: {}", parent);
@@ -59,7 +59,7 @@ public class Slf4jSpanLogger implements SpanLogger {
 	@Override
 	public void logContinuedSpan(Span span) {
 		MDC.put(Span.SPAN_ID_NAME, Span.idToHex(span.getSpanId()));
-		MDC.put(Span.TRACE_ID_NAME, Span.idToHex(span.getTraceId()));
+		MDC.put(Span.TRACE_ID_NAME, span.traceIdString());
 		MDC.put(Span.SPAN_EXPORT_NAME, String.valueOf(span.isExportable()));
 		log("Continued span: {}", span);
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -17,7 +17,7 @@
 package org.springframework.cloud.sleuth;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +33,45 @@ import static org.assertj.core.api.BDDAssertions.then;
  * @author Spencer Gibb
  */
 public class SpanTests {
+	Span span = Span.builder().begin(1).end(2).name("http:name").traceId(1L).spanId(2L)
+			.remote(true).exportable(true).processId("process").build();
+
+	@Test
+	public void should_consider_trace_and_span_id_on_equals_and_hashCode() throws Exception {
+		Span span = Span.builder().traceId(1L).spanId(2L).build();
+		Span differentSpan = Span.builder().traceId(1L).spanId(3L).build();
+		Span withParent =Span.builder().traceId(1L).spanId(2L).parent(3L).build();
+
+		then(span).isEqualTo(withParent);
+		then(span).isNotEqualTo(differentSpan);
+		then(span.hashCode()).isNotEqualTo(differentSpan.hashCode());
+	}
+
+	@Test
+	public void should_have_toString_with_identifiers_and_export() throws Exception {
+		span = Span.builder().traceId(1L).spanId(2L).parent(3L).name("foo").build();
+
+		then(span).hasToString(
+				"[Trace: 0000000000000001, Span: 0000000000000002, Parent: 0000000000000003, exportable:true]");
+	}
+
+	@Test
+	public void should_have_toString_with_128bit_trace_id() throws Exception {
+		span = Span.builder().traceIdHigh(1L).traceId(2L).spanId(3L).parent(4L).build();
+
+		then(span.toString()).startsWith("[Trace: 00000000000000010000000000000002,");
+	}
+
+	@Test
+	public void should_consider_128bit_trace_and_span_id_on_equals_and_hashCode() throws Exception {
+		Span span = Span.builder().traceIdHigh(1L).traceId(2L).spanId(3L).build();
+		Span differentSpan = Span.builder().traceIdHigh(2L).traceId(2L).spanId(3L).build();
+		Span withParent = Span.builder().traceIdHigh(1L).traceId(2L).spanId(3L).parent(4L).build();
+
+		then(span).isEqualTo(withParent);
+		then(span).isNotEqualTo(differentSpan);
+		then(span.hashCode()).isNotEqualTo(differentSpan.hashCode());
+	}
 
 	@Test
 	public void should_convert_long_to_16_character_hex_string() throws Exception {
@@ -62,6 +101,36 @@ public class SpanTests {
 		then(someLong).isEqualTo(Span.hexToId(lower64Bits));
 	}
 
+	@Test
+	public void should_convert_offset_64bits_of_hex_string_to_long() throws Exception {
+		String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
+		String high64Bits = "463ac35c9f6413ad";
+
+		long someLong = Span.hexToId(hex128Bits, 0);
+
+		then(someLong).isEqualTo(Span.hexToId(high64Bits));
+	}
+
+	@Test
+	public void should_writeFixedLength64BitTraceId() throws Exception {
+		String traceId = span.traceIdString();
+
+		then(traceId).isEqualTo("0000000000000001");
+	}
+
+	@Test
+	public void should_writeFixedLength128BitTraceId() throws Exception {
+		String high128Bits = "463ac35c9f6413ad";
+		String low64Bits = "48485a3953bb6124";
+
+		span = Span.builder().traceIdHigh(Span.hexToId(high128Bits)).traceId(Span.hexToId(low64Bits))
+				.spanId(1L).name("foo").build();
+
+		String traceId = span.traceIdString();
+
+		then(traceId).isEqualTo(high128Bits + low64Bits);
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void should_throw_exception_when_null_string_is_to_be_converted_to_long() throws Exception {
 		Span.hexToId(null);
@@ -69,23 +138,15 @@ public class SpanTests {
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void getAnnotationsReadOnly() {
-		Span span = new Span(1, 2, "http:name", 1L, Collections.<Long>emptyList(), 2L, true,
-				true, "process");
-
 		span.tags().put("a", "b");
 	}
 
 	@Test(expected = UnsupportedOperationException.class)
 	public void getTimelineAnnotationsReadOnly() {
-		Span span = new Span(1, 2, "http:name", 1L, Collections.<Long>emptyList(), 2L, true,
-				true, "process");
-
 		span.logs().add(new Log(1, "1"));
 	}
 
 	@Test public void should_properly_serialize_object() throws JsonProcessingException {
-		Span span = new Span(1, 2, "http:name", 1L,
-				Collections.<Long>emptyList(), 2L, true, true, "process");
 		ObjectMapper objectMapper = new ObjectMapper();
 
 		String serializedName = objectMapper.writeValueAsString(span);
@@ -94,8 +155,6 @@ public class SpanTests {
 	}
 
 	@Test public void should_properly_serialize_logs() throws IOException {
-		Span span = new Span(1, 2, "http:name", 1L,
-				Collections.<Long>emptyList(), 2L, true, true, "process");
 		span.logEvent("cs");
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -108,8 +167,6 @@ public class SpanTests {
 	}
 
 	@Test public void should_properly_serialize_tags() throws IOException {
-		Span span = new Span(1, 2, "http:name", 1L,
-				Collections.<Long>emptyList(), 2L, true, true, "process");
 		span.tag("calculatedTax", "100");
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -128,7 +185,7 @@ public class SpanTests {
 
 	/** When going over a transport like spring-cloud-stream, we must retain the precise duration. */
 	@Test public void shouldSerializeDurationMicros() throws IOException {
-		Span span = Span.builder().traceId(1L).name("http:parent").remote(true).build();
+		Span span = Span.builder().traceId(1L).name("http:parent").build();
 		span.stop();
 
 		assertThat(span.getAccumulatedMicros())
@@ -144,5 +201,42 @@ public class SpanTests {
 
 		assertThat(deserialized.getAccumulatedMicros())
 				.isEqualTo(span.getAccumulatedMicros());
+	}
+
+	// Duration of 0 is confusing to plot and can be misinterpreted as null
+	@Test public void getAccumulatedMicros_roundsUpToOneWhenRunning() throws IOException {
+		AtomicLong nanoTime = new AtomicLong();
+
+		// starts the span, recording its initial tick as zero
+		Span span = new Span(Span.builder().name("http:name").traceId(1L).spanId(2L)) {
+			@Override long nanoTime() {
+				return nanoTime.get();
+			}
+		};
+
+		// When only 100 nanoseconds passed
+		nanoTime.set(100L);
+
+		// We round so that we don't confuse "not started" with a short span.
+		assertThat(span.getAccumulatedMicros()).isEqualTo(1L);
+	}
+
+	// Duration of 0 is confusing to plot and can be misinterpreted as null
+	@Test public void getAccumulatedMicros_roundsUpToOneWhenStopped() throws IOException {
+		final AtomicLong nanoTime = new AtomicLong();
+
+		// starts the span, recording its initial tick as zero
+		Span span = new Span(Span.builder().name("http:name").traceId(1L).spanId(2L)) {
+			@Override long nanoTime() {
+				return nanoTime.get();
+			}
+		};
+
+		// When only 100 nanoseconds passed
+		nanoTime.set(100L);
+		span.stop();
+
+		// We round so that we don't confuse "not started" with a short span.
+		assertThat(span.getAccumulatedMicros()).isEqualTo(1L);
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue410/Issue410Tests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue410/Issue410Tests.java
@@ -81,7 +81,7 @@ public class Issue410Tests {
 		try {
 			String response = this.restTemplate.getForObject("http://localhost:" + port() + "/without_pool", String.class);
 
-			then(response).isEqualTo(Span.idToHex(span.getTraceId()));
+			then(response).isEqualTo(span.traceIdString());
 			Awaitility.await().until(() -> {
 				then(this.asyncTask.getSpan().get()).isNotNull();
 				then(this.asyncTask.getSpan().get().getTraceId()).isEqualTo(span.getTraceId());
@@ -97,7 +97,7 @@ public class Issue410Tests {
 		try {
 			String response = this.restTemplate.getForObject("http://localhost:" + port() + "/with_pool", String.class);
 
-			then(response).isEqualTo(Span.idToHex(span.getTraceId()));
+			then(response).isEqualTo(span.traceIdString());
 			Awaitility.await().until(() -> {
 				then(this.asyncTask.getSpan().get()).isNotNull();
 				then(this.asyncTask.getSpan().get().getTraceId()).isEqualTo(span.getTraceId());
@@ -116,7 +116,7 @@ public class Issue410Tests {
 		try {
 			String response = this.restTemplate.getForObject("http://localhost:" + port() + "/completable", String.class);
 
-			then(response).isEqualTo(Span.idToHex(span.getTraceId()));
+			then(response).isEqualTo(span.traceIdString());
 			Awaitility.await().until(() -> {
 				then(this.asyncTask.getSpan().get()).isNotNull();
 				then(this.asyncTask.getSpan().get().getTraceId()).isEqualTo(span.getTraceId());
@@ -135,7 +135,7 @@ public class Issue410Tests {
 		try {
 			String response = this.restTemplate.getForObject("http://localhost:" + port() + "/taskScheduler", String.class);
 
-			then(response).isEqualTo(Span.idToHex(span.getTraceId()));
+			then(response).isEqualTo(span.traceIdString());
 			Awaitility.await().until(() -> {
 				then(this.asyncTask.getSpan().get()).isNotNull();
 				then(this.asyncTask.getSpan().get().getTraceId()).isEqualTo(span.getTraceId());
@@ -273,7 +273,7 @@ class Application {
 	public String withPool() {
 		log.info("Executing with pool.");
 		this.asyncTask.runWithPool();
-		return Span.idToHex(this.tracer.getCurrentSpan().getTraceId());
+		return this.tracer.getCurrentSpan().traceIdString();
 
 	}
 
@@ -281,19 +281,19 @@ class Application {
 	public String withoutPool() {
 		log.info("Executing without pool.");
 		this.asyncTask.runWithoutPool();
-		return Span.idToHex(this.tracer.getCurrentSpan().getTraceId());
+		return this.tracer.getCurrentSpan().traceIdString();
 	}
 
 	@RequestMapping("/completable")
 	public String completable() throws ExecutionException, InterruptedException {
 		log.info("Executing completable");
-		return Span.idToHex(this.asyncTask.completableFutures().getTraceId());
+		return this.asyncTask.completableFutures().traceIdString();
 	}
 
 	@RequestMapping("/taskScheduler")
 	public String taskScheduler() throws ExecutionException, InterruptedException {
 		log.info("Executing completable via task scheduler");
-		return Span.idToHex(this.asyncTask.taskScheduler().getTraceId());
+		return this.asyncTask.taskScheduler().traceIdString();
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
@@ -19,10 +19,10 @@ package org.springframework.cloud.sleuth.instrument.messaging;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-
 import org.junit.Test;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.messaging.Message;
+
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StringUtils;
@@ -54,6 +54,17 @@ public class MessagingSpanExtractorTests {
 		} catch (IllegalArgumentException e) {
 			then(e).hasMessageContaining("Malformed id");
 		}
+	}
+
+	@Test
+	public void should_parse_128bit_trace_id() {
+		String traceId128 = "463ac35c9f6413ad48485a3953bb6124";
+
+		Span span = this.extractor.joinTrace(
+				MessageBuilder.createMessage("",
+            headers(traceId128, randomId())));
+
+		then(span.traceIdString()).isEqualTo(traceId128);
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
@@ -79,7 +79,7 @@ public class HttpServletRequestExtractorTests {
 	}
 
 	@Test
-	public void should_downgrade_128bit_trace_id_by_dropping_high_bits() {
+	public void should_accept_128bit_trace_id() {
 		String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
 		String lower64Bits = "48485a3953bb6124";
 
@@ -90,6 +90,6 @@ public class HttpServletRequestExtractorTests {
 
 		Span span = this.extractor.joinTrace(this.request);
 
-		then(span.getTraceId()).isEqualTo(Span.hexToId(lower64Bits));
+		then(span.traceIdString()).isEqualTo(hex128Bits);
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceCustomFilterResponseInjectorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceCustomFilterResponseInjectorTests.java
@@ -119,7 +119,7 @@ public class TraceCustomFilterResponseInjectorTests {
 
 		@Override
 		public void inject(Span span, HttpServletResponse carrier) {
-			carrier.addHeader(Span.TRACE_ID_NAME, Span.idToHex(span.getTraceId()));
+			carrier.addHeader(Span.TRACE_ID_NAME, span.traceIdString());
 			carrier.addHeader(Span.SPAN_ID_NAME, Span.idToHex(span.getSpanId()));
 		}
 	}

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
@@ -99,6 +99,7 @@ final class ConvertToZipkinSpanList {
 				zipkinSpan.duration(calculateDurationInMicros(span));
 			}
 		}
+		zipkinSpan.traceIdHigh(span.getTraceIdHigh());
 		zipkinSpan.traceId(span.getTraceId());
 		if (span.getParents().size() > 0) {
 			if (span.getParents().size() > 1) {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
@@ -95,6 +95,7 @@ public class ZipkinSpanListener implements SpanReporter {
 				zipkinSpan.duration(calculateDurationInMicros(span));
 			}
 		}
+		zipkinSpan.traceIdHigh(span.getTraceIdHigh());
 		zipkinSpan.traceId(span.getTraceId());
 		if (span.getParents().size() > 0) {
 			if (span.getParents().size() > 1) {

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
@@ -216,6 +216,16 @@ public class ZipkinSpanListenerTests {
 	}
 
 	@Test
+	public void converts128BitTraceId() {
+		Span span = Span.builder().traceIdHigh(1L).traceId(2L).spanId(3L).name("foo").build();
+
+		zipkin.Span result = this.spanReporter.convert(span);
+
+		assertThat(result.traceIdHigh).isEqualTo(span.getTraceIdHigh());
+		assertThat(result.traceId).isEqualTo(span.getTraceId());
+	}
+
+	@Test
 	public void shouldReuseServerAddressTag() {
 		this.parent.logEvent(Constants.CLIENT_SEND);
 		this.parent.tag(Span.SPAN_PEER_SERVICE_TAG_NAME, "fooservice");


### PR DESCRIPTION
This supports 128-bit traces via a new field traceIdHigh, which matches
other zipkin implementations. In encoded form, the trace ID is simply
twice as long (32 hex characters).

With this change in, a 128-bit trace propagated will not be downgraded
to 64-bits when sending downstream, reporting to Zipkin or adding to
the logging context.

This will be followed by a change to support initiating 128-bit traces.