### PR TITLE
Starts 128-bit traces when spring.sleuth.traceId128=true (1.0.x backport)

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.autoconfig;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Sleuth settings
+ *
+ * @since 1.0.11
+ */
+@ConfigurationProperties("spring.sleuth")
+public class SleuthProperties {
+	/** When true, generate 128-bit trace IDs instead of 64-bit ones. */
+	private boolean traceId128 = false;
+
+	public boolean isTraceId128() {
+		return this.traceId128;
+	}
+
+	public void setTraceId128(boolean traceId128) {
+		this.traceId128 = traceId128;
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.autoconfig;
 
 import java.util.Random;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -44,8 +45,10 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConditionalOnProperty(value="spring.sleuth.enabled", matchIfMissing=true)
-@EnableConfigurationProperties(TraceKeys.class)
+@EnableConfigurationProperties({TraceKeys.class, SleuthProperties.class})
 public class TraceAutoConfiguration {
+	@Autowired
+	SleuthProperties properties;
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -65,7 +68,7 @@ public class TraceAutoConfiguration {
 			SpanNamer spanNamer, SpanLogger spanLogger,
 			SpanReporter spanReporter) {
 		return new DefaultTracer(sampler, random, spanNamer, spanLogger,
-				spanReporter);
+				spanReporter, this.properties.isTraceId128());
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015-2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.cloud.sleuth.autoconfig;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.log.SleuthLogAutoConfiguration;
+import org.springframework.cloud.sleuth.sampler.NeverSampler;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.EnvironmentTestUtils.addEnvironment;
+
+public class TraceAutoConfigurationTest {
+
+  AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+  @After
+  public void close() {
+    context.close();
+  }
+
+  @Test
+  public void defaultsTo64BitTraceId() {
+    context = new AnnotationConfigApplicationContext();
+    context.register(
+        PropertyPlaceholderAutoConfiguration.class,
+        SleuthLogAutoConfiguration.class,
+        TraceAutoConfiguration.class
+    );
+    context.refresh();
+    Tracer tracer = context.getBean(Tracer.class);
+
+    Span span = null;
+    try {
+      span = tracer.createSpan("foo", NeverSampler.INSTANCE);
+      assertThat(span.getTraceIdHigh()).isEqualTo(0L);
+      assertThat(span.getTraceId()).isNotEqualTo(0L);
+    } finally {
+      if (span != null){
+        tracer.close(span);
+      }
+    }
+  }
+
+  @Test
+  public void optInto128BitTraceId() {
+    addEnvironment(context, "spring.sleuth.traceId128:true");
+    context.register(
+        PropertyPlaceholderAutoConfiguration.class,
+        SleuthLogAutoConfiguration.class,
+        TraceAutoConfiguration.class
+    );
+    context.refresh();
+    Tracer tracer = context.getBean(Tracer.class);
+
+    Span span = null;
+    try {
+      span = tracer.createSpan("foo", NeverSampler.INSTANCE);
+      assertThat(span.getTraceIdHigh()).isNotEqualTo(0L);
+      assertThat(span.getTraceId()).isNotEqualTo(0L);
+    } finally {
+      if (span != null){
+        tracer.close(span);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds autoconfiguration to create 128-bit traces when
`spring.sleuth.traceId128=true`.

See #455