### PR TITLE
Custom HTTP status codes support

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -249,8 +249,8 @@ public class TraceFilter extends GenericFilterBean {
 		if (response.getStatus() == 0) {
 			return false;
 		}
-		HttpStatus httpStatus = HttpStatus.valueOf(response.getStatus());
-		return httpStatus.is2xxSuccessful() || httpStatus.is3xxRedirection();
+		HttpStatus.Series httpStatusSeries = HttpStatus.Series.valueOf(response.getStatus());
+		return httpStatusSeries == HttpStatus.Series.SUCCESSFUL || httpStatusSeries == HttpStatus.Series.REDIRECTION;
 	}
 
 	private Span getSpanFromAttribute(HttpServletRequest request) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -326,6 +326,32 @@ public class TraceFilterTests {
 	}
 
 	@Test
+	public void closesSpanWhenResponseStatusIs2xx() throws Exception {
+		this.request = builder().header(Span.SPAN_ID_NAME, PARENT_ID)
+				.header(Span.TRACE_ID_NAME, 20L).buildRequest(new MockServletContext());
+		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, this.spanReporter,
+				this.spanExtractor, this.httpTraceKeysInjector);
+		this.response.setStatus(200);
+
+		filter.doFilter(this.request, this.response, this.filterChain);
+
+		then(TestSpanContextHolder.getCurrentSpan()).isNull();
+	}
+
+	@Test
+	public void closesSpanWhenResponseStatusIs3xx() throws Exception {
+		this.request = builder().header(Span.SPAN_ID_NAME, PARENT_ID)
+				.header(Span.TRACE_ID_NAME, 20L).buildRequest(new MockServletContext());
+		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, this.spanReporter,
+				this.spanExtractor, this.httpTraceKeysInjector);
+		this.response.setStatus(302);
+
+		filter.doFilter(this.request, this.response, this.filterChain);
+
+		then(TestSpanContextHolder.getCurrentSpan()).isNull();
+	}
+
+	@Test
 	public void returns400IfSpanIsMalformedAndCreatesANewSpan() throws Exception {
 		this.request = builder().header(Span.SPAN_ID_NAME, "asd")
 				.header(Span.TRACE_ID_NAME, 20L).buildRequest(new MockServletContext());


### PR DESCRIPTION
Applications using custom HTTP status codes are currently having issues with Spring Cloud Sleuth.

`TraceFilter.httpStatusSuccessful()` is throwing an IllegalArgumentException on `HttpStatus.valueOf(response.getStatus())`.

This can be fixed by replacing in `TraceFilter.httpStatusSuccessful()`

```java
HttpStatus httpStatus = HttpStatus.valueOf(response.getStatus());
return httpStatus.is2xxSuccessful() || httpStatus.is3xxRedirection();
```
with
```java
HttpStatus.Series httpStatusSeries = HttpStatus.Series.valueOf(response.getStatus());
return httpStatusSeries == HttpStatus.Series.SUCCESSFUL || httpStatusSeries == HttpStatus.Series.REDIRECTION;
```