### PR TITLE
Continuing Spans

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -66,9 +66,9 @@ public class TraceAutoConfiguration {
 	@ConditionalOnMissingBean(Tracer.class)
 	public DefaultTracer sleuthTracer(Sampler sampler, Random random,
 			SpanNamer spanNamer, SpanLogger spanLogger,
-			SpanReporter spanReporter) {
+			SpanReporter spanReporter, TraceKeys traceKeys) {
 		return new DefaultTracer(sampler, random, spanNamer, spanLogger,
-				spanReporter, this.properties.isTraceId128());
+				spanReporter, this.properties.isTraceId128(), traceKeys);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceExecutor.java
@@ -62,7 +62,7 @@ public class LazyTraceExecutor implements Executor {
 				return;
 			}
 		}
-		this.delegate.execute(new LocalComponentTraceRunnable(this.tracer, traceKeys(), spanNamer(), command));
+		this.delegate.execute(new SpanContinuingTraceRunnable(this.tracer, traceKeys(), spanNamer(), command));
 	}
 
 	// due to some race conditions trace keys might not be ready yet

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SpanContinuingTraceCallable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SpanContinuingTraceCallable.java
@@ -42,7 +42,7 @@ public class SpanContinuingTraceCallable<V> extends TraceCallable<V> {
 	}
 
 	public SpanContinuingTraceCallable(Tracer tracer, TraceKeys traceKeys,
-			SpanNamer spanNamer, Callable<V> delegate, String name) {
+			SpanNamer spanNamer, String name, Callable<V> delegate) {
 		super(tracer, spanNamer, delegate, name);
 		this.traceCallable = new LocalComponentTraceCallable<>(tracer, traceKeys, spanNamer, name, delegate);
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SpanContinuingTraceCallable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SpanContinuingTraceCallable.java
@@ -31,7 +31,7 @@ import org.springframework.cloud.sleuth.Tracer;
  * @author Marcin Grzejszczak
  * @since 1.0.10
  */
-class SpanContinuingTraceCallable<V> extends TraceCallable<V> {
+public class SpanContinuingTraceCallable<V> extends TraceCallable<V> {
 
 	private final LocalComponentTraceCallable<V> traceCallable;
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SpanContinuingTraceRunnable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SpanContinuingTraceRunnable.java
@@ -29,7 +29,7 @@ import org.springframework.cloud.sleuth.Tracer;
  * @author Marcin Grzejszczak
  * @since 1.0.10
  */
-class SpanContinuingTraceRunnable extends TraceRunnable {
+public class SpanContinuingTraceRunnable extends TraceRunnable {
 
 	private final LocalComponentTraceRunnable traceRunnable;
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceContinuingCallable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceContinuingCallable.java
@@ -29,7 +29,9 @@ import org.springframework.cloud.sleuth.Tracer;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated as of 1.2 in favor of {@link SpanContinuingTraceCallable}
  */
+@Deprecated
 public class TraceContinuingCallable<V> extends TraceCallable<V> implements Callable<V> {
 
 	public TraceContinuingCallable(Tracer tracer, SpanNamer spanNamer, Callable<V> delegate) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
@@ -98,14 +98,14 @@ public class TraceableExecutorService implements ExecutorService {
 
 	@Override
 	public <T> Future<T> submit(Callable<T> task) {
-		Callable<T> c = new LocalComponentTraceCallable<>(tracer(), traceKeys(),
+		Callable<T> c = new SpanContinuingTraceCallable<>(tracer(), traceKeys(),
 				spanNamer(), this.spanName, task);
 		return this.delegate.submit(c);
 	}
 
 	@Override
 	public <T> Future<T> submit(Runnable task, T result) {
-		Runnable r = new LocalComponentTraceRunnable(tracer(), traceKeys(),
+		Runnable r = new SpanContinuingTraceRunnable(tracer(), traceKeys(),
 				spanNamer(), task, this.spanName);
 		return this.delegate.submit(r, result);
 	}
@@ -142,8 +142,8 @@ public class TraceableExecutorService implements ExecutorService {
 	private <T> Collection<? extends Callable<T>> wrapCallableCollection(Collection<? extends Callable<T>> tasks) {
 		List<Callable<T>> ts = new ArrayList<>();
 		for (Callable<T> task : tasks) {
-			if (!(task instanceof LocalComponentTraceCallable)) {
-				ts.add(new LocalComponentTraceCallable<>(tracer(), traceKeys(),
+			if (!(task instanceof SpanContinuingTraceCallable)) {
+				ts.add(new SpanContinuingTraceCallable<>(tracer(), traceKeys(),
 						spanNamer(), this.spanName, task));
 			}
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
@@ -44,25 +44,25 @@ public class TraceableScheduledExecutorService extends TraceableExecutorService 
 
 	@Override
 	public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-		Runnable r = new LocalComponentTraceRunnable(this.tracer, this.traceKeys, this.spanNamer, command);
+		Runnable r = new SpanContinuingTraceRunnable(this.tracer, this.traceKeys, this.spanNamer, command);
 		return getScheduledExecutorService().schedule(r, delay, unit);
 	}
 
 	@Override
 	public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-		Callable<V> c = new LocalComponentTraceCallable<>(this.tracer, this.traceKeys, this.spanNamer,  callable);
+		Callable<V> c = new SpanContinuingTraceCallable<>(this.tracer, this.traceKeys, this.spanNamer,  callable);
 		return getScheduledExecutorService().schedule(c, delay, unit);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-		Runnable r = new LocalComponentTraceRunnable(this.tracer, this.traceKeys, this.spanNamer,  command);
+		Runnable r = new SpanContinuingTraceRunnable(this.tracer, this.traceKeys, this.spanNamer,  command);
 		return getScheduledExecutorService().scheduleAtFixedRate(r, initialDelay, period, unit);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-		Runnable r = new LocalComponentTraceRunnable(this.tracer, this.traceKeys, this.spanNamer,  command);
+		Runnable r = new SpanContinuingTraceRunnable(this.tracer, this.traceKeys, this.spanNamer,  command);
 		return getScheduledExecutorService().scheduleWithFixedDelay(r, initialDelay, delay, unit);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -81,8 +81,8 @@ public class TraceWebAutoConfiguration {
 	}
 
 	@Bean
-	public TraceWebAspect traceWebAspect(Tracer tracer, SpanNamer spanNamer) {
-		return new TraceWebAspect(tracer, spanNamer);
+	public TraceWebAspect traceWebAspect(Tracer tracer, TraceKeys traceKeys, SpanNamer spanNamer) {
+		return new TraceWebAspect(tracer, spanNamer, traceKeys);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
@@ -66,7 +66,7 @@ public class DefaultTracer implements Tracer {
 
 	public DefaultTracer(Sampler defaultSampler, Random random, SpanNamer spanNamer,
 				SpanLogger spanLogger, SpanReporter spanReporter, TraceKeys traceKeys) {
-		this(defaultSampler, random, spanNamer, spanLogger, spanReporter, false, null);
+		this(defaultSampler, random, spanNamer, spanLogger, spanReporter, false, traceKeys);
 	}
 
 	public DefaultTracer(Sampler defaultSampler, Random random, SpanNamer spanNamer,

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/trace/DefaultTracer.java
@@ -18,13 +18,15 @@ package org.springframework.cloud.sleuth.trace;
 
 import java.util.Random;
 import java.util.concurrent.Callable;
+
 import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.cloud.sleuth.SpanReporter;
-import org.springframework.cloud.sleuth.TraceCallable;
-import org.springframework.cloud.sleuth.TraceRunnable;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.async.SpanContinuingTraceCallable;
+import org.springframework.cloud.sleuth.instrument.async.SpanContinuingTraceRunnable;
 import org.springframework.cloud.sleuth.log.SpanLogger;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 
@@ -46,21 +48,37 @@ public class DefaultTracer implements Tracer {
 
 	private final SpanReporter spanReporter;
 
+	private final TraceKeys traceKeys;
+
 	private final boolean traceId128;
 
+	@Deprecated
 	public DefaultTracer(Sampler defaultSampler, Random random, SpanNamer spanNamer,
 			SpanLogger spanLogger, SpanReporter spanReporter) {
 		this(defaultSampler, random, spanNamer, spanLogger, spanReporter, false);
 	}
 
+	@Deprecated
 	public DefaultTracer(Sampler defaultSampler, Random random, SpanNamer spanNamer,
 				SpanLogger spanLogger, SpanReporter spanReporter, boolean traceId128) {
+		this(defaultSampler, random, spanNamer, spanLogger, spanReporter, traceId128, null);
+	}
+
+	public DefaultTracer(Sampler defaultSampler, Random random, SpanNamer spanNamer,
+				SpanLogger spanLogger, SpanReporter spanReporter, TraceKeys traceKeys) {
+		this(defaultSampler, random, spanNamer, spanLogger, spanReporter, false, null);
+	}
+
+	public DefaultTracer(Sampler defaultSampler, Random random, SpanNamer spanNamer,
+				SpanLogger spanLogger, SpanReporter spanReporter, boolean traceId128,
+			TraceKeys traceKeys) {
 		this.defaultSampler = defaultSampler;
 		this.random = random;
 		this.spanNamer = spanNamer;
 		this.spanLogger = spanLogger;
 		this.spanReporter = spanReporter;
 		this.traceId128 = traceId128;
+		this.traceKeys = traceKeys != null ? traceKeys : new TraceKeys();
 	}
 
 	@Override
@@ -237,7 +255,7 @@ public class DefaultTracer implements Tracer {
 	@Override
 	public <V> Callable<V> wrap(Callable<V> callable) {
 		if (isTracing()) {
-			return new TraceCallable<>(this, this.spanNamer, callable);
+			return new SpanContinuingTraceCallable<>(this, this.traceKeys, this.spanNamer, callable);
 		}
 		return callable;
 	}
@@ -250,7 +268,7 @@ public class DefaultTracer implements Tracer {
 	@Override
 	public Runnable wrap(Runnable runnable) {
 		if (isTracing()) {
-			return new TraceRunnable(this, this.spanNamer, runnable);
+			return new SpanContinuingTraceRunnable(this, this.traceKeys, this.spanNamer, runnable);
 		}
 		return runnable;
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
@@ -258,7 +258,7 @@ public class SpringCloudSleuthDocTests {
 	public void should_wrap_callable_in_its_sleuth_representative() {
 		SpanNamer spanNamer = new DefaultSpanNamer();
 		Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(), spanNamer,
-				new NoOpSpanLogger(), new NoOpSpanReporter());
+				new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 		Span initialSpan = tracer.createSpan("initialSpan");
 		// tag::trace_callable[]
 		Callable<String> callable = new Callable<String>() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
@@ -33,8 +33,11 @@ import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanName;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.cloud.sleuth.TraceCallable;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.TraceRunnable;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.async.SpanContinuingTraceCallable;
+import org.springframework.cloud.sleuth.instrument.async.SpanContinuingTraceRunnable;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
@@ -117,7 +120,7 @@ public class SpringCloudSleuthDocTests {
 	}
 
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(), new DefaultSpanNamer(),
-			new NoOpSpanLogger(), new NoOpSpanReporter());
+			new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 
 	@Test
 	public void should_create_a_span_with_tracer() {
@@ -224,7 +227,7 @@ public class SpringCloudSleuthDocTests {
 	public void should_wrap_runnable_in_its_sleuth_representative() {
 		SpanNamer spanNamer = new DefaultSpanNamer();
 		Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(), spanNamer,
-				new NoOpSpanLogger(), new NoOpSpanReporter());
+				new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 		Span initialSpan = tracer.createSpan("initialSpan");
 		// tag::trace_runnable[]
 		Runnable runnable = new Runnable() {
@@ -246,8 +249,9 @@ public class SpringCloudSleuthDocTests {
 		// end::trace_runnable[]
 
 		then(traceRunnable).isExactlyInstanceOf(TraceRunnable.class);
-		then(traceRunnableFromTracer).isExactlyInstanceOf(TraceRunnable.class);
+		then(traceRunnableFromTracer).isExactlyInstanceOf(SpanContinuingTraceRunnable.class);
 		tracer.close(initialSpan);
+		then(this.tracer.getCurrentSpan()).isNull();
 	}
 
 	@Test
@@ -276,7 +280,7 @@ public class SpringCloudSleuthDocTests {
 		// end::trace_callable[]
 
 		then(traceCallable).isExactlyInstanceOf(TraceCallable.class);
-		then(traceCallableFromTracer).isExactlyInstanceOf(TraceCallable.class);
+		then(traceCallableFromTracer).isExactlyInstanceOf(SpanContinuingTraceCallable.class);
 		tracer.close(initialSpan);
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/LocalComponentTraceCallableTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/LocalComponentTraceCallableTest.java
@@ -33,11 +33,12 @@ import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 /**
  * @author Marcin Grzejszczak
  */
+@SuppressWarnings("unchecked")
 public class LocalComponentTraceCallableTest {
 
 	Span closedSpan;
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter()) {
+			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys()) {
 		@Override public Span close(Span span) {
 			LocalComponentTraceCallableTest.this.closedSpan = span;
 			return super.close(span);
@@ -46,7 +47,7 @@ public class LocalComponentTraceCallableTest {
 
 	@Test
 	public void should_delegate_to_callable_wrapped_in_a_local_component() throws Exception {
-		LocalComponentTraceCallable<String> callable = new LocalComponentTraceCallable<>(this.tracer, new TraceKeys(), new DefaultSpanNamer(),
+		SpanContinuingTraceCallable<String> callable = new SpanContinuingTraceCallable<>(this.tracer, new TraceKeys(), new DefaultSpanNamer(),
 				() -> "hello");
 
 		String response = callable.call();

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceCallableTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceCallableTests.java
@@ -14,6 +14,7 @@ import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanName;
 import org.springframework.cloud.sleuth.TraceCallable;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
@@ -28,7 +29,7 @@ public class TraceCallableTests {
 	ExecutorService executor = Executors.newSingleThreadExecutor();
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(),
 			new Random(), new DefaultSpanNamer(),
-			new NoOpSpanLogger(), new NoOpSpanReporter());
+			new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 
 	@After
 	public void clean() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnableTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnableTests.java
@@ -13,6 +13,7 @@ import org.springframework.cloud.sleuth.DefaultSpanNamer;
 import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanName;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.TraceRunnable;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
@@ -28,7 +29,7 @@ public class TraceRunnableTests {
 	ExecutorService executor = Executors.newSingleThreadExecutor();
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(),
 			new Random(), new DefaultSpanNamer(),
-			new NoOpSpanLogger(), new NoOpSpanReporter());
+			new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 
 	@After
 	public void cleanup() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
@@ -16,11 +16,6 @@
 
 package org.springframework.cloud.sleuth.instrument.async;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +29,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
 
 /**
  * @author Marcin Grzejszczak
@@ -53,46 +53,46 @@ public class TraceableScheduledExecutorServiceTest {
 	TraceableScheduledExecutorService traceableScheduledExecutorService;
 
 	@Test
-	public void should_schedule_a_local_component_trace_runnable() throws Exception {
+	public void should_schedule_a_trace_runnable() throws Exception {
 		this.traceableScheduledExecutorService.schedule(aRunnable(), 1L, TimeUnit.DAYS);
 
 		then(this.scheduledExecutorService).should().schedule(
 				BDDMockito
-						.<Runnable>argThat(instanceOf(LocalComponentTraceRunnable.class)),
+						.<Runnable>argThat(instanceOf(SpanContinuingTraceRunnable.class)),
 				anyLong(), any(TimeUnit.class));
 	}
 
 	@Test
-	public void should_schedule_a_local_component_trace_callable() throws Exception {
+	public void should_schedule_a_trace_callable() throws Exception {
 		this.traceableScheduledExecutorService.schedule(aCallable(), 1L, TimeUnit.DAYS);
 
 		then(this.scheduledExecutorService).should().schedule(
 				BDDMockito.<Callable<?>>argThat(
-						instanceOf(LocalComponentTraceCallable.class)),
+						instanceOf(SpanContinuingTraceCallable.class)),
 				anyLong(), any(TimeUnit.class));
 	}
 
 	@Test
-	public void should_schedule_at_fixed_rate_a_local_component_trace_runnable()
+	public void should_schedule_at_fixed_rate_a_trace_runnable()
 			throws Exception {
 		this.traceableScheduledExecutorService.scheduleAtFixedRate(aRunnable(), 1L, 1L,
 				TimeUnit.DAYS);
 
 		then(this.scheduledExecutorService).should().scheduleAtFixedRate(
 				BDDMockito
-						.<Runnable>argThat(instanceOf(LocalComponentTraceRunnable.class)),
+						.<Runnable>argThat(instanceOf(SpanContinuingTraceRunnable.class)),
 				anyLong(), anyLong(), any(TimeUnit.class));
 	}
 
 	@Test
-	public void should_schedule_with_fixed_delay_a_local_component_trace_runnable()
+	public void should_schedule_with_fixed_delay_a_trace_runnable()
 			throws Exception {
 		this.traceableScheduledExecutorService.scheduleWithFixedDelay(aRunnable(), 1L, 1L,
 				TimeUnit.DAYS);
 
 		then(this.scheduledExecutorService).should().scheduleWithFixedDelay(
 				BDDMockito
-						.<Runnable>argThat(instanceOf(LocalComponentTraceRunnable.class)),
+						.<Runnable>argThat(instanceOf(SpanContinuingTraceRunnable.class)),
 				anyLong(), anyLong(), any(TimeUnit.class));
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
@@ -48,7 +48,7 @@ public class SleuthHystrixConcurrencyStrategyTest {
 
 	ArrayListSpanAccumulator spanReporter = new ArrayListSpanAccumulator();
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-			new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanReporter);
+			new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanReporter, new TraceKeys());
 	TraceKeys traceKeys = new TraceKeys();
 
 	@Before

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/TraceCommandTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/TraceCommandTests.java
@@ -46,7 +46,7 @@ public class TraceCommandTests {
 
 	static final long EXPECTED_TRACE_ID = 1L;
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter());
+			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 
 	@Before
 	public void setup() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
@@ -48,7 +48,7 @@ public class TraceFilterMockChainIntegrationTests {
 
 	private Tracer tracer = new DefaultTracer(new AlwaysSampler(),
 			new Random(), new DefaultSpanNamer(),
-			new NoOpSpanLogger(), new NoOpSpanReporter());
+			new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 	private TraceKeys traceKeys = new TraceKeys();
 	private HttpTraceKeysInjector keysInjector = new HttpTraceKeysInjector(this.tracer, this.traceKeys);
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -82,7 +82,7 @@ public class TraceFilterTests {
 	public void init() {
 		initMocks(this);
 		this.tracer = new DefaultTracer(new DelegateSampler(), new Random(),
-				new DefaultSpanNamer(), this.spanLogger, this.spanReporter) {
+				new DefaultSpanNamer(), this.spanLogger, this.spanReporter, new TraceKeys()) {
 			@Override
 			public Span continueSpan(Span span) {
 				TraceFilterTests.this.span = super.continueSpan(span);

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncListenableTaskExecutorTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncListenableTaskExecutorTest.java
@@ -16,9 +16,6 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.Mockito.mock;
-
 import java.util.Random;
 import java.util.concurrent.Callable;
 
@@ -27,12 +24,16 @@ import org.mockito.BDDMockito;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
 import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.TraceCallable;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.TraceRunnable;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.core.task.AsyncListenableTaskExecutor;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Marcin Grzejszczak
@@ -41,7 +42,7 @@ public class TraceAsyncListenableTaskExecutorTest {
 
 	AsyncListenableTaskExecutor delegate = mock(AsyncListenableTaskExecutor.class);
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter()) {
+			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys()) {
 		@Override
 		public boolean isTracing() {
 			return true;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
@@ -66,7 +66,7 @@ public class TraceRestTemplateInterceptorIntegrationTests {
 	@Before
 	public void setup() {
 		this.tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator);
+				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator, new TraceKeys());
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
 				new TraceRestTemplateInterceptor(this.tracer, new ZipkinHttpSpanInjector(),
 						new HttpTraceKeysInjector(this.tracer, new TraceKeys()))));

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
@@ -69,7 +69,7 @@ public class TraceRestTemplateInterceptorTests {
 	@Before
 	public void setup() {
 		this.tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator);
+				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator, new TraceKeys());
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
 				new TraceRestTemplateInterceptor(this.tracer, new ZipkinHttpSpanInjector(),
 						new HttpTraceKeysInjector(this.tracer, new TraceKeys()))));

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignRetriesTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignRetriesTests.java
@@ -69,7 +69,7 @@ public class FeignRetriesTests {
 
 	ArrayListSpanAccumulator spanAccumulator = new ArrayListSpanAccumulator();
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(), new DefaultSpanNamer(),
-			new NoOpSpanLogger(), this.spanAccumulator);
+			new NoOpSpanLogger(), this.spanAccumulator, new TraceKeys());
 
 	@Before
 	@After

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientTests.java
@@ -60,7 +60,7 @@ public class TraceFeignClientTests {
 	ArrayListSpanAccumulator spanAccumulator = new ArrayListSpanAccumulator();
 	@Mock BeanFactory beanFactory;
 	Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(), new DefaultSpanNamer(),
-			new NoOpSpanLogger(), this.spanAccumulator);
+			new NoOpSpanLogger(), this.spanAccumulator, new TraceKeys());
 	@Mock Client client;
 	@InjectMocks TraceFeignClient traceFeignClient;
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilterTests.java
@@ -16,10 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import javax.servlet.http.HttpServletResponse;
 import java.util.Random;
-
-import com.netflix.zuul.context.RequestContext;
+import javax.servlet.http.HttpServletResponse;
 
 import org.junit.After;
 import org.junit.Before;
@@ -37,6 +35,8 @@ import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 
+import com.netflix.zuul.context.RequestContext;
+
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 /**
@@ -49,7 +49,7 @@ public class TracePostZuulFilterTests {
 	@Mock HttpServletResponse httpServletResponse;
 
 	private DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(),
-			new Random(), new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter());
+			new Random(), new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 
 	private TracePostZuulFilter filter = new TracePostZuulFilter(this.tracer, new TraceKeys());
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilterTests.java
@@ -16,12 +16,9 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
-
-import com.netflix.zuul.context.RequestContext;
-import com.netflix.zuul.monitoring.MonitoringHelper;
+import javax.servlet.http.HttpServletRequest;
 
 import org.junit.After;
 import org.junit.Before;
@@ -42,6 +39,9 @@ import org.springframework.cloud.sleuth.sampler.NeverSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 
+import com.netflix.zuul.context.RequestContext;
+import com.netflix.zuul.monitoring.MonitoringHelper;
+
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 /**
@@ -54,7 +54,7 @@ public class TracePreZuulFilterTests {
 	@Mock HttpServletRequest httpServletRequest;
 
 	private DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter());
+			new DefaultSpanNamer(), new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 
 	private TracePreZuulFilter filter = new TracePreZuulFilter(this.tracer, new ZipkinHttpSpanInjector(),
 			new HttpTraceKeysInjector(this.tracer, new TraceKeys()));

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/trace/DefaultTracerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/trace/DefaultTracerTests.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.sleuth.DefaultSpanNamer;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.cloud.sleuth.SpanReporter;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.log.SpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
@@ -69,7 +70,7 @@ public class DefaultTracerTests {
 	public void tracingWorks() {
 
 		DefaultTracer tracer = new DefaultTracer(NeverSampler.INSTANCE, new Random(),
-				new DefaultSpanNamer(), this.spanLogger, this.spanReporter);
+				new DefaultSpanNamer(), this.spanLogger, this.spanReporter, new TraceKeys());
 
 		Span span = tracer.createSpan(CREATE_SIMPLE_TRACE, new AlwaysSampler());
 		try {
@@ -103,7 +104,7 @@ public class DefaultTracerTests {
 	@Test
 	public void nonExportable() {
 		DefaultTracer tracer = new DefaultTracer(NeverSampler.INSTANCE, new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span span = tracer.createSpan(CREATE_SIMPLE_TRACE);
 		assertThat(span.isExportable()).isFalse();
 	}
@@ -111,7 +112,7 @@ public class DefaultTracerTests {
 	@Test
 	public void exportable() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span span = tracer.createSpan(CREATE_SIMPLE_TRACE);
 		assertThat(span.isExportable()).isTrue();
 	}
@@ -119,7 +120,7 @@ public class DefaultTracerTests {
 	@Test
 	public void exportableInheritedFromParent() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span span = tracer.createSpan(CREATE_SIMPLE_TRACE, NeverSampler.INSTANCE);
 		assertThat(span.isExportable()).isFalse();
 		Span child = tracer.createSpan(CREATE_SIMPLE_TRACE_SPAN_NAME + "/child", span);
@@ -129,7 +130,7 @@ public class DefaultTracerTests {
 	@Test
 	public void parentNotRemovedIfActiveOnJoin() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span parent = tracer.createSpan(CREATE_SIMPLE_TRACE);
 		Span span = tracer.createSpan(IMPORTANT_WORK_1, parent);
 		tracer.close(span);
@@ -139,7 +140,7 @@ public class DefaultTracerTests {
 	@Test
 	public void parentRemovedIfNotActiveOnJoin() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span parent = Span.builder().name(CREATE_SIMPLE_TRACE).traceId(1L).spanId(1L)
 				.build();
 		Span span = tracer.createSpan(IMPORTANT_WORK_1, parent);
@@ -150,7 +151,7 @@ public class DefaultTracerTests {
 	@Test
 	public void grandParentRestoredAfterAutoClose() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span grandParent = tracer.createSpan(CREATE_SIMPLE_TRACE);
 		Span parent = Span.builder().name(IMPORTANT_WORK_1).traceId(1L).spanId(1L)
 				.build();
@@ -162,7 +163,7 @@ public class DefaultTracerTests {
 	@Test
 	public void samplingIsRanAgainstChildSpanWhenThereIsNoParent() {
 		DefaultTracer tracer = new DefaultTracer(new NeverSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 
 		Span span = tracer.createChild(null, "childName");
 
@@ -172,7 +173,7 @@ public class DefaultTracerTests {
 	@Test
 	public void shouldUpdateLogsInSpanWhenItGetsContinued() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span span = Span.builder().name(IMPORTANT_WORK_1).traceId(1L).spanId(1L)
 				.build();
 		Span continuedSpan = tracer.continueSpan(span);
@@ -188,7 +189,7 @@ public class DefaultTracerTests {
 	@Test
 	public void shouldPropagateBaggageFromParentToChild() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span parent = Span.builder().name(IMPORTANT_WORK_1).traceId(1L).spanId(1L)
 				.baggage("foo", "bar").build();
 		Span child = tracer.createSpan("child", parent);
@@ -200,7 +201,7 @@ public class DefaultTracerTests {
 	@Test
 	public void shouldPropagateBaggageToContinuedSpan() {
 		DefaultTracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(),
-				this.spanNamer, this.spanLogger, this.spanReporter);
+				this.spanNamer, this.spanLogger, this.spanReporter, new TraceKeys());
 		Span parent = Span.builder().name(IMPORTANT_WORK_1).traceId(1L).spanId(1L)
 				.baggage("foo", "bar").build();
 		Span continuedSpan = tracer.continueSpan(parent);

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
@@ -7,6 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
+import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.metric.CounterServiceBasedSpanMetricReporter;
@@ -127,7 +128,7 @@ public class HttpZipkinSpanReporterTest {
 		AtomicReference<Span> receivedSpan = new AtomicReference<>();
 		Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(), new DefaultSpanNamer(),
 				new NoOpSpanLogger(), new ZipkinSpanListener(receivedSpan::set,
-				new ServerPropertiesEndpointLocator(new ServerProperties(), "foo")));
+				new ServerPropertiesEndpointLocator(new ServerProperties(), "foo")), new TraceKeys());
 		// tag::service_name[]
 		org.springframework.cloud.sleuth.Span newSpan = tracer.createSpan("redis");
 		try {


### PR DESCRIPTION
with this change we change the approach to continue spans (if they already exist) instead of starting new ones. The RPC spans would still be generated but Hystrix, Async, Callables / Runnables will reuse an existing span if there is one.

the scenarios are as follows:

Assuming that we have a trace X with span Y

* if you used `tracer.wrap(Callable)` or `trace.wrap(Runnable)` then:
  * previously you'd get a span Z created when the Callable / Runnable is executed
  * with this change you'll continue the span Y
* if you used a `HystrixCommand` then
  * previously you'd get a span Z together with added tags when the command got executed
  * with this change you'll continue the span Y and the tags will be added to span Y
* if you used a `ExecutorService` then
  * previously you'd get a span Z together with added tags when a method from `ExecutorService` got executed
  * with this change you'll continue the span Y and the tags will be added to span Y

Assuming that there was no span then everything will work as previously.

In order to create a new span you just have to create it manually. Example of creating a new span for an `@Async` annotated method.

```
// obviously you should inject via constructor ;)
@Autowired Tracer tracer;

@Async
public Future<String> foo() {
    Span span = tracer.createSpan("newSpan");
    try {
       // do your stuff
    } finally {
       this.tracer.close(span);
    }
}
```

fixes #174 

cc @adriancole @dsyer @ryanjbaxter @spencergibb 