### PR TITLE
Created @ConfigurationProperties classes and updated additional metadata

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
@@ -25,8 +25,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties("spring.sleuth")
 public class SleuthProperties {
+
+	private boolean enabled = true;
 	/** When true, generate 128-bit trace IDs instead of 64-bit ones. */
 	private boolean traceId128 = false;
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
 
 	public boolean isTraceId128() {
 		return this.traceId128;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/RxJavaAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/RxJavaAutoConfiguration.java
@@ -1,20 +1,17 @@
 package org.springframework.cloud.sleuth.instrument.rxjava;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.StringUtils;
 
 import rx.plugins.RxJavaSchedulersHook;
 
@@ -30,28 +27,13 @@ import rx.plugins.RxJavaSchedulersHook;
 @ConditionalOnBean(Tracer.class)
 @ConditionalOnClass(RxJavaSchedulersHook.class)
 @ConditionalOnProperty(value = "spring.sleuth.rxjava.schedulers.hook.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(SleuthRxJavaSchedulersProperties.class)
 public class RxJavaAutoConfiguration {
-
-	/**
-	 * Contains a list of thread names for which spans will not be sampled. Extracted to a constant
-	 * for readability reasons.
-	 */
-	private static final List<String> DEFAULT_IGNORED_THREADS = Arrays.asList("HystrixMetricPoller", "^RxComputation.*$");
 
 	@Bean
 	SleuthRxJavaSchedulersHook sleuthRxJavaSchedulersHook(Tracer tracer, TraceKeys traceKeys,
-			// Comma separated list of thread name matchers
-			@Value("${spring.sleuth.rxjava.schedulers.ignoredthreads:}") String threadsToSample) {
-		return new SleuthRxJavaSchedulersHook(tracer, traceKeys, threads(threadsToSample));
-	}
-
-	private List<String> threads(String threadsToSample) {
-		List<String> threads = new ArrayList<>();
-		if (StringUtils.isEmpty(threadsToSample)) {
-			threads.addAll(DEFAULT_IGNORED_THREADS);
-		} else {
-			threads.addAll(Arrays.asList(threadsToSample.split(",")));
-		}
-		return threads;
+			SleuthRxJavaSchedulersProperties sleuthRxJavaSchedulersProperties) {
+		return new SleuthRxJavaSchedulersHook(tracer, traceKeys,
+				Arrays.asList(sleuthRxJavaSchedulersProperties.getIgnoredthreads()));
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersProperties.java
@@ -1,0 +1,51 @@
+package org.springframework.cloud.sleuth.instrument.rxjava;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for RxJava tracing
+ *
+ * @author Arthur Gavlyukovskiy
+ * @since 1.0.12
+ */
+@ConfigurationProperties("spring.sleuth.rxjava.schedulers")
+public class SleuthRxJavaSchedulersProperties {
+
+	/**
+	 * Thread names for which spans will not be sampled.
+	 */
+	private String[] ignoredthreads = { "HystrixMetricPoller", "^RxComputation.*$" };
+	private Hook hook;
+
+	public String[] getIgnoredthreads() {
+		return this.ignoredthreads;
+	}
+
+	public void setIgnoredthreads(String[] ignoredthreads) {
+		this.ignoredthreads = ignoredthreads;
+	}
+
+	public Hook getHook() {
+		return this.hook;
+	}
+
+	public void setHook(Hook hook) {
+		this.hook = hook;
+	}
+
+	private static class Hook {
+
+		/**
+		 * Enable support for RxJava via RxJavaSchedulersHook.
+		 */
+		private boolean enabled = true;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/SleuthSchedulingProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/SleuthSchedulingProperties.java
@@ -1,0 +1,39 @@
+package org.springframework.cloud.sleuth.instrument.scheduling;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for {@link org.springframework.scheduling.annotation.Scheduled} tracing
+ *
+ * @author Arthur Gavlyukovskiy
+ * @since 1.0.12
+ */
+@ConfigurationProperties("spring.sleuth.scheduled")
+public class SleuthSchedulingProperties {
+
+	/**
+	 * Enable tracing for {@link org.springframework.scheduling.annotation.Scheduled}.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * Pattern for the fully qualified name of a class that should be skipped.
+	 */
+	private String skipPattern = "";
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getSkipPattern() {
+		return this.skipPattern;
+	}
+
+	public void setSkipPattern(String skipPattern) {
+		this.skipPattern = skipPattern;
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
@@ -16,19 +16,19 @@
 
 package org.springframework.cloud.sleuth.instrument.scheduling;
 
-import java.util.regex.Pattern;
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import java.util.regex.Pattern;
 
 /**
  * Registers beans related to task scheduling.
@@ -44,17 +44,13 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
 @ConditionalOnBean(Tracer.class)
 @AutoConfigureAfter(TraceAutoConfiguration.class)
+@EnableConfigurationProperties(SleuthSchedulingProperties.class)
 public class TraceSchedulingAutoConfiguration {
-
-	/**
-	 * Pattern for the fully qualified name of a class that should be skipped
-	 */
-	private @Value("${spring.sleuth.scheduled.skipPattern:}") String skipPattern;
 
 	@ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
 	@Bean
-	public TraceSchedulingAspect traceSchedulingAspect(Tracer tracer, TraceKeys traceKeys) {
-		return new TraceSchedulingAspect(tracer, traceKeys, Pattern.compile(this.skipPattern));
+	public TraceSchedulingAspect traceSchedulingAspect(Tracer tracer, TraceKeys traceKeys,
+			SleuthSchedulingProperties sleuthSchedulingProperties) {
+		return new TraceSchedulingAspect(tracer, traceKeys, Pattern.compile(sleuthSchedulingProperties.getSkipPattern()));
 	}
-
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
@@ -1,0 +1,126 @@
+package org.springframework.cloud.sleuth.instrument.web;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration properties for web tracing
+ *
+ * @author Arthur Gavlyukovskiy
+ * @since 1.0.12
+ */
+@ConfigurationProperties("spring.sleuth.web")
+public class SleuthWebProperties {
+
+	public static final String DEFAULT_SKIP_PATTERN =
+			"/api-docs.*|/autoconfig|/configprops|/dump|/health|/info|/metrics.*|/mappings|/trace|/swagger.*|.*\\.png|.*\\.css|.*\\.js|.*\\.html|/favicon.ico|/hystrix.stream";
+
+	/**
+	 * When true enables instrumentation for web applications
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * Pattern for URLs that should be skipped in tracing
+	 */
+	private String skipPattern = DEFAULT_SKIP_PATTERN;
+
+	private Client client;
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getSkipPattern() {
+		return this.skipPattern;
+	}
+
+	public void setSkipPattern(String skipPattern) {
+		this.skipPattern = skipPattern;
+	}
+
+	public Client getClient() {
+		return this.client;
+	}
+
+	public void setClient(Client client) {
+		this.client = client;
+	}
+
+	public static class Client {
+
+		/**
+		 * Enable interceptor injecting into {@link org.springframework.web.client.RestTemplate}
+		 */
+		private boolean enabled = true;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+	}
+
+	public static class Async {
+
+		@NestedConfigurationProperty
+		private AsyncClient client;
+
+		public AsyncClient getClient() {
+			return this.client;
+		}
+
+		public void setClient(AsyncClient client) {
+			this.client = client;
+		}
+	}
+
+	public static class AsyncClient {
+
+		/**
+		 * Enable span information propagation for {@link org.springframework.http.client.AsyncClientHttpRequestFactory}.
+		 */
+		private boolean enabled;
+
+		@NestedConfigurationProperty
+		private Template template;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		public Template getTemplate() {
+			return this.template;
+		}
+
+		public void setTemplate(Template template) {
+			this.template = template;
+		}
+	}
+
+	public static class Template {
+
+		/**
+		 * Enable span information propagation for {@link org.springframework.web.client.AsyncRestTemplate}.
+		 */
+		private boolean enabled;
+
+		public boolean isEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -80,6 +80,12 @@ public class TraceFilter extends GenericFilterBean {
 	protected static final String TRACE_ERROR_HANDLED_REQUEST_ATTR = TraceFilter.class.getName()
 			+ ".ERROR_HANDLED";
 
+	/**
+	 * @deprecated please use {@link SleuthWebProperties#DEFAULT_SKIP_PATTERN}
+	 */
+	@Deprecated
+	public static final String DEFAULT_SKIP_PATTERN = SleuthWebProperties.DEFAULT_SKIP_PATTERN;
+
 	private final Tracer tracer;
 	private final TraceKeys traceKeys;
 	private final Pattern skipPattern;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -80,9 +80,6 @@ public class TraceFilter extends GenericFilterBean {
 	protected static final String TRACE_ERROR_HANDLED_REQUEST_ATTR = TraceFilter.class.getName()
 			+ ".ERROR_HANDLED";
 
-	public static final String DEFAULT_SKIP_PATTERN =
-			"/api-docs.*|/autoconfig|/configprops|/dump|/health|/info|/metrics.*|/mappings|/trace|/swagger.*|.*\\.png|.*\\.css|.*\\.js|.*\\.html|/favicon.ico|/hystrix.stream";
-
 	private final Tracer tracer;
 	private final TraceKeys traceKeys;
 	private final Pattern skipPattern;
@@ -95,7 +92,7 @@ public class TraceFilter extends GenericFilterBean {
 	public TraceFilter(Tracer tracer, TraceKeys traceKeys, SpanReporter spanReporter,
 			HttpSpanExtractor spanExtractor,
 			HttpTraceKeysInjector httpTraceKeysInjector) {
-		this(tracer, traceKeys, Pattern.compile(DEFAULT_SKIP_PATTERN), spanReporter,
+		this(tracer, traceKeys, Pattern.compile(SleuthWebProperties.DEFAULT_SKIP_PATTERN), spanReporter,
 				spanExtractor, httpTraceKeysInjector);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -24,7 +24,6 @@ import static javax.servlet.DispatcherType.REQUEST;
 import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -61,14 +60,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @ConditionalOnWebApplication
 @ConditionalOnBean(Tracer.class)
 @AutoConfigureAfter(TraceAutoConfiguration.class)
-@EnableConfigurationProperties(TraceKeys.class)
+@EnableConfigurationProperties({TraceKeys.class, SleuthWebProperties.class})
 public class TraceWebAutoConfiguration {
-
-	/**
-	 * Pattern for URLs that should be skipped in tracing
-	 */
-	@Value("${spring.sleuth.web.skipPattern:}")
-	private String skipPattern;
 
 	/**
 	 * Nested config that configures Web MVC if it's present (without adding a runtime
@@ -121,9 +114,8 @@ public class TraceWebAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public HttpSpanExtractor httpSpanExtractor(
-			@Value("${spring.sleuth.web.skipPattern:}") String skipPattern) {
-		return new ZipkinHttpSpanExtractor(Pattern.compile(skipPattern));
+	public HttpSpanExtractor httpSpanExtractor(SleuthWebProperties sleuthWebProperties) {
+		return new ZipkinHttpSpanExtractor(Pattern.compile(sleuthWebProperties.getSkipPattern()));
 	}
 
 	@Bean
@@ -135,24 +127,20 @@ public class TraceWebAutoConfiguration {
 	@Configuration
 	@ConditionalOnClass(ManagementServerProperties.class)
 	@ConditionalOnMissingBean(SkipPatternProvider.class)
+	@EnableConfigurationProperties(SleuthWebProperties.class)
 	protected static class SkipPatternProviderConfig {
-
-		/**
-		 * Pattern for URLs that should be skipped in tracing
-		 */
-		@Value("${spring.sleuth.web.skipPattern:}")
-		private String skipPattern;
 
 		@Bean
 		@ConditionalOnBean(ManagementServerProperties.class)
 		public SkipPatternProvider skipPatternForManagementServerProperties(
-				final ManagementServerProperties managementServerProperties) {
+				final ManagementServerProperties managementServerProperties,
+				final SleuthWebProperties sleuthWebProperties) {
 			return new SkipPatternProvider() {
 				@Override
 				public Pattern skipPattern() {
 					return getPatternForManagementServerProperties(
 							managementServerProperties,
-							SkipPatternProviderConfig.this.skipPattern);
+							sleuthWebProperties);
 				}
 			};
 		}
@@ -163,7 +151,8 @@ public class TraceWebAutoConfiguration {
 		 */
 		static Pattern getPatternForManagementServerProperties(
 				ManagementServerProperties managementServerProperties,
-				String skipPattern) {
+				SleuthWebProperties sleuthWebProperties) {
+			String skipPattern = sleuthWebProperties.getSkipPattern();
 			if (StringUtils.hasText(skipPattern)
 					&& StringUtils.hasText(managementServerProperties.getContextPath())) {
 				return Pattern.compile(skipPattern + "|"
@@ -178,16 +167,16 @@ public class TraceWebAutoConfiguration {
 
 		@Bean
 		@ConditionalOnMissingBean(ManagementServerProperties.class)
-		public SkipPatternProvider defaultSkipPatternBeanIfManagementServerPropsArePresent() {
-			return defaultSkipPatternProvider(this.skipPattern);
+		public SkipPatternProvider defaultSkipPatternBeanIfManagementServerPropsArePresent(SleuthWebProperties sleuthWebProperties) {
+			return defaultSkipPatternProvider(sleuthWebProperties.getSkipPattern());
 		}
 	}
 
 	@Bean
 	@ConditionalOnMissingClass("org.springframework.boot.actuate.autoconfigure.ManagementServerProperties")
 	@ConditionalOnMissingBean(SkipPatternProvider.class)
-	public SkipPatternProvider defaultSkipPatternBean() {
-		return defaultSkipPatternProvider(this.skipPattern);
+	public SkipPatternProvider defaultSkipPatternBean(SleuthWebProperties sleuthWebProperties) {
+		return defaultSkipPatternProvider(sleuthWebProperties.getSkipPattern());
 	}
 
 	private static SkipPatternProvider defaultSkipPatternProvider(
@@ -202,7 +191,7 @@ public class TraceWebAutoConfiguration {
 
 	private static Pattern defaultSkipPattern(String skipPattern) {
 		return StringUtils.hasText(skipPattern) ? Pattern.compile(skipPattern)
-				: Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN);
+				: Pattern.compile(SleuthWebProperties.DEFAULT_SKIP_PATTERN);
 	}
 
 	interface SkipPatternProvider {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
@@ -17,11 +17,11 @@
 package org.springframework.cloud.sleuth.log;
 
 import org.slf4j.MDC;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,19 +40,15 @@ public class SleuthLogAutoConfiguration {
 
 	@Configuration
 	@ConditionalOnClass(MDC.class)
+	@EnableConfigurationProperties(SleuthSlf4jProperties.class)
 	protected static class Slf4jConfiguration {
-		/**
-		 * Name pattern for which span should not be printed in the logs
-		 */
-		@Value("${spring.sleuth.log.slf4j.nameSkipPattern:}")
-		private String nameSkipPattern;
 
 		@Bean
 		@ConditionalOnProperty(value = "spring.sleuth.log.slf4j.enabled", matchIfMissing = true)
 		@ConditionalOnMissingBean
-		public SpanLogger slf4jSpanLogger() {
+		public SpanLogger slf4jSpanLogger(SleuthSlf4jProperties sleuthSlf4jProperties) {
 			// Sets up MDC entries X-B3-TraceId and X-B3-SpanId
-			return new Slf4jSpanLogger(this.nameSkipPattern);
+			return new Slf4jSpanLogger(sleuthSlf4jProperties.getNameSkipPattern());
 		}
 
 		@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
@@ -1,0 +1,39 @@
+package org.springframework.cloud.sleuth.log;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for slf4j
+ *
+ * @author Arthur Gavlyukovskiy
+ * @since 1.0.12
+ */
+@ConfigurationProperties("spring.sleuth.log.slf4j")
+public class SleuthSlf4jProperties {
+
+	/**
+	 * Enable a {@link Slf4jSpanLogger} that prints tracing information in the logs.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * Name pattern for which span should not be printed in the logs.
+	 */
+	private String nameSkipPattern = "";
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getNameSkipPattern() {
+		return this.nameSkipPattern;
+	}
+
+	public void setNameSkipPattern(String nameSkipPattern) {
+		this.nameSkipPattern = nameSkipPattern;
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SleuthMetricProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SleuthMetricProperties.java
@@ -14,7 +14,7 @@ public class SleuthMetricProperties {
 	/**
 	 * Enable calculation of accepted and dropped spans through {@link org.springframework.boot.actuate.metrics.CounterService}
 	 */
-	private boolean enabled;
+	private boolean enabled = true;
 
 	private Span span = new Span();
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SleuthMetricProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/metric/SleuthMetricProperties.java
@@ -11,7 +11,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("spring.sleuth.metric")
 public class SleuthMetricProperties {
 
+	/**
+	 * Enable calculation of accepted and dropped spans through {@link org.springframework.boot.actuate.metrics.CounterService}
+	 */
 	private boolean enabled;
+
+	private Span span = new Span();
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -20,8 +25,6 @@ public class SleuthMetricProperties {
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
 	}
-
-	private Span span = new Span();
 
 	public Span getSpan() {
 		return this.span;

--- a/spring-cloud-sleuth-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-sleuth-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -10,5 +10,47 @@
     "type": "java.lang.Boolean",
     "description": "Enable Spring Integration sleuth instrumentation.",
     "defaultValue": true
+  },
+  {
+    "name": "spring.sleuth.integration.websockets.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable tracing for WebSockets.",
+    "defaultValue": true
+  },
+  {
+    "name": "spring.sleuth.async.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable instrumenting async related components so that the tracing information is passed between threads.",
+    "defaultValue": true
+  },
+  {
+    "name": "spring.sleuth.async.configurer.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable default AsyncConfigurer.",
+    "defaultValue": true
+  },
+  {
+    "name": "spring.sleuth.hystrix.strategy.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable custom HystrixConcurrencyStrategy that wraps all Callable instances into their Sleuth representative - the TraceCallable.",
+    "defaultValue": true
+  },
+  {
+    "name": "spring.sleuth.feign.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable span information propagation when using Feign.",
+    "defaultValue": true
+  },
+  {
+    "name": "spring.sleuth.feign.processor.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable post processor that wraps Feign Context in its tracing representations.",
+    "defaultValue": true
+  },
+  {
+    "name": "spring.sleuth.zuul.enabled",
+    "type": "java.lang.Boolean",
+    "description": "Enable span information propagation when using Zuul.",
+    "defaultValue": true
   }
 ]}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
@@ -31,40 +31,43 @@ public class SkipPatternProviderConfigTest {
 
 	@Test
 	public void should_combine_skip_pattern_and_management_context_when_they_are_both_not_empty() throws Exception {
-		String skipPattern = "foo.*|bar.*";
-
+		SleuthWebProperties sleuthWebProperties = new SleuthWebProperties();
+		sleuthWebProperties.setSkipPattern("foo.*|bar.*");
 		Pattern pattern = SkipPatternProviderConfig.getPatternForManagementServerProperties(
-				managementServerPropertiesWithContextPath(), skipPattern);
+				managementServerPropertiesWithContextPath(), sleuthWebProperties);
 
 		then(pattern.pattern()).isEqualTo("foo.*|bar.*|/management/context.*");
 	}
 
 	@Test
 	public void should_pick_skip_pattern_when_its_not_empty_and_management_context_is_empty() throws Exception {
-		String skipPattern = "foo.*|bar.*";
+		SleuthWebProperties sleuthWebProperties = new SleuthWebProperties();
+		sleuthWebProperties.setSkipPattern("foo.*|bar.*");
 
-		Pattern pattern = SkipPatternProviderConfig.getPatternForManagementServerProperties(new ManagementServerProperties(), skipPattern);
+		Pattern pattern = SkipPatternProviderConfig.getPatternForManagementServerProperties(new ManagementServerProperties(), sleuthWebProperties);
 
 		then(pattern.pattern()).isEqualTo("foo.*|bar.*");
 	}
 
 	@Test
 	public void should_pick_management_context_when_skip_patterns_is_empty_and_context_path_is_not() throws Exception {
-		String skipPattern = "";
+		SleuthWebProperties sleuthWebProperties = new SleuthWebProperties();
+		sleuthWebProperties.setSkipPattern("");
 
 		Pattern pattern = SkipPatternProviderConfig.getPatternForManagementServerProperties(
-				managementServerPropertiesWithContextPath(), skipPattern);
+				managementServerPropertiesWithContextPath(), sleuthWebProperties);
 
 		then(pattern.pattern()).isEqualTo("/management/context.*");
 	}
 
 	@Test
 	public void should_pick_default_pattern_when_both_management_context_and_skip_patterns_are_empty() throws Exception {
-		String skipPattern = "";
+		SleuthWebProperties sleuthWebProperties = new SleuthWebProperties();
+		sleuthWebProperties.setSkipPattern("");
 
-		Pattern pattern = SkipPatternProviderConfig.getPatternForManagementServerProperties(new ManagementServerProperties(), skipPattern);
+		Pattern pattern = SkipPatternProviderConfig.getPatternForManagementServerProperties(new ManagementServerProperties(), sleuthWebProperties);
 
-		then(pattern.pattern()).isEqualTo(TraceFilter.DEFAULT_SKIP_PATTERN);
+		then(pattern.pattern()).isEqualTo(SleuthWebProperties.DEFAULT_SKIP_PATTERN);
 	}
 
 	private ManagementServerProperties managementServerPropertiesWithContextPath() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
@@ -73,7 +73,7 @@ public class TraceFilterMockChainIntegrationTests {
 	@Test
 	public void startsNewTrace() throws Exception {
 		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, new NoOpSpanReporter(),
-				new ZipkinHttpSpanExtractor(Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN)),
+				new ZipkinHttpSpanExtractor(Pattern.compile(SleuthWebProperties.DEFAULT_SKIP_PATTERN)),
 				keysInjector);
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TestSpanContextHolder.getCurrentSpan());
@@ -85,7 +85,7 @@ public class TraceFilterMockChainIntegrationTests {
 		this.request = builder().header(Span.SPAN_ID_NAME, generator.nextLong())
 				.header(Span.TRACE_ID_NAME, generator.nextLong()).buildRequest(new MockServletContext());
 		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, new NoOpSpanReporter(),
-				new ZipkinHttpSpanExtractor(Pattern.compile(TraceFilter.DEFAULT_SKIP_PATTERN)),
+				new ZipkinHttpSpanExtractor(Pattern.compile(SleuthWebProperties.DEFAULT_SKIP_PATTERN)),
 				keysInjector);
 		filter.doFilter(this.request, this.response, this.filterChain);
 		assertNull(TestSpanContextHolder.getCurrentSpan());

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -65,7 +65,7 @@ public class TraceFilterTests {
 	@Mock SpanLogger spanLogger;
 	ArrayListSpanAccumulator spanReporter = new ArrayListSpanAccumulator();
 	HttpSpanExtractor spanExtractor = new ZipkinHttpSpanExtractor(Pattern
-			.compile(TraceFilter.DEFAULT_SKIP_PATTERN));
+			.compile(SleuthWebProperties.DEFAULT_SKIP_PATTERN));
 
 	private Tracer tracer;
 	private TraceKeys traceKeys = new TraceKeys();


### PR DESCRIPTION
As we discussed in https://github.com/spring-cloud/spring-cloud-sleuth/issues/477 and gitter I created configuration properties for all properties used in spring-sleuth-core. 
I have used additional-spring-configuration-metadata.json for single `enabled` properties.

In case of camel case property name it resolves both `skip-pattern` and `skipPattern`, but I'd rather update documentation to use conventional property names.
Also `spring.sleuth.rxjava.schedulers.ignoredthreads` looks strange without word separator, we can add new one called `ignored-threads` and deprecate old one, what do you say?`