### PR TITLE
Issue 403 - DNS lookups may impact performance for 1.0.x

### DIFF
--- a/spring-cloud-sleuth-stream/pom.xml
+++ b/spring-cloud-sleuth-stream/pom.xml
@@ -27,7 +27,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-commons</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/DiscoveryClientEndpointLocatorConfigurationTest.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/DiscoveryClientEndpointLocatorConfigurationTest.java
@@ -1,0 +1,94 @@
+package org.springframework.cloud.sleuth.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Matcin Wielgus
+ */
+public class DiscoveryClientEndpointLocatorConfigurationTest {
+    @Test
+    public void endpointLocatorShouldDefaultToServerPropertiesEndpointLocator() {
+        try (ConfigurableApplicationContext ctxt = new SpringApplication(
+                EmptyConfiguration.class).run("--spring.main.web_environment=false")) {
+            assertThat(ctxt.getBean(HostLocator.class))
+                    .isInstanceOf(ServerPropertiesHostLocator.class);
+        }
+    }
+
+    @Test
+    public void endpointLocatorShouldDefaultToServerPropertiesEndpointLocatorEvenWhenDiscoveryClientPresent() {
+        try (ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithDiscoveryClient.class)
+                .run("--spring.main.web_environment=false")) {
+            assertThat(ctxt.getBean(HostLocator.class))
+                    .isInstanceOf(ServerPropertiesHostLocator.class);
+        }
+    }
+
+    @Test
+    public void endpointLocatorShouldRespectExistingEndpointLocator() {
+        try (ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithCustomLocator.class)
+                .run("--spring.main.web_environment=false")) {
+            assertThat(ctxt.getBean(HostLocator.class))
+                    .isSameAs(ConfigurationWithCustomLocator.locator);
+        }
+    }
+
+    @Test
+    public void endpointLocatorShouldBeFallbackHavingEndpointLocatorWhenAskedTo() {
+        try (ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithDiscoveryClient.class).run(
+                "--spring.zipkin.discoveryLocalEndpointLocator=true",
+                "--spring.main.web_environment=false")) {
+            assertThat(ctxt.getBean(HostLocator.class))
+                    .isInstanceOf(DiscoveryClientHostLocator.class);
+        }
+    }
+
+    @Test
+    public void endpointLocatorShouldRespectExistingEndpointLocatorEvenWhenAskedToBeDiscovery() {
+        try (ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithDiscoveryClient.class,
+                ConfigurationWithCustomLocator.class).run(
+                "--spring.zipkin.discoveryLocalEndpointLocator=true",
+                "--spring.main.web_environment=false")) {
+            assertThat(ctxt.getBean(HostLocator.class))
+                    .isSameAs(ConfigurationWithCustomLocator.locator);
+        }
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class EmptyConfiguration {
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class ConfigurationWithDiscoveryClient {
+        @Bean
+        public DiscoveryClient getDiscoveryClient() {
+            return Mockito.mock(DiscoveryClient.class);
+        }
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class ConfigurationWithCustomLocator {
+        static HostLocator locator = Mockito.mock(HostLocator.class);
+
+        @Bean
+        public HostLocator getEndpointLocator() {
+            return locator;
+        }
+    }
+}

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/ServerPropertiesHostLocatorTests.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/ServerPropertiesHostLocatorTests.java
@@ -21,49 +21,57 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.commons.util.InetUtilsProperties;
 import org.springframework.cloud.sleuth.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerPropertiesHostLocatorTests {
+
+	public static final byte[] ADR1234 = { 1, 2, 3, 4 };
+
 	Span span = new Span(1, 3, "http:name", 1L, Collections.<Long>emptyList(), 2L, true, true,
 			"process");
 
 	@Test
-	public void portDefaultsTo8080() {
+	public void portDefaultsTo8080() throws UnknownHostException {
 		ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(
-				new ServerProperties(), "unknown", new ZipkinProperties());
+				new ServerProperties(), "unknown", new ZipkinProperties(),
+				localAddress(ADR1234));
 
 		assertThat(locator.locate(this.span).getPort()).isEqualTo((short) 8080);
 	}
 
 	@Test
-	public void portFromServerProperties() {
+	public void portFromServerProperties() throws UnknownHostException {
 		ServerProperties properties = new ServerProperties();
 		properties.setPort(1234);
 
 		ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(properties,
-				"unknown", new ZipkinProperties());
+				"unknown", new ZipkinProperties(),localAddress(ADR1234));
 
 		assertThat(locator.locate(this.span).getPort()).isEqualTo((short) 1234);
 	}
 
 	@Test
-	public void portDefaultsToLocalhost() {
+	public void portDefaultsToLocalhost() throws UnknownHostException {
 		ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(
-				new ServerProperties(), "unknown", new ZipkinProperties());
+				new ServerProperties(), "unknown", new ZipkinProperties(),
+						localAddress(ADR1234));
 
-		assertThat(locator.locate(this.span).getAddress()).isEqualTo("127.0.0.1");
+		assertThat(locator.locate(this.span).getAddress()).isEqualTo("1.2.3.4");
 	}
 
 	@Test
 	public void hostFromServerPropertiesIp() throws UnknownHostException {
 		ServerProperties properties = new ServerProperties();
-		properties.setAddress(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }));
+		properties.setAddress(InetAddress.getByAddress(ADR1234));
 
 		ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(properties,
-				"unknown", new ZipkinProperties());
+				"unknown", new ZipkinProperties(),localAddress(new byte[] { 1, 1, 1, 1 }));
 
 		assertThat(locator.locate(this.span).getAddress()).isEqualTo("1.2.3.4");
 	}
@@ -76,8 +84,15 @@ public class ServerPropertiesHostLocatorTests {
 		zipkinProperties.setName("foo");
 
 		ServerPropertiesHostLocator locator = new ServerPropertiesHostLocator(properties,
-				"unknown", zipkinProperties);
+				"unknown", zipkinProperties,localAddress(ADR1234));
 
 		assertThat(locator.locate(this.span).getServiceName()).isEqualTo("foo");
+	}
+
+	private InetUtils localAddress(byte[] address) throws UnknownHostException {
+		InetUtils mocked = Mockito.spy(new InetUtils(new InetUtilsProperties()));
+		Mockito.when(mocked.findFirstNonLoopbackAddress())
+				.thenReturn(InetAddress.getByAddress(address));
+		return mocked;
 	}
 }

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/SleuthStreamAutoConfigurationTest.java
@@ -10,6 +10,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.cloud.commons.util.UtilAutoConfiguration;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.log.SpanLogger;
@@ -120,7 +121,7 @@ public class SleuthStreamAutoConfigurationTest {
 	@Import({ SleuthStreamAutoConfiguration.class, TraceMetricsAutoConfiguration.class,
 			TestSupportBinderAutoConfiguration.class,
 			ChannelBindingAutoConfiguration.class, TraceAutoConfiguration.class,
-			PropertyPlaceholderAutoConfiguration.class })
+			PropertyPlaceholderAutoConfiguration.class, UtilAutoConfiguration.class })
 	public static class BaseConfiguration {
 		@Bean
 		SpanLogger spanLogger() {

--- a/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/StreamSpanListenerTests.java
+++ b/spring-cloud-sleuth-stream/src/test/java/org/springframework/cloud/sleuth/stream/StreamSpanListenerTests.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
+import org.springframework.cloud.commons.util.UtilAutoConfiguration;
 import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanReporter;
@@ -158,7 +159,7 @@ public class StreamSpanListenerTests {
 	@Import({ ZipkinTestConfiguration.class, SleuthStreamAutoConfiguration.class,
 			TraceMetricsAutoConfiguration.class, TestSupportBinderAutoConfiguration.class,
 			ChannelBindingAutoConfiguration.class, TraceAutoConfiguration.class,
-			PropertyPlaceholderAutoConfiguration.class })
+			PropertyPlaceholderAutoConfiguration.class, UtilAutoConfiguration.class })
 	protected static class TestConfiguration {
 	}
 

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -40,7 +40,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-commons</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/FallbackHavingEndpointLocator.java
@@ -1,7 +1,5 @@
 package org.springframework.cloud.sleuth.zipkin;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import zipkin.Endpoint;
@@ -13,8 +11,6 @@ import zipkin.Endpoint;
  * @since 1.0.0
  */
 public class FallbackHavingEndpointLocator implements EndpointLocator {
-
-	private final AtomicReference<Endpoint> cachedEndpoint = new AtomicReference<>();
 
 	private static final Log log = LogFactory.getLog(FallbackHavingEndpointLocator.class);
 
@@ -29,8 +25,7 @@ public class FallbackHavingEndpointLocator implements EndpointLocator {
 
 	@Override
 	public Endpoint local() {
-		this.cachedEndpoint.compareAndSet(null, endpoint());
-		return this.cachedEndpoint.get();
+		return endpoint();
 	}
 
 	private Endpoint endpoint() {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocator.java
@@ -17,11 +17,13 @@
 package org.springframework.cloud.sleuth.zipkin;
 
 import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
+import org.springframework.cloud.commons.util.InetUtilsProperties;
 import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.context.event.EventListener;
 import org.springframework.util.StringUtils;
@@ -47,20 +49,26 @@ public class ServerPropertiesEndpointLocator implements EndpointLocator {
 
 	private final ServerProperties serverProperties;
 	private final String appName;
+	private final InetUtils inetUtils;
 	private final ZipkinProperties zipkinProperties;
 	private Integer port;
 
 	@Deprecated
-	public ServerPropertiesEndpointLocator(ServerProperties serverProperties,
-			String appName) {
-		this(serverProperties, appName, new ZipkinProperties());
+	public ServerPropertiesEndpointLocator(ServerProperties serverProperties,String appName) {
+		this(serverProperties,appName,new ZipkinProperties(), null);
 	}
 
 	public ServerPropertiesEndpointLocator(ServerProperties serverProperties,
-			String appName, ZipkinProperties zipkinProperties) {
+			String appName, ZipkinProperties zipkinProperties, InetUtils inetUtils) {
 		this.serverProperties = serverProperties;
 		this.appName = appName;
 		this.zipkinProperties = zipkinProperties;
+		if (inetUtils == null){
+			this.inetUtils = new InetUtils(new InetUtilsProperties());
+		}
+		else {
+			this.inetUtils = inetUtils;
+		}
 	}
 
 	@Override
@@ -97,11 +105,12 @@ public class ServerPropertiesEndpointLocator implements EndpointLocator {
 	}
 
 	private int getAddress() {
-		if (this.serverProperties!=null && this.serverProperties.getAddress() != null) {
-			return InetUtils.getIpAddressAsInt(this.serverProperties.getAddress().getHostAddress());
+		if (this.serverProperties != null && this.serverProperties.getAddress() != null) {
+			return ByteBuffer.wrap(this.serverProperties.getAddress().getAddress())
+					.getInt();
 		}
 		else {
-			return 127 << 24 | 1;
+			return ByteBuffer.wrap(this.inetUtils.findFirstNonLoopbackAddress().getAddress()).getInt();
 		}
 	}
 }

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinAutoConfiguration.java
@@ -21,11 +21,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
@@ -70,7 +70,8 @@ public class ZipkinAutoConfiguration {
 	}
 
 	@Configuration
-	@ConditionalOnMissingClass("org.springframework.cloud.client.discovery.DiscoveryClient")
+	@ConditionalOnMissingBean(EndpointLocator.class)
+	@ConditionalOnProperty(value = "spring.zipkin.discoveryLocalEndpointLocator", havingValue = "false", matchIfMissing = true)
 	protected static class DefaultEndpointLocatorConfiguration {
 
 		@Autowired(required=false)
@@ -79,19 +80,24 @@ public class ZipkinAutoConfiguration {
 		@Autowired
 		private ZipkinProperties zipkinProperties;
 
+		@Autowired(required=false)
+		private InetUtils inetUtils;
+
 		@Value("${spring.application.name:unknown}")
 		private String appName;
 
 		@Bean
 		public EndpointLocator zipkinEndpointLocator() {
 			return new ServerPropertiesEndpointLocator(this.serverProperties, this.appName,
-					this.zipkinProperties);
+					this.zipkinProperties, this.inetUtils);
 		}
 
 	}
 
 	@Configuration
 	@ConditionalOnClass(DiscoveryClient.class)
+	@ConditionalOnMissingBean(EndpointLocator.class)
+	@ConditionalOnProperty(value = "spring.zipkin.discoveryLocalEndpointLocator", havingValue = "true")
 	protected static class DiscoveryClientEndpointLocatorConfiguration {
 
 		@Autowired(required=false)
@@ -99,6 +105,9 @@ public class ZipkinAutoConfiguration {
 
 		@Autowired
 		private ZipkinProperties zipkinProperties;
+
+		@Autowired(required=false)
+		private InetUtils inetUtils;
 
 		@Value("${spring.application.name:unknown}")
 		private String appName;
@@ -110,7 +119,7 @@ public class ZipkinAutoConfiguration {
 		public EndpointLocator zipkinEndpointLocator() {
 			return new FallbackHavingEndpointLocator(discoveryClientEndpointLocator(),
 					new ServerPropertiesEndpointLocator(this.serverProperties, this.appName,
-							this.zipkinProperties));
+							this.zipkinProperties, this.inetUtils));
 		}
 
 		private DiscoveryClientEndpointLocator discoveryClientEndpointLocator() {

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocatorConfigurationTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/DiscoveryClientEndpointLocatorConfigurationTest.java
@@ -1,0 +1,89 @@
+package org.springframework.cloud.sleuth.zipkin;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Matcin Wielgus
+ */
+public class DiscoveryClientEndpointLocatorConfigurationTest {
+
+    @Test
+    public void endpointLocatorShouldDefaultToServerPropertiesEndpointLocator() {
+        ConfigurableApplicationContext ctxt = new SpringApplication(
+                EmptyConfiguration.class).run();
+        assertThat(ctxt.getBean(EndpointLocator.class))
+                .isInstanceOf(ServerPropertiesEndpointLocator.class);
+        ctxt.close();
+    }
+
+    @Test
+    public void endpointLocatorShouldDefaultToServerPropertiesEndpointLocatorEvenWhenDiscoveryClientPresent() {
+        ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithDiscoveryClient.class).run();
+        assertThat(ctxt.getBean(EndpointLocator.class))
+                .isInstanceOf(ServerPropertiesEndpointLocator.class);
+        ctxt.close();
+    }
+
+    @Test
+    public void endpointLocatorShouldRespectExistingEndpointLocator() {
+        ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithCustomLocator.class).run();
+        assertThat(ctxt.getBean(EndpointLocator.class))
+                .isSameAs(ConfigurationWithCustomLocator.locator);
+        ctxt.close();
+    }
+
+    @Test
+    public void endpointLocatorShouldBeFallbackHavingEndpointLocatorWhenAskedTo() {
+        ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithDiscoveryClient.class).run("--spring.zipkin.discoveryLocalEndpointLocator=true");
+        assertThat(ctxt.getBean(EndpointLocator.class))
+                .isInstanceOf(FallbackHavingEndpointLocator.class);
+        ctxt.close();
+    }
+
+    @Test
+    public void endpointLocatorShouldRespectExistingEndpointLocatorEvenWhenAskedToBeDiscovery() {
+        ConfigurableApplicationContext ctxt = new SpringApplication(
+                ConfigurationWithDiscoveryClient.class,ConfigurationWithCustomLocator.class).run("--spring.zipkin.discoveryLocalEndpointLocator=true");
+        assertThat(ctxt.getBean(EndpointLocator.class))
+                .isSameAs(ConfigurationWithCustomLocator.locator);
+        ctxt.close();
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class EmptyConfiguration {
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class ConfigurationWithDiscoveryClient {
+        @Bean
+        public DiscoveryClient getDiscoveryClient() {
+            return Mockito.mock(DiscoveryClient.class);
+        }
+    }
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class ConfigurationWithCustomLocator {
+        static EndpointLocator locator = Mockito.mock(EndpointLocator.class);
+
+        @Bean
+        public EndpointLocator getEndpointLocator() {
+            return locator;
+        }
+    }
+
+}

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/HttpZipkinSpanReporterTest.java
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.commons.util.InetUtilsProperties;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
@@ -130,7 +132,7 @@ public class HttpZipkinSpanReporterTest {
 		Tracer tracer = new DefaultTracer(new AlwaysSampler(), new Random(), new DefaultSpanNamer(),
 				new NoOpSpanLogger(), new ZipkinSpanListener(receivedSpan::set,
 				new ServerPropertiesEndpointLocator(new ServerProperties(), "foo",
-						new ZipkinProperties())));
+						new ZipkinProperties(), new InetUtils(new InetUtilsProperties()))));
 		// tag::service_name[]
 		org.springframework.cloud.sleuth.Span newSpan = tracer.createSpan("redis");
 		try {

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocatorTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ServerPropertiesEndpointLocatorTests.java
@@ -20,46 +20,53 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.commons.util.InetUtilsProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ServerPropertiesEndpointLocatorTests {
 
+	public static final byte[] ADDRESS1234 = { 1, 2, 3, 4 };
+
 	@Test
-	public void portDefaultsTo8080() {
+	public void portDefaultsTo8080() throws UnknownHostException {
 		ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(
-				new ServerProperties(), "unknown", new ZipkinProperties());
+				new ServerProperties(), "unknown", new ZipkinProperties(),
+				localAddress(ADDRESS1234));
 
 		assertThat(locator.local().port).isEqualTo((short) 8080);
 	}
 
 	@Test
-	public void portFromServerProperties() {
+	public void portFromServerProperties() throws UnknownHostException {
 		ServerProperties properties = new ServerProperties();
 		properties.setPort(1234);
 
 		ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(
-				properties, "unknown", new ZipkinProperties());
+				properties, "unknown", new ZipkinProperties(),localAddress(ADDRESS1234));
 
 		assertThat(locator.local().port).isEqualTo((short) 1234);
 	}
 
 	@Test
-	public void portDefaultsToLocalhost() {
+	public void portDefaultsToLocalhost() throws UnknownHostException {
 		ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(
-				new ServerProperties(), "unknown", new ZipkinProperties());
+				new ServerProperties(), "unknown", new ZipkinProperties(), localAddress(ADDRESS1234));
 
-		assertThat(locator.local().ipv4).isEqualTo(127 << 24 | 1);
+		assertThat(locator.local().ipv4).isEqualTo(1 << 24 | 2 << 16 | 3 << 8 | 4);
 	}
 
 	@Test
 	public void hostFromServerPropertiesIp() throws UnknownHostException {
 		ServerProperties properties = new ServerProperties();
-		properties.setAddress(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }));
+		properties.setAddress(InetAddress.getByAddress(ADDRESS1234));
 
 		ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(
-				properties, "unknown", new ZipkinProperties());
+				properties, "unknown", new ZipkinProperties(),
+				localAddress(new byte[] { 4, 4, 4, 4 }));
 
 		assertThat(locator.local().ipv4).isEqualTo(1 << 24 | 2 << 16 | 3 << 8 | 4);
 	}
@@ -71,8 +78,15 @@ public class ServerPropertiesEndpointLocatorTests {
 		zipkinProperties.getService().setName("foo");
 
 		ServerPropertiesEndpointLocator locator = new ServerPropertiesEndpointLocator(
-				properties, "unknown", zipkinProperties);
+				properties, "unknown", zipkinProperties,localAddress(ADDRESS1234));
 
 		assertThat(locator.local().serviceName).isEqualTo("foo");
+	}
+
+	private InetUtils localAddress(byte[] address) throws UnknownHostException {
+		InetUtils mocked = Mockito.spy(new InetUtils(new InetUtilsProperties()));
+		Mockito.when(mocked.findFirstNonLoopbackAddress())
+				.thenReturn(InetAddress.getByAddress(address));
+		return mocked;
 	}
 }


### PR DESCRIPTION
Changes done according to discussion in https://github.com/spring-cloud/spring-cloud-sleuth/pull/404


Due to possible performance problems when DiscoveryClient gives nonexistent DNS name as local address Local endpoint is created from server properties by default.

Local Ip determined from spring.commons InetUtils.
To enable local endpoint resolution via service discovery, DiscoveryClient must be present and 'spring.zipkin.discoveryLocalEndpointLocator' should be set to true.
FallbackHavingEndpointLocator was caching and recreating EndpointLocator in the same time - removed the caching part.

Fixes gh-403