### PR TITLE
Add an option to use the X-B3-Flags header to override any sampling d…

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -28,12 +28,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * Class for gathering and reporting statistics about a block of execution.
@@ -82,6 +82,7 @@ public class Span implements SpanContext {
 	public static final String SPAN_NAME_NAME = "X-Span-Name";
 	public static final String SPAN_ID_NAME = "X-B3-SpanId";
 	public static final String SPAN_EXPORT_NAME = "X-Span-Export";
+	public static final String SPAN_FLAGS = "X-B3-Flags";
 	public static final String SPAN_BAGGAGE_HEADER_PREFIX = "baggage";
 	public static final Set<String> SPAN_HEADERS = new HashSet<>(
 			Arrays.asList(SAMPLED_NAME, PROCESS_ID_NAME, PARENT_ID_NAME, TRACE_ID_NAME,

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractor.java
@@ -31,8 +31,13 @@ public class HeaderBasedMessagingExtractor implements MessagingSpanTextMapExtrac
 				.traceIdHigh(traceId.length() == 32 ? Span.hexToId(traceId, 0) : 0)
 				.traceId(Span.hexToId(traceId))
 				.spanId(Span.hexToId(carrier.get(TraceMessageHeaders.SPAN_ID_NAME)));
-		spanBuilder.exportable(
+		String flags = carrier.get(TraceMessageHeaders.SPAN_FLAGS_NAME);
+		if (Span.SPAN_SAMPLED.equals(flags)) {
+			spanBuilder.exportable(true);
+		} else {
+			spanBuilder.exportable(
 				Span.SPAN_SAMPLED.equals(carrier.get(TraceMessageHeaders.SAMPLED_NAME)));
+		}
 		String processId = carrier.get(TraceMessageHeaders.PROCESS_ID_NAME);
 		String spanName = carrier.get(TraceMessageHeaders.SPAN_NAME_NAME);
 		if (spanName != null) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessageHeaders.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessageHeaders.java
@@ -32,6 +32,7 @@ public class TraceMessageHeaders {
 	public static final String PARENT_ID_NAME = "spanParentSpanId";
 	public static final String TRACE_ID_NAME = "spanTraceId";
 	public static final String SPAN_NAME_NAME = "spanName";
+	public static final String SPAN_FLAGS_NAME = "spanFlags";
 
 	static final String MESSAGE_SENT_FROM_CLIENT = "messageSent";
 	static final String HEADER_DELIMITER = "_";

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/ZipkinHttpSpanExtractor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/ZipkinHttpSpanExtractor.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.sleuth.instrument.web;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+import java.util.Random;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.LogFactory;
@@ -33,7 +34,10 @@ public class ZipkinHttpSpanExtractor implements HttpSpanExtractor {
 	@Override
 	public Span joinTrace(SpanTextMap textMap) {
 		Map<String, String> carrier = TextMapUtil.asMap(textMap);
-		if (carrier.get(Span.TRACE_ID_NAME) == null) {
+		boolean debug = Span.SPAN_SAMPLED.equals(carrier.get(Span.SPAN_FLAGS));
+		if (debug) {
+			generateIdIfMissing(carrier, Span.TRACE_ID_NAME);
+		} else if (carrier.get(Span.TRACE_ID_NAME) == null) {
 			// can't build a Span without trace id
 			return null;
 		}
@@ -46,6 +50,12 @@ public class ZipkinHttpSpanExtractor implements HttpSpanExtractor {
 		} catch (Exception e) {
 			log.error("Exception occurred while trying to extract span from carrier", e);
 			return null;
+		}
+	}
+
+	private void generateIdIfMissing(Map<String, String> carrier, String key) {
+		if (!carrier.containsKey(key)) {
+			carrier.put(key, Span.idToHex(new Random().nextLong()));
 		}
 	}
 
@@ -82,7 +92,10 @@ public class ZipkinHttpSpanExtractor implements HttpSpanExtractor {
 			span.parent(Span.hexToId(carrier.get(Span.PARENT_ID_NAME)));
 		}
 		span.remote(true);
-		if (skip) {
+		boolean debug = Span.SPAN_SAMPLED.equals(carrier.get(Span.SPAN_FLAGS));
+		if (debug) {
+			span.exportable(true);
+		} else if (skip) {
 			span.exportable(false);
 		}
 		for (Map.Entry<String, String> entry : carrier.entrySet()) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/ZipkinHttpSpanExtractor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/ZipkinHttpSpanExtractor.java
@@ -36,6 +36,8 @@ public class ZipkinHttpSpanExtractor implements HttpSpanExtractor {
 		Map<String, String> carrier = TextMapUtil.asMap(textMap);
 		boolean debug = Span.SPAN_SAMPLED.equals(carrier.get(Span.SPAN_FLAGS));
 		if (debug) {
+			// we're only generating Trace ID since if there's no Span ID will assume
+			// that it's equal to Trace ID
 			generateIdIfMissing(carrier, Span.TRACE_ID_NAME);
 		} else if (carrier.get(Span.TRACE_ID_NAME) == null) {
 			// can't build a Span without trace id

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
@@ -16,20 +16,17 @@
 
 package org.springframework.cloud.sleuth.assertions;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.assertj.core.api.AbstractAssert;
 import org.springframework.cloud.sleuth.Span;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -111,6 +108,16 @@ public class ListOfSpansAssert extends AbstractAssert<ListOfSpansAssert, ListOfS
 		return this;
 	}
 
+	public ListOfSpansAssert allSpansAreExportable() {
+		isNotNull();
+		printSpans();
+		if (!everySpanIsExportable()) {
+			failWithMessage("Expected spans \n <%s> \nto be exportable but there's at least "
+					+ "one which is not", spansToString());
+		}
+		return this;
+	}
+
 	private boolean spanWithKeyTagExists(String tagKey) {
 		for (Span span : this.actual.spans) {
 			if (span.tags().containsKey(tagKey)) {
@@ -136,6 +143,15 @@ public class ListOfSpansAssert extends AbstractAssert<ListOfSpansAssert, ListOfS
 			}
 		}
 		return exists;
+	}
+
+	private boolean everySpanIsExportable() {
+		for (Span span : this.actual.spans) {
+			if (!span.isExportable()) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private boolean hasBaggage(String baggageKey, String baggageValue) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SpanAssert.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SpanAssert.java
@@ -189,4 +189,14 @@ public class SpanAssert extends AbstractAssert<SpanAssert, Span> {
 		}
 		return this;
 	}
+
+	public SpanAssert isNotExportable() {
+		isNotNull();
+		if (this.actual.isExportable()) {
+			String message = "The span is NOT supposed to be exportable but it is!";
+			log.error(message);
+			failWithMessage(message);
+		}
+		return this;
+	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
@@ -85,6 +85,47 @@ public class HeaderBasedMessagingExtractorTests {
 		then(span).isNotExportable();
 	}
 
+	@Test
+	public void samplesWhenDebugFlagIsSetTo1RegardlessOfTraceAndSpanId() {
+		HeaderBasedMessagingExtractor extractor = new HeaderBasedMessagingExtractor();
+		SpanTextMap spanTextMap = spanTextMap();
+		spanTextMap.put(TraceMessageHeaders.SPAN_FLAGS_NAME, "1");
+
+		Span span = extractor.joinTrace(spanTextMap);
+
+		then(span).isExportable();
+		then(span.traceIdString()).isNotEmpty();
+		then(span.getSpanId()).isNotNull();
+	}
+
+	@Test
+	public void samplesWhenDebugFlagIsSetTo1AndOnlySpanIdIsSet() {
+		HeaderBasedMessagingExtractor extractor = new HeaderBasedMessagingExtractor();
+		SpanTextMap spanTextMap = spanTextMap();
+		spanTextMap.put(TraceMessageHeaders.SPAN_FLAGS_NAME, "1");
+		spanTextMap.put(TraceMessageHeaders.SPAN_ID_NAME, Span.idToHex(10L));
+
+		Span span = extractor.joinTrace(spanTextMap);
+
+		then(span).isExportable();
+		then(span.traceIdString()).isNotEmpty();
+		then(span.getSpanId()).isEqualTo(10L);
+	}
+
+	@Test
+	public void samplesWhenDebugFlagIsSetTo1AndOnlyTraceIdIsSet() {
+		HeaderBasedMessagingExtractor extractor = new HeaderBasedMessagingExtractor();
+		SpanTextMap spanTextMap = spanTextMap();
+		spanTextMap.put(TraceMessageHeaders.SPAN_FLAGS_NAME, "1");
+		spanTextMap.put(TraceMessageHeaders.TRACE_ID_NAME, Span.idToHex(10L));
+
+		Span span = extractor.joinTrace(spanTextMap);
+
+		then(span).isExportable();
+		then(span.getTraceId()).isEqualTo(10L);
+		then(span.getSpanId()).isNotNull();
+	}
+
 	private SpanTextMap spanTextMap() {
 		return new SpanTextMap() {
 			private final Map<String, String> map = new HashMap<>();

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
@@ -123,7 +123,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		then(span).isExportable();
 		then(span.getTraceId()).isEqualTo(10L);
-		then(span.getSpanId()).isNotNull();
+		then(span.getSpanId()).isEqualTo(10L);
 	}
 
 	private SpanTextMap spanTextMap() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.messaging;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.junit.Test;
+import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.SpanTextMap;
+
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
+
+/**
+ * @author Marcin Grzejszczak
+ */
+public class HeaderBasedMessagingExtractorTests {
+
+	@Test
+	public void overridesTheSampleFlagWithSpanFlagForSampledScenario() {
+		HeaderBasedMessagingExtractor extractor = new HeaderBasedMessagingExtractor();
+		SpanTextMap spanTextMap = spanTextMap();
+		spanTextMap.put(TraceMessageHeaders.SPAN_ID_NAME, Span.idToHex(10L));
+		spanTextMap.put(TraceMessageHeaders.TRACE_ID_NAME, Span.idToHex(20L));
+		spanTextMap.put(TraceMessageHeaders.SAMPLED_NAME, "0");
+		spanTextMap.put(TraceMessageHeaders.SPAN_FLAGS_NAME, "1");
+
+		Span span = extractor.joinTrace(spanTextMap);
+
+		then(span).isExportable();
+	}
+
+	@Test
+	public void doesNotOverrideTheSampleHeaderWithSpanFlagWhenTheSpanFlagIsNot1() {
+		HeaderBasedMessagingExtractor extractor = new HeaderBasedMessagingExtractor();
+		SpanTextMap spanTextMap = spanTextMap();
+		spanTextMap.put(TraceMessageHeaders.SPAN_ID_NAME, Span.idToHex(10L));
+		spanTextMap.put(TraceMessageHeaders.TRACE_ID_NAME, Span.idToHex(20L));
+		spanTextMap.put(TraceMessageHeaders.SAMPLED_NAME, "1");
+		spanTextMap.put(TraceMessageHeaders.SPAN_FLAGS_NAME, "0");
+
+		Span span = extractor.joinTrace(spanTextMap);
+
+		then(span).isExportable();
+	}
+
+	@Test
+	public void samplesASpanWhenSampledFlagIsSetTo1() {
+		HeaderBasedMessagingExtractor extractor = new HeaderBasedMessagingExtractor();
+		SpanTextMap spanTextMap = spanTextMap();
+		spanTextMap.put(TraceMessageHeaders.SPAN_ID_NAME, Span.idToHex(10L));
+		spanTextMap.put(TraceMessageHeaders.TRACE_ID_NAME, Span.idToHex(20L));
+		spanTextMap.put(TraceMessageHeaders.SAMPLED_NAME, "1");
+
+		Span span = extractor.joinTrace(spanTextMap);
+
+		then(span).isExportable();
+	}
+
+	@Test
+	public void doesNotSampleASpanWhenSampledFlagIsSetTo0() {
+		HeaderBasedMessagingExtractor extractor = new HeaderBasedMessagingExtractor();
+		SpanTextMap spanTextMap = spanTextMap();
+		spanTextMap.put(TraceMessageHeaders.SPAN_ID_NAME, Span.idToHex(10L));
+		spanTextMap.put(TraceMessageHeaders.TRACE_ID_NAME, Span.idToHex(20L));
+		spanTextMap.put(TraceMessageHeaders.SAMPLED_NAME, "0");
+
+		Span span = extractor.joinTrace(spanTextMap);
+
+		then(span).isNotExportable();
+	}
+
+	private SpanTextMap spanTextMap() {
+		return new SpanTextMap() {
+			private final Map<String, String> map = new HashMap<>();
+
+			@Override public Iterator<Map.Entry<String, String>> iterator() {
+				return this.map.entrySet().iterator();
+			}
+
+			@Override public void put(String key, String value) {
+				this.map.put(key, value);
+			}
+		};
+	}
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -433,7 +433,7 @@ public class TraceFilterTests {
 	}
 
 	@Test
-	public void samplesWhenDebugFlagIsSetTo1AndOnlyTraceIdIsSet() throws Exception {
+	public void samplesWhenDebugFlagIsSetTo1AndTraceIdIsAlsoSet() throws Exception {
 		this.request = builder()
 				.header(Span.SPAN_FLAGS, 1)
 				.header(Span.TRACE_ID_NAME, 10L)

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -414,6 +414,42 @@ public class TraceFilterTests {
 		then(ExceptionUtils.getLastException()).isNull();
 	}
 
+	@Test
+	public void samplesWhenDebugFlagIsSetTo1AndOnlySpanIdIsSet() throws Exception {
+		this.request = builder()
+				.header(Span.SPAN_FLAGS, 1)
+				.header(Span.SPAN_ID_NAME, 10L)
+				.buildRequest(new MockServletContext());
+		this.sampler = new NeverSampler();
+		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, this.spanReporter,
+				this.spanExtractor, this.httpTraceKeysInjector);
+
+		filter.doFilter(this.request, this.response, this.filterChain);
+
+		then(new ListOfSpans(this.spanReporter.getSpans()))
+				.allSpansAreExportable().hasSize(2).hasASpanWithSpanId(Span.hexToId("10"));
+		then(TestSpanContextHolder.getCurrentSpan()).isNull();
+		then(ExceptionUtils.getLastException()).isNull();
+	}
+
+	@Test
+	public void samplesWhenDebugFlagIsSetTo1AndOnlyTraceIdIsSet() throws Exception {
+		this.request = builder()
+				.header(Span.SPAN_FLAGS, 1)
+				.header(Span.TRACE_ID_NAME, 10L)
+				.buildRequest(new MockServletContext());
+		this.sampler = new NeverSampler();
+		TraceFilter filter = new TraceFilter(this.tracer, this.traceKeys, this.spanReporter,
+				this.spanExtractor, this.httpTraceKeysInjector);
+
+		filter.doFilter(this.request, this.response, this.filterChain);
+
+		then(new ListOfSpans(this.spanReporter.getSpans()))
+				.allSpansAreExportable().allSpansHaveTraceId(Span.hexToId("10"));
+		then(TestSpanContextHolder.getCurrentSpan()).isNull();
+		then(ExceptionUtils.getLastException()).isNull();
+	}
+
 	public void verifyParentSpanHttpTags() {
 		verifyParentSpanHttpTags(HttpStatus.OK);
 	}

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/ConvertToZipkinSpanList.java
@@ -72,6 +72,7 @@ final class ConvertToZipkinSpanList {
 	 */
 	// VisibleForTesting
 	static zipkin.Span convert(Span span, Host host) {
+		//TODO: Consider adding support for the debug flag (related to #496)
 		Builder zipkinSpan = zipkin.Span.builder();
 
 		Endpoint ep = Endpoint.builder()

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
@@ -87,6 +87,7 @@ public class ZipkinSpanListener implements SpanReporter {
 	 */
 	// Visible for testing
 	zipkin.Span convert(Span span) {
+		//TODO: Consider adding support for the debug flag (related to #496)
 		zipkin.Span.Builder zipkinSpan = zipkin.Span.builder();
 
 		Endpoint endpoint = this.endpointLocator.local();


### PR DESCRIPTION
…ecision

without this change it's pretty much impossible to enforce sampling for certain traces
with this change setting the X-B3-Flags to 1 for HTTP messages / spanFlags to 1 for messaging will override any sampling decisions

fixes #496

cc @adriancole 