### PR TITLE
Add a new log method to span that allows for setting the time

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -344,6 +344,13 @@ public class Span implements SpanContext {
 	}
 
 	/**
+	 * Add a {@link Log#event event} to a specific point in the timeline associated with this span.
+	 */
+	public void logEvent(long timestamp, String event) {
+		this.logs.add(new Log(timestamp, event));
+	}
+
+	/**
 	 * Sets a baggage item in the Span (and its SpanContext) as a key/value pair.
 	 *
 	 * Baggage enables powerful distributed context propagation functionality where arbitrary application data can be

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -344,11 +344,11 @@ public class Span implements SpanContext {
 	}
 
 	/**
-	 * Add a {@link Log#event event} to a specific point (a timestamp in milleseconds) in the timeline
+	 * Add a {@link Log#event event} to a specific point (a timestamp in milliseconds) in the timeline
 	 * associated with this span.
 	 */
-	public void logEvent(long timestampMilleseconds, String event) {
-		this.logs.add(new Log(timestampMilleseconds, event));
+	public void logEvent(long timestampMilliseconds, String event) {
+		this.logs.add(new Log(timestampMilliseconds, event));
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -344,10 +344,11 @@ public class Span implements SpanContext {
 	}
 
 	/**
-	 * Add a {@link Log#event event} to a specific point in the timeline associated with this span.
+	 * Add a {@link Log#event event} to a specific point (a timestamp in milleseconds) in the timeline
+	 * associated with this span.
 	 */
-	public void logEvent(long timestamp, String event) {
-		this.logs.add(new Log(timestamp, event));
+	public void logEvent(long timestampMilleseconds, String event) {
+		this.logs.add(new Log(timestampMilleseconds, event));
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -340,7 +340,7 @@ public class Span implements SpanContext {
 	 * Add an {@link Log#event event} to the timeline associated with this span.
 	 */
 	public void logEvent(String event) {
-		this.logs.add(new Log(System.currentTimeMillis(), event));
+		logEvent(System.currentTimeMillis(), event);
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -166,6 +166,13 @@ public class SpanTests {
 				.isEqualTo(span.logs());
 	}
 
+	@Test public void can_log_with_generated_timestamp() throws IOException {
+		span.logEvent("event1");
+
+		long beforeLog = System.currentTimeMillis();
+		assertThat(span.logs().get(0).getTimestamp()).isGreaterThanOrEqualTo(beforeLog);
+	}
+
 	@Test public void can_log_with_specified_timestamp() throws IOException {
 		span.logEvent(1L, "event1");
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -166,6 +166,12 @@ public class SpanTests {
 				.isEqualTo(span.logs());
 	}
 
+	@Test public void can_log_with_specified_timestamp() throws IOException {
+		span.logEvent(1L, "event1");
+
+		then(span.logs().get(0).getTimestamp()).isEqualTo(1L);
+	}
+
 	@Test public void should_properly_serialize_tags() throws IOException {
 		span.tag("calculatedTax", "100");
 


### PR DESCRIPTION
I have a use case where we have the time where an event took place but not the ability to create the log as it happens. This method will allow us to still log those events to sleuth.

This also makes the OpenTracing adapter I am working on more feature complete so that is good too.