### PR TITLE
Fixing the moment when SS is set

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SpanCloser.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SpanCloser.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2013-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.web;
+
+import java.lang.invoke.MethodHandles;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.SpanReporter;
+import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.http.HttpStatus;
+
+/**
+ * A helper class to close spans
+ *
+ * @author Marcin Grzejszczak
+ */
+class SpanCloser {
+
+	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
+	private Tracer tracer;
+	private SpanReporter spanReporter;
+	// we want to share the logic of adding response tags between interceptor and filter
+	// also the add response tags method is protected and we want it to be consistent between
+	// filter / interceptors
+	private TraceFilter traceFilter;
+	private BeanFactory beanFactory;
+
+	SpanCloser(Tracer tracer, SpanReporter spanReporter, TraceFilter traceFilter) {
+		this.tracer = tracer;
+		this.spanReporter = spanReporter;
+		this.traceFilter = traceFilter;
+	}
+
+	SpanCloser(BeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
+	}
+
+	void detachOrCloseSpans(HttpServletRequest request,
+			HttpServletResponse response, Span spanFromRequest, Throwable exception) {
+		Span span = spanFromRequest;
+		if (log.isDebugEnabled()) {
+			log.debug("Will try to detach or close " + span + "");
+		}
+		if (span != null) {
+			getTraceFilter().addResponseTags(response, exception);
+			if (span.hasSavedSpan() && requestHasAlreadyBeenHandled(request)) {
+				recordParentSpan(span.getSavedSpan());
+			} else if (!requestHasAlreadyBeenHandled(request)) {
+				if (log.isDebugEnabled()) {
+					log.debug("Closing the span " + span + " since the request wasn't handled");
+				}
+				span = getTracer().close(span);
+			}
+			recordParentSpan(span);
+			// in case of a response with exception status will close the span when exception dispatch is handled
+			// checking if tracing is in progress due to async / different order of view controller processing
+			if (httpStatusSuccessful(response) && getTracer().isTracing()) {
+				if (log.isDebugEnabled()) {
+					log.debug("Closing the span " + span + " since the response was successful");
+				}
+				getTracer().close(span);
+			} else if (errorAlreadyHandled(request) && getTracer().isTracing()) {
+				if (log.isDebugEnabled()) {
+					log.debug(
+							"Won't detach the span " + span + " since error has already been handled");
+				}
+			} else if (getTracer().isTracing()) {
+				if (log.isDebugEnabled()) {
+					log.debug("Detaching the span " + span + " since the response was unsuccessful");
+				}
+				getTracer().detach(span);
+			}
+		}
+	}
+
+	private void recordParentSpan(Span parent) {
+		if (parent == null) {
+			return;
+		}
+		if (parent.isRemote()) {
+			if (log.isDebugEnabled()) {
+				log.debug("Trying to send the parent span " + parent + " to Zipkin");
+			}
+			parent.stop();
+			parent.logEvent(Span.SERVER_SEND);
+			getSpanReporter().report(parent);
+		} else {
+			parent.logEvent(Span.SERVER_SEND);
+		}
+	}
+
+	private boolean requestHasAlreadyBeenHandled(HttpServletRequest request) {
+		return request.getAttribute(TraceRequestAttributes.HANDLED_SPAN_REQUEST_ATTR) != null;
+	}
+
+	private boolean errorAlreadyHandled(HttpServletRequest request) {
+		return Boolean.valueOf(
+				String.valueOf(request.getAttribute(TraceFilter.TRACE_ERROR_HANDLED_REQUEST_ATTR)));
+	}
+
+	private boolean httpStatusSuccessful(HttpServletResponse response) {
+		if (response.getStatus() == 0) {
+			return false;
+		}
+		HttpStatus.Series httpStatusSeries = HttpStatus.Series.valueOf(response.getStatus());
+		return httpStatusSeries == HttpStatus.Series.SUCCESSFUL || httpStatusSeries == HttpStatus.Series.REDIRECTION;
+	}
+
+
+	private Tracer getTracer() {
+		if (this.tracer == null) {
+			this.tracer = this.beanFactory.getBean(Tracer.class);
+		}
+		return this.tracer;
+	}
+
+	private TraceFilter getTraceFilter() {
+		if (this.traceFilter == null) {
+			this.traceFilter = this.beanFactory.getBean(TraceFilter.class);
+		}
+		return this.traceFilter;
+	}
+
+	private SpanReporter getSpanReporter() {
+		if (this.spanReporter == null) {
+			this.spanReporter = this.beanFactory.getBean(SpanReporter.class);
+		}
+		return this.spanReporter;
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -155,7 +155,14 @@ public class TraceFilter extends GenericFilterBean {
 				return;
 			}
 			spanFromRequest = createSpanIfRequestNotHandled(request, spanFromRequest, name, skip);
-			detachOrCloseSpans(request, response, spanFromRequest, exception);
+			if (!requestHasAlreadyBeenHandled(request)) {
+				if (log.isDebugEnabled() && !skip) {
+					log.debug("The request with uri [" + request.getRequestURI() + "] hasn't been handled by any of Sleuth's components. "
+							+ "That means that most likely you're using custom HandlerMappings and didn't add Sleuth's TraceHandlerInterceptor. "
+							+ "Sleuth will try to close that span");
+				}
+				detachOrCloseSpans(request, response, spanFromRequest, exception);
+			}
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHandlerInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHandlerInterceptor.java
@@ -25,10 +25,12 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.web.ErrorController;
 import org.springframework.cloud.sleuth.Span;
+import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.cloud.sleuth.util.SpanNameUtil;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
@@ -54,6 +56,7 @@ public class TraceHandlerInterceptor extends HandlerInterceptorAdapter {
 	private Tracer tracer;
 	private TraceKeys traceKeys;
 	private ErrorController errorController;
+	private SpanReporter spanReporter;
 
 	public TraceHandlerInterceptor(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
@@ -127,11 +130,8 @@ public class TraceHandlerInterceptor extends HandlerInterceptorAdapter {
 	@Override
 	public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
 			Object handler, Exception ex) throws Exception {
-		if (isErrorControllerRelated(request)) {
-			if (log.isDebugEnabled()) {
-				log.debug("Skipping closing of a span for error controller processing");
-			}
-			return;
+		if (log.isDebugEnabled()) {
+			log.debug("Executing after completion");
 		}
 		Span span = getRootSpanFromAttribute(request);
 		if (ex != null) {
@@ -140,6 +140,12 @@ public class TraceHandlerInterceptor extends HandlerInterceptorAdapter {
 				log.debug("Adding an error tag [" + errorMsg + "] to span " + span + "");
 			}
 			getTracer().addTag(Span.SPAN_ERROR_TAG_NAME, errorMsg);
+		}
+		if (isErrorControllerRelated(request)) {
+			if (log.isDebugEnabled()) {
+				log.debug("Skipping closing of a span for error controller processing");
+			}
+			return;
 		}
 		if (getNewSpanFromAttribute(request) != null) {
 			if (log.isDebugEnabled()) {
@@ -150,6 +156,7 @@ public class TraceHandlerInterceptor extends HandlerInterceptorAdapter {
 			getTracer().close(newSpan);
 			clearNewSpanCreatedAttribute(request);
 		}
+		detachOrCloseSpans(request, response, span, ex);
 	}
 
 	private Span getNewSpanFromAttribute(HttpServletRequest request) {
@@ -172,6 +179,86 @@ public class TraceHandlerInterceptor extends HandlerInterceptorAdapter {
 		request.removeAttribute(TraceRequestAttributes.NEW_SPAN_REQUEST_ATTR);
 	}
 
+	private void detachOrCloseSpans(HttpServletRequest request,
+			HttpServletResponse response, Span spanFromRequest, Throwable exception) {
+		Span span = spanFromRequest;
+		if (span != null) {
+			addResponseTags(response, exception);
+			if (span.hasSavedSpan() && requestHasAlreadyBeenHandled(request)) {
+				recordParentSpan(span.getSavedSpan());
+			} else if (!requestHasAlreadyBeenHandled(request)) {
+				span = this.tracer.close(span);
+			}
+			recordParentSpan(span);
+			// in case of a response with exception status will close the span when exception dispatch is handled
+			// checking if tracing is in progress due to async / different order of view controller processing
+			if (httpStatusSuccessful(response) && this.tracer.isTracing()) {
+				if (log.isDebugEnabled()) {
+					log.debug("Closing the span " + span + " since the response was successful");
+				}
+				this.tracer.close(span);
+			} else if (errorAlreadyHandled(request) && this.tracer.isTracing()) {
+				if (log.isDebugEnabled()) {
+					log.debug(
+							"Won't detach the span " + span + " since error has already been handled");
+				}
+			} else if (this.tracer.isTracing()) {
+				if (log.isDebugEnabled()) {
+					log.debug("Detaching the span " + span + " since the response was unsuccessful");
+				}
+				this.tracer.detach(span);
+			}
+		}
+	}
+
+	private void addResponseTags(HttpServletResponse response, Throwable e) {
+		int httpStatus = response.getStatus();
+		if (httpStatus == HttpServletResponse.SC_OK && e != null) {
+			// Filter chain threw exception but the response status may not have been set
+			// yet, so we have to guess.
+			this.tracer.addTag(this.traceKeys.getHttp().getStatusCode(),
+					String.valueOf(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+		}
+		// only tag valid http statuses
+		else if (httpStatus >= 100 && (httpStatus < 200) || (httpStatus > 399)) {
+			this.tracer.addTag(this.traceKeys.getHttp().getStatusCode(),
+					String.valueOf(response.getStatus()));
+		}
+	}
+
+	private void recordParentSpan(Span parent) {
+		if (parent == null) {
+			return;
+		}
+		if (parent.isRemote()) {
+			if (log.isDebugEnabled()) {
+				log.debug("Trying to send the parent span " + parent + " to Zipkin");
+			}
+			parent.stop();
+			parent.logEvent(Span.SERVER_SEND);
+			getSpanReporter().report(parent);
+		} else {
+			parent.logEvent(Span.SERVER_SEND);
+		}
+	}
+
+	private boolean requestHasAlreadyBeenHandled(HttpServletRequest request) {
+		return request.getAttribute(TraceRequestAttributes.HANDLED_SPAN_REQUEST_ATTR) != null;
+	}
+
+	private boolean errorAlreadyHandled(HttpServletRequest request) {
+		return Boolean.valueOf(
+				String.valueOf(request.getAttribute(TraceFilter.TRACE_ERROR_HANDLED_REQUEST_ATTR)));
+	}
+
+	private boolean httpStatusSuccessful(HttpServletResponse response) {
+		if (response.getStatus() == 0) {
+			return false;
+		}
+		HttpStatus.Series httpStatusSeries = HttpStatus.Series.valueOf(response.getStatus());
+		return httpStatusSeries == HttpStatus.Series.SUCCESSFUL || httpStatusSeries == HttpStatus.Series.REDIRECTION;
+	}
+
 	private Tracer getTracer() {
 		if (this.tracer == null) {
 			this.tracer = this.beanFactory.getBean(Tracer.class);
@@ -191,5 +278,12 @@ public class TraceHandlerInterceptor extends HandlerInterceptorAdapter {
 			this.errorController = this.beanFactory.getBean(ErrorController.class);
 		}
 		return this.errorController;
+	}
+
+	private SpanReporter getSpanReporter() {
+		if (this.spanReporter == null) {
+			this.spanReporter = this.beanFactory.getBean(SpanReporter.class);
+		}
+		return this.spanReporter;
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
@@ -18,14 +18,14 @@ package org.springframework.cloud.sleuth.instrument.zuul;
 
 import java.lang.invoke.MethodHandles;
 
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
 
 /**8
  * A post request {@link ZuulFilter} that publishes an event upon start of the filtering

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import com.netflix.zuul.ExecutionStatus;
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.ZuulFilterResult;
-import com.netflix.zuul.context.RequestContext;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
@@ -28,8 +27,10 @@ import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.instrument.web.TraceRequestAttributes;
 
-import java.lang.invoke.MethodHandles;
-import java.net.URI;
+import com.netflix.zuul.ExecutionStatus;
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.ZuulFilterResult;
+import com.netflix.zuul.context.RequestContext;
 
 /**
  * A pre request {@link ZuulFilter} that sets tracing related headers on the request

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
+import org.springframework.cloud.sleuth.instrument.web.TraceFilter;
 import org.springframework.cloud.sleuth.instrument.web.TraceRequestAttributes;
 
 import com.netflix.zuul.ExecutionStatus;
@@ -44,6 +45,8 @@ public class TracePreZuulFilter extends ZuulFilter {
 	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	private static final String ZUUL_COMPONENT = "zuul";
+	private static final String FORCE_SERVER_SPAN_CLOSING_REQUEST_ATTR = TraceFilter.class.getName()
+			+ ".FORCE_SERVER_SPAN_CLOSING";
 
 	private final Tracer tracer;
 	private final SpanInjector<RequestContext> spanInjector;
@@ -96,7 +99,7 @@ public class TracePreZuulFilter extends ZuulFilter {
 		return result;
 	}
 
-	// TraceFilter will not create the "fallback" span
+	// TraceFilter will not create the "fallback" span ...
 	private void markRequestAsHandled(RequestContext ctx) {
 		ctx.getRequest().setAttribute(TraceRequestAttributes.HANDLED_SPAN_REQUEST_ATTR, "true");
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulHandlerMappingBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulHandlerMappingBeanPostProcessor.java
@@ -22,7 +22,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.web.ErrorController;
+import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
+import org.springframework.cloud.netflix.zuul.web.ZuulController;
 import org.springframework.cloud.netflix.zuul.web.ZuulHandlerMapping;
 import org.springframework.cloud.sleuth.instrument.web.TraceHandlerInterceptor;
 
@@ -50,11 +54,34 @@ class TraceZuulHandlerMappingBeanPostProcessor implements BeanPostProcessor {
 			if (log.isDebugEnabled()) {
 				log.debug("Attaching trace interceptor to bean [" + beanName + "] of type [" + bean.getClass().getSimpleName() + "]");
 			}
-			ZuulHandlerMapping zuulHandlerMapping = (ZuulHandlerMapping) bean;
-			zuulHandlerMapping.setInterceptors(
-					new Object[] { new TraceHandlerInterceptor(this.beanFactory) });
+			RouteLocator routeLocator = this.beanFactory.getBean(RouteLocator.class);
+			ZuulController zuulController = this.beanFactory.getBean(ZuulController.class);
+			ZuulHandlerMappingWrapper wrapper = new ZuulHandlerMappingWrapper(routeLocator, zuulController);
+			wrapper.setErrorController(errorController());
+			wrapper.setInterceptors(new TraceHandlerInterceptor(this.beanFactory));
+			wrapper.forceRefresh();
+			return wrapper;
 		}
 		return bean;
+	}
+
+	private ErrorController errorController() {
+		try {
+			return this.beanFactory.getBean(ErrorController.class);
+		} catch (NoSuchBeanDefinitionException e) {
+			return null;
+		}
+	}
+
+	class ZuulHandlerMappingWrapper extends ZuulHandlerMapping {
+
+		public ZuulHandlerMappingWrapper(RouteLocator routeLocator, ZuulController zuul) {
+			super(routeLocator, zuul);
+		}
+
+		void forceRefresh() {
+			initInterceptors();
+		}
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulHandlerMappingBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulHandlerMappingBeanPostProcessor.java
@@ -75,7 +75,7 @@ class TraceZuulHandlerMappingBeanPostProcessor implements BeanPostProcessor {
 
 	class ZuulHandlerMappingWrapper extends ZuulHandlerMapping {
 
-		public ZuulHandlerMappingWrapper(RouteLocator routeLocator, ZuulController zuul) {
+		ZuulHandlerMappingWrapper(RouteLocator routeLocator, ZuulController zuul) {
 			super(routeLocator, zuul);
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
@@ -196,10 +196,10 @@ class RpcLogKeeper {
 	org.springframework.cloud.sleuth.Log cr;
 
 	void assertThatFullRpcCycleTookPlace() {
-		SleuthAssertions.assertThat(this.cs).describedAs("Client Send").isNotNull();
-		SleuthAssertions.assertThat(this.sr).describedAs("Server Received").isNotNull();
-		SleuthAssertions.assertThat(this.ss).describedAs("Server Send").isNotNull();
-		SleuthAssertions.assertThat(this.cr).describedAs("Client Received").isNotNull();
+		assertThat(this.cs).describedAs("Client Send").isNotNull();
+		assertThat(this.sr).describedAs("Server Received").isNotNull();
+		assertThat(this.ss).describedAs("Server Send").isNotNull();
+		assertThat(this.cr).describedAs("Client Received").isNotNull();
 	}
 
 	void assertThatRpcLogsTookPlaceInOrder() {
@@ -207,8 +207,8 @@ class RpcLogKeeper {
 		long srTimestamp = this.sr.getTimestamp();
 		long ssTimestamp = this.ss.getTimestamp();
 		long crTimestamp = this.cr.getTimestamp();
-		SleuthAssertions.assertThat(csTimestamp).as("CS happened before SR").isLessThan(srTimestamp);
-		SleuthAssertions.assertThat(srTimestamp).as("SR happened before SS").isLessThan(ssTimestamp);
-		SleuthAssertions.assertThat(ssTimestamp).as("SS happened before CR").isLessThan(crTimestamp);
+		assertThat(csTimestamp).as("CS happened before SR").isLessThanOrEqualTo(srTimestamp);
+		assertThat(srTimestamp).as("SR happened before SS").isLessThanOrEqualTo(ssTimestamp);
+		assertThat(ssTimestamp).as("SS happened before CR").isLessThanOrEqualTo(crTimestamp);
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/ListOfSpansAssert.java
@@ -196,10 +196,10 @@ class RpcLogKeeper {
 	org.springframework.cloud.sleuth.Log cr;
 
 	void assertThatFullRpcCycleTookPlace() {
-		assertThat(this.cs).describedAs("Client Send").isNotNull();
-		assertThat(this.sr).describedAs("Server Received").isNotNull();
-		assertThat(this.ss).describedAs("Server Send").isNotNull();
-		assertThat(this.cr).describedAs("Client Received").isNotNull();
+		assertThat(this.cs).describedAs("Client Send log").isNotNull();
+		assertThat(this.sr).describedAs("Server Received log").isNotNull();
+		assertThat(this.ss).describedAs("Server Send log").isNotNull();
+		assertThat(this.cr).describedAs("Client Received log").isNotNull();
 	}
 
 	void assertThatRpcLogsTookPlaceInOrder() {
@@ -207,8 +207,8 @@ class RpcLogKeeper {
 		long srTimestamp = this.sr.getTimestamp();
 		long ssTimestamp = this.ss.getTimestamp();
 		long crTimestamp = this.cr.getTimestamp();
-		assertThat(csTimestamp).as("CS happened before SR").isLessThanOrEqualTo(srTimestamp);
-		assertThat(srTimestamp).as("SR happened before SS").isLessThanOrEqualTo(ssTimestamp);
-		assertThat(ssTimestamp).as("SS happened before CR").isLessThanOrEqualTo(crTimestamp);
+		assertThat(csTimestamp).as("CS timestamp should be before SR timestamp").isLessThanOrEqualTo(srTimestamp);
+		assertThat(srTimestamp).as("SR timestamp should be before SS timestamp").isLessThanOrEqualTo(ssTimestamp);
+		assertThat(ssTimestamp).as("SS timestamp should be before CR timestamp").isLessThanOrEqualTo(crTimestamp);
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
@@ -75,8 +75,7 @@ public class TraceFilterWebIntegrationTests {
 				.hasASpanWithTagEqualTo("http.status_code", "500");
 		then(ExceptionUtils.getLastException()).isNull();
 		then(new ListOfSpans(this.accumulator.getSpans()))
-				.hasASpanWithTagEqualTo(Span.SPAN_ERROR_TAG_NAME,
-						"Request processing failed; nested exception is java.lang.RuntimeException: Throwing exception");
+				.hasASpanWithTagEqualTo(Span.SPAN_ERROR_TAG_NAME, "Throwing exception");
 	}
 
 	private int port() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/servererrors/FeignClientServerErrorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/servererrors/FeignClientServerErrorTests.java
@@ -98,8 +98,7 @@ public class FeignClientServerErrorTests {
 					.doesNotContain("Tried to close span but it is not the current span");
 			then(ExceptionUtils.getLastException()).isNull();
 			then(new ListOfSpans(this.listener.getEvents()))
-					.hasASpanWithTagEqualTo(Span.SPAN_ERROR_TAG_NAME,
-							"Request processing failed; nested exception is java.lang.RuntimeException: Internal Error");
+					.hasASpanWithTagEqualTo(Span.SPAN_ERROR_TAG_NAME, "Internal Error");
 		});
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 
@@ -67,6 +68,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import com.jayway.awaitility.Awaitility;
 import com.netflix.loadbalancer.BaseLoadBalancer;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
@@ -108,21 +110,23 @@ public class WebClientTests {
 	@SuppressWarnings("unchecked")
 	public void shouldCreateANewSpanWithClientSideTagsWhenNoPreviousTracingWasPresent(
 			ResponseEntityProvider provider) {
-		ResponseEntity<String> response = provider.get(this);
+		final ResponseEntity<String> response = provider.get(this);
 
-		then(getHeader(response, Span.TRACE_ID_NAME)).isNull();
-		then(getHeader(response, Span.SPAN_ID_NAME)).isNull();
-		then(this.listener.getSpans()).isNotEmpty();
-		List<Span> spans = new ArrayList<>(this.listener.getSpans());
-		Optional<Span> noTraceSpan = spans.stream().filter(span ->
-				"http:/notrace".equals(span.getName()) && !span.tags().isEmpty()
-						&& span.tags().containsKey("http.path")).findFirst();
-		then(noTraceSpan.isPresent()).isTrue();
-		// TODO: matches cause there is an issue with Feign not providing the full URL at the interceptor level
-		then(noTraceSpan.get()).matchesATag("http.url", ".*/notrace")
-				.hasATag("http.path", "/notrace")
-				.hasATag("http.method", "GET");
-		then(new ListOfSpans(spans)).hasRpcTagsInProperOrder();
+		Awaitility.await().atMost(2, TimeUnit.SECONDS).until(() -> {
+			then(getHeader(response, Span.TRACE_ID_NAME)).isNull();
+			then(getHeader(response, Span.SPAN_ID_NAME)).isNull();
+			then(this.listener.getSpans()).isNotEmpty();
+			List<Span> spans = new ArrayList<>(this.listener.getSpans());
+			Optional<Span> noTraceSpan = spans.stream().filter(span ->
+					"http:/notrace".equals(span.getName()) && !span.tags().isEmpty()
+							&& span.tags().containsKey("http.path")).findFirst();
+			then(noTraceSpan.isPresent()).isTrue();
+			// TODO: matches cause there is an issue with Feign not providing the full URL at the interceptor level
+			then(noTraceSpan.get()).matchesATag("http.url", ".*/notrace")
+					.hasATag("http.path", "/notrace")
+					.hasATag("http.method", "GET");
+			then(new ListOfSpans(spans)).hasRpcTagsInProperOrder();
+		});
 	}
 
 	Object[] parametersForShouldCreateANewSpanWithClientSideTagsWhenNoPreviousTracingWasPresent() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
@@ -128,8 +128,8 @@ public class WebClientTests {
 	Object[] parametersForShouldCreateANewSpanWithClientSideTagsWhenNoPreviousTracingWasPresent() {
 		return $(
 				(ResponseEntityProvider) (tests) -> tests.testFeignInterface.getNoTrace(),
-				(ResponseEntityProvider) (tests) -> tests.template
-						.getForEntity("http://fooservice/notrace", String.class));
+				(ResponseEntityProvider) (tests) -> tests.template.getForEntity("http://fooservice/notrace", String.class)
+		);
 	}
 
 	@Test
@@ -345,8 +345,10 @@ public class WebClientTests {
 
 		@RequestMapping(value = "/notrace", method = RequestMethod.GET)
 		public String notrace(
-				@RequestHeader(name = Span.TRACE_ID_NAME, required = false) String traceId) {
+				@RequestHeader(name = Span.TRACE_ID_NAME, required = false) String traceId)
+				throws InterruptedException {
 			then(traceId).isNotNull();
+			Thread.sleep(10);
 			return "OK";
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
@@ -49,6 +49,7 @@ import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.assertions.ListOfSpans;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
@@ -112,7 +113,8 @@ public class WebClientTests {
 		then(getHeader(response, Span.TRACE_ID_NAME)).isNull();
 		then(getHeader(response, Span.SPAN_ID_NAME)).isNull();
 		then(this.listener.getSpans()).isNotEmpty();
-		Optional<Span> noTraceSpan = new ArrayList<>(this.listener.getSpans()).stream().filter(span ->
+		List<Span> spans = new ArrayList<>(this.listener.getSpans());
+		Optional<Span> noTraceSpan = spans.stream().filter(span ->
 				"http:/notrace".equals(span.getName()) && !span.tags().isEmpty()
 						&& span.tags().containsKey("http.path")).findFirst();
 		then(noTraceSpan.isPresent()).isTrue();
@@ -120,6 +122,7 @@ public class WebClientTests {
 		then(noTraceSpan.get()).matchesATag("http.url", ".*/notrace")
 				.hasATag("http.path", "/notrace")
 				.hasATag("http.method", "GET");
+		then(new ListOfSpans(spans)).hasRpcTagsInProperOrder();
 	}
 
 	Object[] parametersForShouldCreateANewSpanWithClientSideTagsWhenNoPreviousTracingWasPresent() {


### PR DESCRIPTION
without this change there's a problem with the time when the SS is set on a span. Currently it's done  in `TraceFilter`'s finally block. The problem is that this code is executed after the response has been sent back to the client. Thus CR sometimes was set faster than SS (it doesn't make any sense from the logical point of view).

with this change we move setting the SS on the span to the `TraceHandlerInterceptor`.  We leave the mechanism of `TraceFilter` stamping the span SS as a fallback one. That means that if for some reason the `TraceHandlerInterceptor` wasn't executed then we need to try to save the situation. 

also this change fixes ensures that the `TraceHandlerInterceptor` is available for Zuul. Until now even though we've added it to the list of interceptors it was never executed at runtime. That's why we're wrapping the `ZuulHandlerMapping` with our own wrapper and we're initializing the interceptors for it.

fixes #492 #431 