### PR TITLE
Display overriden service name in logs (addition to #487)

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
@@ -51,7 +51,7 @@ public class TraceEnvironmentPostProcessor implements EnvironmentPostProcessor {
 		// This doesn't work with all logging systems but it's a useful default so you see
 		// traces in logs without having to configure it.
 		map.put("logging.pattern.level",
-				"%clr(%5p) %clr([${spring.application.name:-},%X{X-B3-TraceId:-},%X{X-B3-SpanId:-},%X{X-Span-Export:-}]){yellow}");
+				"%clr(%5p) %clr([${spring.zipkin.service.name:${spring.application.name:-}},%X{X-B3-TraceId:-},%X{X-B3-SpanId:-},%X{X-Span-Export:-}]){yellow}");
 		map.put("spring.aop.proxyTargetClass", "true");
 		addOrReplace(environment.getPropertySources(), map);
 	}


### PR DESCRIPTION
Use `spring.zipkin.service.name` if present.