### PR TITLE
Fix incorrect comparison for sampling always

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/PercentageBasedSampler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/PercentageBasedSampler.java
@@ -37,9 +37,9 @@ public class PercentageBasedSampler implements Sampler {
 
 	@Override
 	public boolean isSampled(Span currentSpan) {
-		if (this.configuration.getPercentage() == 0 || currentSpan == null) {
+		if (this.configuration.getPercentage() < 0.01f || currentSpan == null) {
 			return false;
-		} else if (this.configuration.getPercentage() == 100) {
+		} else if (this.configuration.getPercentage() > 0.99f) {
 			return true;
 		}
 		synchronized (this) {


### PR DESCRIPTION
`percentage`is a `float`, where 1.0f means 100%