### PR TITLE
Moved adding annotated parameters from span creator to interceptor

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/DefaultSpanCreator.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/DefaultSpanCreator.java
@@ -37,12 +37,9 @@ class DefaultSpanCreator implements SpanCreator {
 	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
 	private final Tracer tracer;
-	private final SpanTagAnnotationHandler annotationHandler;
 
-	DefaultSpanCreator(Tracer tracer,
-			SpanTagAnnotationHandler annotationHandler) {
+	DefaultSpanCreator(Tracer tracer) {
 		this.tracer = tracer;
-		this.annotationHandler = annotationHandler;
 	}
 
 	@Override public Span createSpan(MethodInvocation pjp, NewSpan newSpanAnnotation) {
@@ -53,9 +50,7 @@ class DefaultSpanCreator implements SpanCreator {
 			log.debug("For the class [" + pjp.getThis().getClass() + "] method "
 					+ "[" + pjp.getMethod().getName() + "] will name the span [" + changedName + "]");
 		}
-		Span span = createSpan(changedName);
-		this.annotationHandler.addAnnotatedParameters(pjp);
-		return span;
+		return createSpan(changedName);
 	}
 
 	private Span createSpan(String name) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
@@ -248,9 +248,9 @@ class SleuthInterceptor  implements IntroductionInterceptor, BeanFactoryAware  {
 				span = spanCreator().createSpan(invocation, newSpan);
 			}
 			if (hasLog) {
-				spanTagAnnotationHandler().addAnnotatedParameters(invocation);
 				span.logEvent(log + ".start");
 			}
+			spanTagAnnotationHandler().addAnnotatedParameters(invocation);
 			return invocation.proceed();
 		} finally {
 			if (span != null) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAnnotationAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAnnotationAutoConfiguration.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.cloud.sleuth.annotation;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -23,7 +22,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -43,16 +41,10 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(SleuthAnnotationProperties.class)
 public class SleuthAnnotationAutoConfiguration {
 	
-	@Autowired private Tracer tracer;
-	
 	@Bean
 	@ConditionalOnMissingBean(SpanCreator.class)
-	SpanCreator spanCreator(ApplicationContext context) {
-		return new DefaultSpanCreator(this.tracer, spanTagAnnotationHandler(context));
-	}
-
-	private SpanTagAnnotationHandler spanTagAnnotationHandler(ApplicationContext context) {
-		return new SpanTagAnnotationHandler(context);
+	SpanCreator spanCreator(Tracer tracer) {
+		return new DefaultSpanCreator(tracer);
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAnnotationDisableTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAnnotationDisableTests.java
@@ -29,10 +29,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 		properties = "spring.sleuth.annotation.enabled=false")
 public class SleuthSpanCreatorAnnotationDisableTests {
 
-	@Autowired(required = false) SpanTagAnnotationHandler handler;
+	@Autowired(required = false) SpanCreator spanCreator;
 	
 	@Test
 	public void shouldNotAutowireBecauseConfigIsDisabled() {
-		assertThat(this.handler).isNull();
+		assertThat(this.spanCreator).isNull();
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAnnotationNoSleuthTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAnnotationNoSleuthTests.java
@@ -30,12 +30,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 		properties = "spring.sleuth.enabled=false")
 public class SleuthSpanCreatorAnnotationNoSleuthTests {
 
-	@Autowired(required = false) SpanTagAnnotationHandler handler;
+	@Autowired(required = false) SpanCreator spanCreator;
 	@Autowired(required = false) Tracer tracer;
 
 	@Test
 	public void shouldNotAutowireBecauseConfigIsDisabled() {
-		assertThat(this.handler).isNull();
+		assertThat(this.spanCreator).isNull();
 		assertThat(this.tracer).isNull();
 	}
 }


### PR DESCRIPTION
Also updated tests that were expecting missing `SpanTagAnnotationHandler` when `spring.sleuth.enabled` or `spring.sleuth.annotations.enabled` is false, because this one is not spring bean anymore