### PR TITLE
Adding error tag when exception occurs in SleuthInterceptor

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
@@ -252,6 +253,9 @@ class SleuthInterceptor  implements IntroductionInterceptor, BeanFactoryAware  {
 			}
 			spanTagAnnotationHandler().addAnnotatedParameters(invocation);
 			return invocation.proceed();
+		} catch (Exception e) {
+			tracer().addTag(Span.SPAN_ERROR_TAG_NAME, ExceptionUtils.getExceptionMessage(e));
+			throw e;
 		} finally {
 			if (span != null) {
 				if (hasLog) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
@@ -178,7 +178,7 @@ public class SleuthSpanCreatorAspectTests {
 		List<Span> spans = new ArrayList<>(this.accumulator.getSpans());
 		then(new ListOfSpans(spans)).hasSize(1)
 				.hasASpanWithName("test-method12")
-                .hasASpanWithTagEqualTo("testTag12", "test")
+				.hasASpanWithTagEqualTo("testTag12", "test")
 				.hasASpanWithTagEqualTo("error", "test exception 12");
 		then(ExceptionUtils.getLastException()).isNull();
 	}
@@ -323,7 +323,7 @@ public class SleuthSpanCreatorAspectTests {
 		public void testMethod13() {
 			throw new RuntimeException("test exception 13");
 		}
-    }
+	}
 	
 	@Configuration
 	@EnableAutoConfiguration

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
@@ -60,7 +60,7 @@ public class SleuthSpanCreatorAspectTests {
 		
 		List<Span> spans = new ArrayList<>(this.accumulator.getSpans());
 		then(new ListOfSpans(spans)).hasSize(1).hasASpanWithName("test-method");
-		BDDAssertions.then(ExceptionUtils.getLastException()).isNull();
+		then(ExceptionUtils.getLastException()).isNull();
 	}
 	
 	@Test
@@ -169,6 +169,39 @@ public class SleuthSpanCreatorAspectTests {
 	}
 
 	@Test
+	public void shouldAddErrorTagWhenExceptionOccurredInNewSpan() {
+		try {
+			this.testBean.testMethod12("test");
+		} catch (RuntimeException ignored) {
+		}
+
+		List<Span> spans = new ArrayList<>(this.accumulator.getSpans());
+		then(new ListOfSpans(spans)).hasSize(1)
+				.hasASpanWithName("test-method12")
+                .hasASpanWithTagEqualTo("testTag12", "test")
+				.hasASpanWithTagEqualTo("error", "test exception 12");
+		then(ExceptionUtils.getLastException()).isNull();
+	}
+
+	@Test
+	public void shouldAddErrorTagWhenExceptionOccurredInContinueSpan() {
+		Span span = this.tracer.createSpan("foo");
+		try {
+			this.testBean.testMethod13();
+		} catch (RuntimeException ignored) {
+		}
+		finally {
+			this.tracer.close(span);
+		}
+
+		List<Span> spans = new ArrayList<>(this.accumulator.getSpans());
+		then(new ListOfSpans(spans)).hasSize(1)
+				.hasASpanWithName("foo")
+				.hasASpanWithTagEqualTo("error", "test exception 13");
+		then(ExceptionUtils.getLastException()).isNull();
+	}
+
+	@Test
 	public void shouldNotCreateSpanWhenNotAnnotated() {
 		this.testBean.testMethod7();
 
@@ -215,6 +248,12 @@ public class SleuthSpanCreatorAspectTests {
 		@ContinueSpan(log = "testMethod11")
 		void testMethod11(@SpanTag("testTag11") String param);
 		// end::continue_span[]
+
+		@NewSpan
+		void testMethod12(@SpanTag("testTag12") String param);
+
+		@ContinueSpan(log = "testMethod13")
+		void testMethod13();
 	}
 	
 	protected static class TestBean implements TestBeanInterface {
@@ -274,7 +313,17 @@ public class SleuthSpanCreatorAspectTests {
 		public void testMethod11(@SpanTag("customTestTag11") String param) {
 
 		}
-	}
+
+		@Override
+		public void testMethod12(String param) {
+			throw new RuntimeException("test exception 12");
+		}
+
+		@Override
+		public void testMethod13() {
+			throw new RuntimeException("test exception 13");
+		}
+    }
 	
 	@Configuration
 	@EnableAutoConfiguration


### PR DESCRIPTION
I think it may be useful to have `error` tag if it was threw in annotated method.
Only one concern that we are rethrowing an exception and `error` tag will also be present in all parent spans created through annotation and span from web filter. WDYT?