### PR TITLE
Use HystrixFeign only if it's present on classpath

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
@@ -52,7 +52,7 @@ public class TraceFeignClientAutoConfiguration {
 
 	@Bean
 	@Scope("prototype")
-	@ConditionalOnClass(name = "com.netflix.hystrix.HystrixCommand")
+	@ConditionalOnClass(name = {"com.netflix.hystrix.HystrixCommand", "feign.hystrix.HystrixFeign"})
 	@ConditionalOnProperty(name = "feign.hystrix.enabled", matchIfMissing = true)
 	Feign.Builder feignHystrixBuilder(BeanFactory beanFactory) {
 		return SleuthHystrixFeignBuilder.builder(beanFactory);


### PR DESCRIPTION
Exactly like `HystrixFeignConfiguration`:
https://github.com/spring-cloud/spring-cloud-netflix/blob/c89645e0699342c55314e3ef7a2c6eb8b6ac90de/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/feign/FeignClientsConfiguration.java#L97