### PR TITLE
Making post zuul filter close the span on error

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -181,7 +181,9 @@ public class TraceFilter extends GenericFilterBean {
 		} finally {
 			request.setAttribute(TRACE_ERROR_HANDLED_REQUEST_ATTR, true);
 			addResponseTags(response, null);
-			this.tracer.close(spanFromRequest);
+			if (request.getAttribute(TraceRequestAttributes.ERROR_HANDLED_SPAN_REQUEST_ATTR) == null) {
+				this.tracer.close(spanFromRequest);
+			}
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceRequestAttributes.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceRequestAttributes.java
@@ -32,6 +32,13 @@ public final class TraceRequestAttributes {
 			+ ".TRACE_HANDLED";
 
 	/**
+	 * Attribute containing a {@link org.springframework.cloud.sleuth.Span} set on a request when it got handled by a Sleuth component.
+	 * If that attribute is set then {@link TraceFilter} will not close a span processed by the Error Controller.
+	 */
+	public static final String ERROR_HANDLED_SPAN_REQUEST_ATTR = TraceRequestAttributes.class.getName()
+			+ ".ERROR_TRACE_HANDLED";
+
+	/**
 	 * Set if Handler interceptor has executed some logic
 	 */
 	public static final String NEW_SPAN_REQUEST_ATTR = TraceRequestAttributes.class.getName()

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilter.java
@@ -18,14 +18,14 @@ package org.springframework.cloud.sleuth.instrument.zuul;
 
 import java.lang.invoke.MethodHandles;
 
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.context.RequestContext;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.context.RequestContext;
 
 /**8
  * A post request {@link ZuulFilter} that publishes an event upon start of the filtering
@@ -52,6 +52,7 @@ public class TracePostZuulFilter extends ZuulFilter {
 
 	@Override
 	public Object run() {
+		this.tracer.continueSpan(getCurrentSpan());
 		// TODO: the client sent event should come from the client not the filter!
 		getCurrentSpan().logEvent(Span.CLIENT_RECV);
 		if (log.isDebugEnabled()) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TracePreZuulFilter.java
@@ -16,10 +16,9 @@
 
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import com.netflix.zuul.ExecutionStatus;
-import com.netflix.zuul.ZuulFilter;
-import com.netflix.zuul.ZuulFilterResult;
-import com.netflix.zuul.context.RequestContext;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.Span;
@@ -28,8 +27,10 @@ import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.instrument.web.TraceRequestAttributes;
 
-import java.lang.invoke.MethodHandles;
-import java.net.URI;
+import com.netflix.zuul.ExecutionStatus;
+import com.netflix.zuul.ZuulFilter;
+import com.netflix.zuul.ZuulFilterResult;
+import com.netflix.zuul.context.RequestContext;
 
 /**
  * A pre request {@link ZuulFilter} that sets tracing related headers on the request
@@ -98,6 +99,7 @@ public class TracePreZuulFilter extends ZuulFilter {
 	// TraceFilter will not create the "fallback" span
 	private void markRequestAsHandled(RequestContext ctx) {
 		ctx.getRequest().setAttribute(TraceRequestAttributes.HANDLED_SPAN_REQUEST_ATTR, "true");
+		ctx.getRequest().setAttribute(TraceRequestAttributes.ERROR_HANDLED_SPAN_REQUEST_ATTR, "true");
 	}
 
 	private Span getCurrentSpan() {


### PR DESCRIPTION
without this change when dealing with Zuul, it's TraceFilter that is closing a span on error
with this change we're allowing the PostZuulFilter to close that span and TraceFilter doesn't interfere

fixes #563 

cc @brenuart 