### PR TITLE
Added the ErrorParser interface

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ErrorParser.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ErrorParser.java
@@ -1,8 +1,9 @@
 package org.springframework.cloud.sleuth;
 
 /**
- * Contract for parsing errors. For the given exception will produce a message
- * that will be then added as a {@link Span#SPAN_ERROR_TAG_NAME} tag to the Span.
+ * Contract for hooking into process of adding error response tags.
+ * This interface is only called when an exception is thrown upon receiving a response.
+ * (e.g. a response of 500 may not be an exception).
  *
  * @author Marcin Grzejszczak
  * @since 1.2.1
@@ -10,7 +11,10 @@ package org.springframework.cloud.sleuth;
 public interface ErrorParser {
 
 	/**
-	 * Returns a {@link String} representation of a {@link Throwable}
+	 * Allows setting of tags when an exception was thrown when the response was received.
+	 *
+	 * @param span - current span in context
+	 * @param error - error that was thrown upon receiving a response
 	 */
-	String parseError(Throwable error);
+	void parseErrorTags(Span span, Throwable error);
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ErrorParser.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ErrorParser.java
@@ -1,0 +1,16 @@
+package org.springframework.cloud.sleuth;
+
+/**
+ * Contract for parsing errors. For the given exception will produce a message
+ * that will be then added as a {@link Span#SPAN_ERROR_TAG_NAME} tag to the Span.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.2.1
+ */
+public interface ErrorParser {
+
+	/**
+	 * Returns a {@link String} representation of a {@link Throwable}
+	 */
+	String parseError(Throwable error);
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParser.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParser.java
@@ -1,5 +1,8 @@
 package org.springframework.cloud.sleuth;
 
+import java.lang.invoke.MethodHandles;
+
+import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 
 /**
@@ -9,8 +12,17 @@ import org.springframework.cloud.sleuth.util.ExceptionUtils;
  * @since 1.2.1
  */
 public class ExceptionMessageErrorParser implements ErrorParser {
+
+	private static final org.apache.commons.logging.Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
+
 	@Override
-	public String parseError(Throwable error) {
-		return ExceptionUtils.getExceptionMessage(error);
+	public void parseErrorTags(Span span, Throwable error) {
+		if (span.isExportable()) {
+			String errorMsg = ExceptionUtils.getExceptionMessage(error);
+			if (log.isDebugEnabled()) {
+				log.debug("Adding an error tag [" + errorMsg + "] to span " + span);
+			}
+			span.tag(Span.SPAN_ERROR_TAG_NAME, errorMsg);
+		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParser.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParser.java
@@ -6,7 +6,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 
 /**
- * {@link ErrorParser} that returns an exception message of a given error.
+ * {@link ErrorParser} that sets the error tag for an exportable span.
  *
  * @author Marcin Grzejszczak
  * @since 1.2.1

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParser.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParser.java
@@ -1,0 +1,16 @@
+package org.springframework.cloud.sleuth;
+
+import org.springframework.cloud.sleuth.util.ExceptionUtils;
+
+/**
+ * {@link ErrorParser} that returns an exception message of a given error.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.2.1
+ */
+public class ExceptionMessageErrorParser implements ErrorParser {
+	@Override
+	public String parseError(Throwable error) {
+		return ExceptionUtils.getExceptionMessage(error);
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.sleuth;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,10 +34,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * Class for gathering and reporting statistics about a block of execution.
@@ -769,7 +769,7 @@ public class Span implements SpanContext {
 		public Span.SpanBuilder from(Span span) {
 			return begin(span.begin).end(span.end).name(span.name)
 					.traceIdHigh(span.traceIdHigh).traceId(span.traceId)
-					.parents(span.getParents()).logs(span.logs).tags(span.tags)
+					.parents(span.getParents()).logs(span.logs).tags(span.tags).baggage(span.baggage)
 					.spanId(span.spanId).remote(span.remote).exportable(span.exportable)
 					.processId(span.processId).savedSpan(span.savedSpan);
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
@@ -263,7 +263,7 @@ class SleuthInterceptor  implements IntroductionInterceptor, BeanFactoryAware  {
 			if (hasLog) {
 				logEvent(span, log + ".afterFailure");
 			}
-			tracer().addTag(Span.SPAN_ERROR_TAG_NAME, errorParser().parseError(e));
+			errorParser().parseErrorTags(tracer().getCurrentSpan(), e);
 			throw e;
 		} finally {
 			if (span != null) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAdvisorConfig.java
@@ -37,9 +37,9 @@ import org.springframework.aop.support.annotation.AnnotationClassFilter;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.cloud.sleuth.ErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
-import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
@@ -229,6 +229,7 @@ class SleuthInterceptor  implements IntroductionInterceptor, BeanFactoryAware  {
 	private SpanCreator spanCreator;
 	private Tracer tracer;
 	private SpanTagAnnotationHandler spanTagAnnotationHandler;
+	private ErrorParser errorParser;
 
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {
@@ -262,7 +263,7 @@ class SleuthInterceptor  implements IntroductionInterceptor, BeanFactoryAware  {
 			if (hasLog) {
 				logEvent(span, log + ".afterFailure");
 			}
-			tracer().addTag(Span.SPAN_ERROR_TAG_NAME, ExceptionUtils.getExceptionMessage(e));
+			tracer().addTag(Span.SPAN_ERROR_TAG_NAME, errorParser().parseError(e));
 			throw e;
 		} finally {
 			if (span != null) {
@@ -312,6 +313,13 @@ class SleuthInterceptor  implements IntroductionInterceptor, BeanFactoryAware  {
 			this.spanTagAnnotationHandler = new SpanTagAnnotationHandler(this.beanFactory);
 		}
 		return this.spanTagAnnotationHandler;
+	}
+
+	private ErrorParser errorParser() {
+		if (this.errorParser == null) {
+			this.errorParser = this.beanFactory.getBean(ErrorParser.class);
+		}
+		return this.errorParser;
 	}
 
 	@Override public boolean implementsInterface(Class<?> intf) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -23,6 +23,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
+import org.springframework.cloud.sleuth.ErrorParser;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.NoOpSpanAdjuster;
 import org.springframework.cloud.sleuth.NoOpSpanReporter;
 import org.springframework.cloud.sleuth.Sampler;
@@ -89,6 +91,12 @@ public class TraceAutoConfiguration {
 	@ConditionalOnMissingBean
 	public SpanAdjuster defaultSpanAdjuster() {
 		return new NoOpSpanAdjuster();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ErrorParser defaultErrorParser() {
+		return new ExceptionMessageErrorParser();
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/IntegrationTraceChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/IntegrationTraceChannelInterceptor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.integration.channel.ChannelInterceptorAware;
@@ -28,11 +29,15 @@ import org.springframework.messaging.support.ChannelInterceptor;
  */
 class IntegrationTraceChannelInterceptor extends TraceChannelInterceptor implements VetoCapableInterceptor {
 
-
+	@Deprecated
 	public IntegrationTraceChannelInterceptor(Tracer tracer, TraceKeys traceKeys,
 			MessagingSpanTextMapExtractor spanExtractor,
 			MessagingSpanTextMapInjector spanInjector) {
 		super(tracer, traceKeys, spanExtractor, spanInjector);
+	}
+
+	public IntegrationTraceChannelInterceptor(BeanFactory beanFactory) {
+		super(beanFactory);
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
@@ -129,7 +129,7 @@ public class TraceChannelInterceptor extends AbstractTraceChannelInterceptor {
 
 	private void addErrorTag(Exception ex) {
 		if (ex != null) {
-			getTracer().addTag(Span.SPAN_ERROR_TAG_NAME, getErrorParser().parseError(ex));
+			getErrorParser().parseErrorTags(getTracer().getCurrentSpan(), ex);
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceChannelInterceptor.java
@@ -16,12 +16,12 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.sleuth.Log;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.sampler.NeverSampler;
-import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -38,10 +38,15 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
  */
 public class TraceChannelInterceptor extends AbstractTraceChannelInterceptor {
 
+	@Deprecated
 	public TraceChannelInterceptor(Tracer tracer, TraceKeys traceKeys,
 			MessagingSpanTextMapExtractor spanExtractor,
 			MessagingSpanTextMapInjector spanInjector) {
 		super(tracer, traceKeys, spanExtractor, spanInjector);
+	}
+
+	public TraceChannelInterceptor(BeanFactory beanFactory) {
+		super(beanFactory);
 	}
 
 	@Override
@@ -124,7 +129,7 @@ public class TraceChannelInterceptor extends AbstractTraceChannelInterceptor {
 
 	private void addErrorTag(Exception ex) {
 		if (ex != null) {
-			getTracer().addTag(Span.SPAN_ERROR_TAG_NAME, ExceptionUtils.getExceptionMessage(ex));
+			getTracer().addTag(Span.SPAN_ERROR_TAG_NAME, getErrorParser().parseError(ex));
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
@@ -16,8 +16,7 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
-import java.util.Random;
-
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -51,11 +50,8 @@ public class TraceSpringIntegrationAutoConfiguration {
 
 	@Bean
 	@GlobalChannelInterceptor(patterns = "${spring.sleuth.integration.patterns:*}")
-	public TraceChannelInterceptor traceChannelInterceptor(Tracer tracer,
-			TraceKeys traceKeys, Random random, MessagingSpanTextMapExtractor spanExtractor,
-			MessagingSpanTextMapInjector spanInjector) {
-		return new IntegrationTraceChannelInterceptor(tracer, traceKeys, spanExtractor,
-				spanInjector);
+	public TraceChannelInterceptor traceChannelInterceptor(BeanFactory beanFactory) {
+		return new IntegrationTraceChannelInterceptor(beanFactory);
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilter.java
@@ -169,7 +169,7 @@ public class TraceFilter extends GenericFilterBean {
 			filterChain.doFilter(request, new TraceHttpServletResponse(response, spanFromRequest));
 		} catch (Throwable e) {
 			exception = e;
-			tracer().addTag(Span.SPAN_ERROR_TAG_NAME, errorParser().parseError(e));
+			errorParser().parseErrorTags(tracer().getCurrentSpan(), e);
 			throw e;
 		} finally {
 			if (isAsyncStarted(request) || request.isAsyncStarted()) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHandlerInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHandlerInterceptor.java
@@ -138,11 +138,7 @@ public class TraceHandlerInterceptor extends HandlerInterceptorAdapter {
 		}
 		Span span = getRootSpanFromAttribute(request);
 		if (ex != null) {
-			String errorMsg = getErrorParser().parseError(ex);
-			if (log.isDebugEnabled()) {
-				log.debug("Adding an error tag [" + errorMsg + "] to span " + span + "");
-			}
-			getTracer().addTag(Span.SPAN_ERROR_TAG_NAME, errorMsg);
+			getErrorParser().parseErrorTags(span, ex);
 		}
 		if (getNewSpanFromAttribute(request) != null) {
 			if (log.isDebugEnabled()) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAspect.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAspect.java
@@ -157,7 +157,7 @@ public class TraceWebAspect {
 		Span currentSpan = this.tracer.getCurrentSpan();
 		try {
 			if (!currentSpan.tags().containsKey(Span.SPAN_ERROR_TAG_NAME)) {
-				this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, this.errorParser.parseError(ex));
+				this.errorParser.parseErrorTags(currentSpan, ex);
 			}
 			return pjp.proceed();
 		} finally {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAspect.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAspect.java
@@ -26,12 +26,13 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.cloud.sleuth.ErrorParser;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.async.SpanContinuingTraceCallable;
-import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.web.context.request.async.WebAsyncTask;
 
 /**
@@ -76,11 +77,22 @@ public class TraceWebAspect {
 	private final Tracer tracer;
 	private final SpanNamer spanNamer;
 	private final TraceKeys traceKeys;
+	private final ErrorParser errorParser;
 
+	@Deprecated
 	public TraceWebAspect(Tracer tracer, SpanNamer spanNamer, TraceKeys traceKeys) {
 		this.tracer = tracer;
 		this.spanNamer = spanNamer;
 		this.traceKeys = traceKeys;
+		this.errorParser = new ExceptionMessageErrorParser();
+	}
+
+	public TraceWebAspect(Tracer tracer, SpanNamer spanNamer, TraceKeys traceKeys,
+			ErrorParser errorParser) {
+		this.tracer = tracer;
+		this.spanNamer = spanNamer;
+		this.traceKeys = traceKeys;
+		this.errorParser = errorParser;
 	}
 
 	@Pointcut("@within(org.springframework.web.bind.annotation.RestController)")
@@ -145,7 +157,7 @@ public class TraceWebAspect {
 		Span currentSpan = this.tracer.getCurrentSpan();
 		try {
 			if (!currentSpan.tags().containsKey(Span.SPAN_ERROR_TAG_NAME)) {
-				this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, ExceptionUtils.getExceptionMessage(ex));
+				this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, this.errorParser.parseError(ex));
 			}
 			return pjp.proceed();
 		} finally {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -28,8 +28,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.cloud.sleuth.ErrorParser;
 import org.springframework.cloud.sleuth.SpanNamer;
-import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.context.annotation.Bean;
@@ -73,8 +73,8 @@ public class TraceWebAutoConfiguration {
 
 	@Bean
 	public TraceWebAspect traceWebAspect(Tracer tracer, TraceKeys traceKeys,
-			SpanNamer spanNamer) {
-		return new TraceWebAspect(tracer, spanNamer, traceKeys);
+			SpanNamer spanNamer, ErrorParser errorParser) {
+		return new TraceWebAspect(tracer, spanNamer, traceKeys, errorParser);
 	}
 
 	@Bean
@@ -95,12 +95,9 @@ public class TraceWebAutoConfiguration {
 	}
 
 	@Bean
-	public TraceFilter traceFilter(Tracer tracer, TraceKeys traceKeys,
-			SkipPatternProvider skipPatternProvider, SpanReporter spanReporter,
-			HttpSpanExtractor spanExtractor,
-			HttpTraceKeysInjector httpTraceKeysInjector) {
-		return new TraceFilter(tracer, traceKeys, skipPatternProvider.skipPattern(),
-				spanReporter, spanExtractor, httpTraceKeysInjector);
+	public TraceFilter traceFilter(BeanFactory beanFactory,
+			SkipPatternProvider skipPatternProvider) {
+		return new TraceFilter(beanFactory, skipPatternProvider.skipPattern());
 	}
 
 	@Configuration

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncRestTemplate.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncRestTemplate.java
@@ -293,7 +293,7 @@ public class TraceAsyncRestTemplate extends AsyncRestTemplate {
 			if (log.isDebugEnabled()) {
 				log.debug("The callback failed - will close the span");
 			}
-			this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, this.errorParser.parseError(ex));
+			this.errorParser.parseErrorTags(currentSpan(), ex);
 			finish();
 		}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncRestTemplate.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceAsyncRestTemplate.java
@@ -24,9 +24,10 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.sleuth.ErrorParser;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
-import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.core.task.AsyncListenableTaskExecutor;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.client.AsyncClientHttpRequestFactory;
@@ -52,33 +53,78 @@ import org.springframework.web.client.RestTemplate;
 public class TraceAsyncRestTemplate extends AsyncRestTemplate {
 
 	private final Tracer tracer;
+	private final ErrorParser errorParser;
 
+	@Deprecated
 	public TraceAsyncRestTemplate(Tracer tracer) {
 		super();
 		this.tracer = tracer;
+		this.errorParser = new ExceptionMessageErrorParser();
 	}
 
+	@Deprecated
 	public TraceAsyncRestTemplate(AsyncListenableTaskExecutor taskExecutor, Tracer tracer) {
 		super(taskExecutor);
 		this.tracer = tracer;
+		this.errorParser = new ExceptionMessageErrorParser();
 	}
 
+	@Deprecated
 	public TraceAsyncRestTemplate(AsyncClientHttpRequestFactory asyncRequestFactory,
 			Tracer tracer) {
 		super(asyncRequestFactory);
 		this.tracer = tracer;
+		this.errorParser = new ExceptionMessageErrorParser();
 	}
 
+	@Deprecated
 	public TraceAsyncRestTemplate(AsyncClientHttpRequestFactory asyncRequestFactory,
 			ClientHttpRequestFactory syncRequestFactory, Tracer tracer) {
 		super(asyncRequestFactory, syncRequestFactory);
 		this.tracer = tracer;
+		this.errorParser = new ExceptionMessageErrorParser();
 	}
 
+	@Deprecated
 	public TraceAsyncRestTemplate(AsyncClientHttpRequestFactory requestFactory,
 			RestTemplate restTemplate, Tracer tracer) {
 		super(requestFactory, restTemplate);
 		this.tracer = tracer;
+		this.errorParser = new ExceptionMessageErrorParser();
+	}
+
+	public TraceAsyncRestTemplate(Tracer tracer, ErrorParser errorParser) {
+		super();
+		this.tracer = tracer;
+		this.errorParser = errorParser;
+	}
+
+	public TraceAsyncRestTemplate(AsyncListenableTaskExecutor taskExecutor,
+			Tracer tracer, ErrorParser errorParser) {
+		super(taskExecutor);
+		this.tracer = tracer;
+		this.errorParser = errorParser;
+	}
+
+	public TraceAsyncRestTemplate(AsyncClientHttpRequestFactory asyncRequestFactory,
+			Tracer tracer, ErrorParser errorParser) {
+		super(asyncRequestFactory);
+		this.tracer = tracer;
+		this.errorParser = errorParser;
+	}
+
+	public TraceAsyncRestTemplate(AsyncClientHttpRequestFactory asyncRequestFactory,
+			ClientHttpRequestFactory syncRequestFactory, Tracer tracer, ErrorParser errorParser) {
+		super(asyncRequestFactory, syncRequestFactory);
+		this.tracer = tracer;
+		this.errorParser = errorParser;
+	}
+
+	public TraceAsyncRestTemplate(AsyncClientHttpRequestFactory requestFactory,
+			RestTemplate restTemplate, Tracer tracer, ErrorParser errorParser) {
+		super(requestFactory, restTemplate);
+		this.tracer = tracer;
+		this.errorParser = errorParser;
 	}
 
 	@Override
@@ -87,7 +133,8 @@ public class TraceAsyncRestTemplate extends AsyncRestTemplate {
 			throws RestClientException {
 		final ListenableFuture<T> future = super.doExecute(url, method, requestCallback, responseExtractor);
 		final Span span = this.tracer.getCurrentSpan();
-		future.addCallback(new TraceListenableFutureCallback<>(this.tracer, span));
+		future.addCallback(new TraceListenableFutureCallback<>(this.tracer, span,
+				this.errorParser));
 		// potential race can happen here
 		if (span != null && span.equals(this.tracer.getCurrentSpan())) {
 			this.tracer.detach(span);
@@ -231,10 +278,13 @@ public class TraceAsyncRestTemplate extends AsyncRestTemplate {
 
 		private final Tracer tracer;
 		private final Span parent;
+		private final ErrorParser errorParser;
 
-		private TraceListenableFutureCallback(Tracer tracer, Span parent) {
+		private TraceListenableFutureCallback(Tracer tracer, Span parent,
+				ErrorParser errorParser) {
 			this.tracer = tracer;
 			this.parent = parent;
+			this.errorParser = errorParser;
 		}
 
 		@Override
@@ -243,7 +293,7 @@ public class TraceAsyncRestTemplate extends AsyncRestTemplate {
 			if (log.isDebugEnabled()) {
 				log.debug("The callback failed - will close the span");
 			}
-			this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, ExceptionUtils.getExceptionMessage(ex));
+			this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, this.errorParser.parseError(ex));
 			finish();
 		}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 
 import org.springframework.cloud.sleuth.ErrorParser;
 import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
-import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -72,7 +72,7 @@ public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterc
 			if (log.isDebugEnabled()) {
 				log.debug("Exception occurred while trying to execute the request. Will close the span [" + currentSpan() + "]", e);
 			}
-			this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, this.errorParser.parseError(e));
+			this.errorParser.parseErrorTags(currentSpan(), e);
 			finish();
 			throw e;
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -18,11 +18,12 @@ package org.springframework.cloud.sleuth.instrument.web.client;
 
 import java.io.IOException;
 
-import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
+import org.springframework.cloud.sleuth.ErrorParser;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
-import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -41,9 +42,19 @@ import org.springframework.http.client.ClientHttpResponse;
 public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterceptor
 		implements ClientHttpRequestInterceptor {
 
+	private final ErrorParser errorParser;
+
+	@Deprecated
 	public TraceRestTemplateInterceptor(Tracer tracer, HttpSpanInjector spanInjector,
 			HttpTraceKeysInjector httpTraceKeysInjector) {
 		super(tracer, spanInjector, httpTraceKeysInjector);
+		this.errorParser = new ExceptionMessageErrorParser();
+	}
+
+	public TraceRestTemplateInterceptor(Tracer tracer, HttpSpanInjector spanInjector,
+			HttpTraceKeysInjector httpTraceKeysInjector, ErrorParser errorParser) {
+		super(tracer, spanInjector, httpTraceKeysInjector);
+		this.errorParser = errorParser;
 	}
 
 	@Override
@@ -61,7 +72,7 @@ public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterc
 			if (log.isDebugEnabled()) {
 				log.debug("Exception occurred while trying to execute the request. Will close the span [" + currentSpan() + "]", e);
 			}
-			this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, ExceptionUtils.getExceptionMessage(e));
+			this.tracer.addTag(Span.SPAN_ERROR_TAG_NAME, this.errorParser.parseError(e));
 			finish();
 			throw e;
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -16,18 +16,19 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
-import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
+import org.springframework.cloud.sleuth.ErrorParser;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.instrument.web.TraceWebAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -53,9 +54,10 @@ public class TraceWebClientAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public TraceRestTemplateInterceptor traceRestTemplateInterceptor(Tracer tracer,
-			HttpSpanInjector spanInjector,
-			HttpTraceKeysInjector httpTraceKeysInjector) {
-		return new TraceRestTemplateInterceptor(tracer, spanInjector, httpTraceKeysInjector);
+			HttpSpanInjector spanInjector, HttpTraceKeysInjector httpTraceKeysInjector,
+			ErrorParser errorParser) {
+		return new TraceRestTemplateInterceptor(tracer, spanInjector,
+				httpTraceKeysInjector, errorParser);
 	}
 
 	@Configuration

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClient.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClient.java
@@ -155,7 +155,7 @@ class TraceFeignClient implements Client {
 	private void logError(Exception e) {
 		Span span = getTracer().getCurrentSpan();
 		if (span != null) {
-			getTracer().addTag(Span.SPAN_ERROR_TAG_NAME, getErrorParser().parseError(e));
+			getErrorParser().parseErrorTags(span, e);
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParserTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParserTests.java
@@ -1,0 +1,21 @@
+package org.springframework.cloud.sleuth;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author Marcin Grzejszczak
+ */
+public class ExceptionMessageErrorParserTests {
+
+	@Test
+	public void should_return_exception_message() throws Exception {
+		Throwable e = new RuntimeException("foo");
+
+		String msg = new ExceptionMessageErrorParser().parseError(e);
+
+		then(msg).isEqualTo("foo");
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParserTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/ExceptionMessageErrorParserTests.java
@@ -2,7 +2,7 @@ package org.springframework.cloud.sleuth;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 /**
  * @author Marcin Grzejszczak
@@ -10,12 +10,23 @@ import static org.assertj.core.api.BDDAssertions.then;
 public class ExceptionMessageErrorParserTests {
 
 	@Test
-	public void should_return_exception_message() throws Exception {
+	public void should_append_tag_for_exportable_span() throws Exception {
 		Throwable e = new RuntimeException("foo");
+		Span span = new Span.SpanBuilder().exportable(true).build();
 
-		String msg = new ExceptionMessageErrorParser().parseError(e);
+		new ExceptionMessageErrorParser().parseErrorTags(span, e);
 
-		then(msg).isEqualTo("foo");
+		then(span).hasATag("error", "foo");
+	}
+
+	@Test
+	public void should_not_append_tag_for_non_exportable_span() throws Exception {
+		Throwable e = new RuntimeException("foo");
+		Span span = new Span.SpanBuilder().exportable(false).build();
+
+		new ExceptionMessageErrorParser().parseErrorTags(span, e);
+
+		then(span.tags()).isEmpty();
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -16,13 +16,13 @@
 
 package org.springframework.cloud.sleuth;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Test;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -276,6 +276,6 @@ public class SpanTests {
 	private Span.SpanBuilder builder() {
 		return Span.builder().name("http:name").traceId(1L).spanId(2L).parent(3L)
 				.begin(1L).end(2L).traceId(3L).exportable(true).parent(4L)
-				.remote(true).tag("tag", "tag").log(new Log(System.currentTimeMillis(), "log"));
+				.baggage("foo", "bar").remote(true).tag("tag", "tag").log(new Log(System.currentTimeMillis(), "log"));
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/MultipleAsyncRestTemplateTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/MultipleAsyncRestTemplateTests.java
@@ -27,7 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.sleuth.SpanInjector;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
@@ -36,7 +35,6 @@ import org.springframework.cloud.sleuth.instrument.web.client.TraceAsyncRestTemp
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpRequest;
 import org.springframework.http.client.AsyncClientHttpRequest;
 import org.springframework.http.client.AsyncClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequest;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue410/Issue410Tests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/issues/issue410/Issue410Tests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.sleuth.instrument.async.issues.issue410;
 
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 import java.lang.invoke.MethodHandles;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/HystrixAnnotationsIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/HystrixAnnotationsIntegrationTests.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.sleuth.instrument.hystrix;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanExtractorTests.java
@@ -27,7 +27,6 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 public class MessagingSpanExtractorTests {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanInjectorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessagingSpanInjectorTests.java
@@ -26,7 +26,6 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.assertThat;
 
 /**

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaTests.java
@@ -2,7 +2,6 @@ package org.springframework.cloud.sleuth.instrument.rxjava;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 import java.util.ArrayList;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TracingOnScheduledTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TracingOnScheduledTests.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.sleuth.instrument.scheduling;
 
 import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/RestTemplateTraceAspectIntegrationTests.java
@@ -14,7 +14,6 @@ import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.DefaultTestAutoConfiguration;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
-import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SpringDataInstrumentationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SpringDataInstrumentationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.sleuth.instrument.web;
 
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 import java.util.Collection;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorIntegrationTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
@@ -27,6 +31,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.assertions.ListOfSpans;
@@ -43,10 +48,6 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
-
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.SocketPolicy;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -69,7 +70,8 @@ public class TraceRestTemplateInterceptorIntegrationTests {
 				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator, new TraceKeys());
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
 				new TraceRestTemplateInterceptor(this.tracer, new ZipkinHttpSpanInjector(),
-						new HttpTraceKeysInjector(this.tracer, new TraceKeys()))));
+						new HttpTraceKeysInjector(this.tracer, new TraceKeys()),
+						new ExceptionMessageErrorParser())));
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptorTests.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
@@ -73,7 +74,8 @@ public class TraceRestTemplateInterceptorTests {
 				new DefaultSpanNamer(), new NoOpSpanLogger(), this.spanAccumulator, new TraceKeys());
 		this.template.setInterceptors(Arrays.<ClientHttpRequestInterceptor>asList(
 				new TraceRestTemplateInterceptor(this.tracer, new ZipkinHttpSpanInjector(),
-						new HttpTraceKeysInjector(this.tracer, new TraceKeys()))));
+						new HttpTraceKeysInjector(this.tracer, new TraceKeys()),
+						new ExceptionMessageErrorParser())));
 		TestSpanContextHolder.removeCurrentSpan();
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exception/WebClientExceptionTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exception/WebClientExceptionTests.java
@@ -50,7 +50,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exceptionresolver/Issue585Tests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exceptionresolver/Issue585Tests.java
@@ -19,7 +19,6 @@ import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.assertions.ListOfSpans;
-import org.springframework.cloud.sleuth.assertions.SleuthAssertions;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
 import org.springframework.context.annotation.Bean;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignRetriesTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignRetriesTests.java
@@ -16,6 +16,14 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
+import feign.Client;
+import feign.Feign;
+import feign.FeignException;
+import feign.Request;
+import feign.RequestLine;
+import feign.Response;
+import okhttp3.mockwebserver.MockWebServer;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -32,10 +40,12 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
-import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
+import org.springframework.cloud.sleuth.ErrorParser;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.instrument.web.ZipkinHttpSpanInjector;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
@@ -44,14 +54,6 @@ import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
-
-import feign.Client;
-import feign.Feign;
-import feign.FeignException;
-import feign.Request;
-import feign.RequestLine;
-import feign.Response;
-import okhttp3.mockwebserver.MockWebServer;
 
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
@@ -81,6 +83,7 @@ public class FeignRetriesTests {
 		BDDMockito.given(this.beanFactory.getBean(HttpSpanInjector.class))
 				.willReturn(new ZipkinHttpSpanInjector());
 		BDDMockito.given(this.beanFactory.getBean(Tracer.class)).willReturn(this.tracer);
+		BDDMockito.given(this.beanFactory.getBean(ErrorParser.class)).willReturn(new ExceptionMessageErrorParser());
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
+import feign.Client;
+import feign.Request;
+import feign.Response;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -31,11 +35,13 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
-import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
+import org.springframework.cloud.sleuth.ErrorParser;
+import org.springframework.cloud.sleuth.ExceptionMessageErrorParser;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.assertions.SleuthAssertions;
+import org.springframework.cloud.sleuth.instrument.web.HttpSpanInjector;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.instrument.web.ZipkinHttpSpanInjector;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
@@ -44,10 +50,6 @@ import org.springframework.cloud.sleuth.trace.DefaultTracer;
 import org.springframework.cloud.sleuth.trace.TestSpanContextHolder;
 import org.springframework.cloud.sleuth.util.ArrayListSpanAccumulator;
 import org.springframework.cloud.sleuth.util.ExceptionUtils;
-
-import feign.Client;
-import feign.Request;
-import feign.Response;
 
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
@@ -74,6 +76,7 @@ public class TraceFeignClientTests {
 		BDDMockito.given(this.beanFactory.getBean(HttpSpanInjector.class))
 				.willReturn(new ZipkinHttpSpanInjector());
 		BDDMockito.given(this.beanFactory.getBean(Tracer.class)).willReturn(this.tracer);
+		BDDMockito.given(this.beanFactory.getBean(ErrorParser.class)).willReturn(new ExceptionMessageErrorParser());
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/servererrors/FeignClientServerErrorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/servererrors/FeignClientServerErrorTests.java
@@ -63,7 +63,6 @@ import com.netflix.loadbalancer.Server;
 import feign.codec.Decoder;
 import feign.codec.ErrorDecoder;
 
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 /**

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
@@ -79,7 +79,6 @@ import junitparams.Parameters;
 
 import static junitparams.JUnitParamsRunner.$;
 import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 @RunWith(JUnitParamsRunner.class)

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulIntegrationTests.java
@@ -1,6 +1,5 @@
 package org.springframework.cloud.sleuth.instrument.zuul;
 
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 import java.io.IOException;

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
@@ -27,7 +27,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.Span;
-import org.springframework.cloud.sleuth.SpanAdjuster;
 import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;


### PR DESCRIPTION
without this change there's no way to alter the exception message that gets attached as a tag to the span
with this change you can register your own ErrorParser bean to alter that behaviour

fixes #576