### PR TITLE
Add missing implementation of shutdown method on LazyTraceThreadPoolTaskExecutor

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
@@ -90,6 +90,7 @@ public class LazyTraceThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 		return this.delegate.getThreadPoolExecutor();
 	}
 
+	@Override
 	public void destroy() {
 		this.delegate.destroy();
 		super.destroy();
@@ -99,6 +100,11 @@ public class LazyTraceThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 	public void afterPropertiesSet() {
 		this.delegate.afterPropertiesSet();
 		super.afterPropertiesSet();
+	}
+
+	@Override
+	public void shutdown() {
+		this.delegate.shutdown();
 	}
 
 	private Tracer tracer() {


### PR DESCRIPTION
If we call shutdown method on LazyTraceThreadPoolTaskExecutor instance, It will invoke shutdown from ExecutorConfigurationSupport class which ExecutorService is null (as we never initialize executor from LazyTraceThreadPoolTaskExecutor  but use delegate instead). This resulting in null pointer exception.

This fix is to override shutdown method to call delegate.shutdown.

ps. I also add missing override annotation on destroy method :)