### PR TITLE
Introduced a "shared" field in Span

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -512,6 +512,9 @@ public class Span implements SpanContext {
 
 	/**
 	 * Span and trace id got extracted from a carrier?
+	 * We are adding data to the same span created by a remote client2
+	 *
+	 * @since 1.3.0
 	 */
 	public boolean isShared() {
 		return this.shared;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/Span.java
@@ -16,12 +16,6 @@
 
 package org.springframework.cloud.sleuth;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,6 +27,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * Class for gathering and reporting statistics about a block of execution.
@@ -160,6 +161,13 @@ public class Span implements SpanContext {
 	@JsonIgnore
 	private final Long startNanos;
 	private Long durationMicros; // serialized in json so micros precision isn't lost
+	/*
+	 Using B3 propagation, it is most typical to share the same span ID across client and
+	 the server. This has backend implications like who owns the timestamp (hint the
+	 client does). When a SpanReporter receives a completed span, it should know if it
+	 is shared or not.
+	  */
+	private final boolean shared;
 
 	@SuppressWarnings("unused")
 	private Span() {
@@ -191,17 +199,18 @@ public class Span implements SpanContext {
 		this.durationMicros = current.durationMicros;
 		this.baggage = current.baggage;
 		this.savedSpan = savedSpan;
+		this.shared = current.shared;
 	}
 
 	Span(long begin, long end, String name, long traceId, List<Long> parents,
 			long spanId, boolean remote, boolean exportable, String processId) {
 		this(begin, end, name, traceId, parents, spanId, remote, exportable, processId,
-				null);
+				null, false);
 	}
 
 	Span(long begin, long end, String name, long traceId, List<Long> parents,
 			long spanId, boolean remote, boolean exportable, String processId,
-			Span savedSpan) {
+			Span savedSpan, boolean shared) {
 		this(new SpanBuilder()
 				.begin(begin)
 				.end(end)
@@ -212,7 +221,8 @@ public class Span implements SpanContext {
 				.remote(remote)
 				.exportable(exportable)
 				.processId(processId)
-				.savedSpan(savedSpan));
+				.savedSpan(savedSpan)
+				.shared(shared));
 	}
 
 	Span(SpanBuilder builder) {
@@ -242,6 +252,7 @@ public class Span implements SpanContext {
 		this.logs.addAll(builder.logs);
 		this.baggage = new ConcurrentHashMap<>();
 		this.baggage.putAll(builder.baggage);
+		this.shared = builder.shared;
 	}
 
 	public static SpanBuilder builder() {
@@ -500,6 +511,13 @@ public class Span implements SpanContext {
 	}
 
 	/**
+	 * Span and trace id got extracted from a carrier?
+	 */
+	public boolean isShared() {
+		return this.shared;
+	}
+
+	/**
 	 * Returns the 16 or 32 character hex representation of the span's trace ID
 	 *
 	 * @since 1.0.11
@@ -644,6 +662,7 @@ public class Span implements SpanContext {
 		private final List<Log> logs = new ArrayList<>();
 		private final Map<String, String> tags = new LinkedHashMap<>();
 		private final Map<String, String> baggage = new LinkedHashMap<>();
+		private boolean shared;
 
 		SpanBuilder() {
 		}
@@ -745,6 +764,11 @@ public class Span implements SpanContext {
 
 		public Span.SpanBuilder savedSpan(Span savedSpan) {
 			this.savedSpan = savedSpan;
+			return this;
+		}
+
+		public Span.SpanBuilder shared(boolean shared) {
+			this.shared = shared;
 			return this;
 		}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/SpanTests.java
@@ -16,15 +16,16 @@
 
 package org.springframework.cloud.sleuth;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.assertThat;
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.assertThat;
-import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Marcin Grzejszczak
@@ -286,6 +287,7 @@ public class SpanTests {
 	private Span.SpanBuilder builder() {
 		return Span.builder().name("http:name").traceId(1L).spanId(2L).parent(3L)
 				.begin(1L).end(2L).traceId(3L).exportable(true).parent(4L)
-				.baggage("foo", "bar").remote(true).tag("tag", "tag").log(new Log(System.currentTimeMillis(), "log"));
+				.baggage("foo", "bar")
+				.remote(true).shared(true).tag("tag", "tag").log(new Log(System.currentTimeMillis(), "log"));
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SpanAssert.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/assertions/SpanAssert.java
@@ -190,6 +190,26 @@ public class SpanAssert extends AbstractAssert<SpanAssert, Span> {
 		return this;
 	}
 
+	public SpanAssert isShared() {
+		isNotNull();
+		if (!this.actual.isShared()) {
+			String message = "The span is supposed to be shared but it's not!";
+			log.error(message);
+			failWithMessage(message);
+		}
+		return this;
+	}
+
+	public SpanAssert isNotShared() {
+		isNotNull();
+		if (this.actual.isShared()) {
+			String message = "The span is NOT supposed to be shared but it is!";
+			log.error(message);
+			failWithMessage(message);
+		}
+		return this;
+	}
+
 	public SpanAssert isNotExportable() {
 		isNotNull();
 		if (this.actual.isExportable()) {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/HeaderBasedMessagingExtractorTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -23,8 +25,6 @@ import java.util.Map;
 import org.junit.Test;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanTextMap;
-
-import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 /**
  * @author Marcin Grzejszczak
@@ -42,7 +42,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		Span span = extractor.joinTrace(spanTextMap);
 
-		then(span).isExportable();
+		then(span).isExportable().isShared();
 	}
 
 	@Test
@@ -56,7 +56,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		Span span = extractor.joinTrace(spanTextMap);
 
-		then(span).isExportable();
+		then(span).isExportable().isShared();
 	}
 
 	@Test
@@ -69,7 +69,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		Span span = extractor.joinTrace(spanTextMap);
 
-		then(span).isExportable();
+		then(span).isExportable().isShared();
 	}
 
 	@Test
@@ -82,7 +82,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		Span span = extractor.joinTrace(spanTextMap);
 
-		then(span).isNotExportable();
+		then(span).isNotExportable().isNotShared();
 	}
 
 	@Test
@@ -93,7 +93,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		Span span = extractor.joinTrace(spanTextMap);
 
-		then(span).isExportable();
+		then(span).isExportable().isNotShared();
 		then(span.traceIdString()).isNotEmpty();
 		then(span.getSpanId()).isNotNull();
 	}
@@ -107,7 +107,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		Span span = extractor.joinTrace(spanTextMap);
 
-		then(span).isExportable();
+		then(span).isExportable().isNotShared();
 		then(span.traceIdString()).isNotEmpty();
 		then(span.getSpanId()).isEqualTo(10L);
 	}
@@ -121,7 +121,7 @@ public class HeaderBasedMessagingExtractorTests {
 
 		Span span = extractor.joinTrace(spanTextMap);
 
-		then(span).isExportable();
+		then(span).isExportable().isNotShared();
 		then(span.getTraceId()).isEqualTo(10L);
 		then(span.getSpanId()).isEqualTo(10L);
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/HttpServletRequestExtractorTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.web;
 
+import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
+
 import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.Random;
@@ -29,8 +31,6 @@ import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.cloud.sleuth.Span;
-
-import static org.springframework.cloud.sleuth.assertions.SleuthAssertions.then;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpServletRequestExtractorTests {
@@ -82,18 +82,60 @@ public class HttpServletRequestExtractorTests {
 
 	@Test
 	public void should_accept_128bit_trace_id() {
-		String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
-		String lower64Bits = "48485a3953bb6124";
+		String hex128Bits = spanInHeaders();
 
-		BDDMockito.given(this.request.getHeaderNames())
-				.willReturn(new Vector<>(Arrays.asList(Span.TRACE_ID_NAME, Span.SPAN_ID_NAME)).elements());
-		BDDMockito.given(this.request.getHeader(Span.TRACE_ID_NAME))
-				.willReturn(hex128Bits);
-		BDDMockito.given(this.request.getHeader(Span.SPAN_ID_NAME))
-				.willReturn(lower64Bits);
 
 		Span span = this.extractor.joinTrace(new HttpServletRequestTextMap(this.request));
 
 		then(span.traceIdString()).isEqualTo(hex128Bits);
+	}
+
+	@Test
+	public void should_set_shared_flag_for_sampled_span_in_headers() {
+		spanInHeaders();
+
+		Span span = this.extractor.joinTrace(new HttpServletRequestTextMap(this.request));
+
+		then(span.isShared()).isTrue();
+	}
+
+	@Test
+	public void should_not_set_shared_flag_for_non_sampled_span_in_headers() {
+		spanInHeaders();
+		BDDMockito.given(this.request.getHeader(Span.SAMPLED_NAME))
+				.willReturn(Span.SPAN_NOT_SAMPLED);
+
+		Span span = this.extractor.joinTrace(new HttpServletRequestTextMap(this.request));
+
+		then(span.isShared()).isFalse();
+	}
+
+	@Test
+	public void should_not_set_shared_flag_for_sampled_span_in_headers_without_span_trace_id() {
+		BDDMockito.given(this.request.getHeaderNames())
+				.willReturn(new Vector<>(Arrays.asList(Span.SPAN_FLAGS, Span.SPAN_ID_NAME)).elements());
+		BDDMockito.given(this.request.getHeader(Span.SPAN_FLAGS))
+				.willReturn("1");
+		BDDMockito.given(this.request.getHeader(Span.SPAN_ID_NAME))
+				.willReturn("48485a3953bb6124");
+
+		Span span = this.extractor.joinTrace(new HttpServletRequestTextMap(this.request));
+
+		then(span.isShared()).isFalse();
+	}
+
+	private String spanInHeaders() {
+		String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
+		String lower64Bits = "48485a3953bb6124";
+
+		BDDMockito.given(this.request.getHeaderNames())
+				.willReturn(new Vector<>(Arrays.asList(Span.TRACE_ID_NAME, Span.SPAN_ID_NAME, Span.SAMPLED_NAME)).elements());
+		BDDMockito.given(this.request.getHeader(Span.TRACE_ID_NAME))
+				.willReturn(hex128Bits);
+		BDDMockito.given(this.request.getHeader(Span.SPAN_ID_NAME))
+				.willReturn(lower64Bits);
+		BDDMockito.given(this.request.getHeader(Span.SAMPLED_NAME))
+				.willReturn(Span.SPAN_SAMPLED);
+		return hex128Bits;
 	}
 }

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListener.java
@@ -99,9 +99,14 @@ public class ZipkinSpanListener implements SpanReporter {
 		// rather let the client do that. Worst case we were propagated an unreported ID and
 		// Zipkin backfills timestamp and duration.
 		if (!convertedSpan.isRemote()) {
-			zipkinSpan.timestamp(convertedSpan.getBegin() * 1000L);
-			if (!convertedSpan.isRunning()) { // duration is authoritative, only write when the span stopped
-				zipkinSpan.duration(calculateDurationInMicros(convertedSpan));
+			// don't report server-side timestamp on shared spans
+			if (Boolean.TRUE.equals(convertedSpan.isShared())) {
+				zipkinSpan.timestamp(null).duration(null);
+			} else {
+				zipkinSpan.timestamp(convertedSpan.getBegin() * 1000L);
+				if (!convertedSpan.isRunning()) { // duration is authoritative, only write when the span stopped
+					zipkinSpan.duration(calculateDurationInMicros(convertedSpan));
+				}
 			}
 		}
 		zipkinSpan.traceIdHigh(convertedSpan.getTraceIdHigh());

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin/ZipkinSpanListenerTests.java
@@ -319,6 +319,37 @@ public class ZipkinSpanListenerTests {
 		assertThat(result.name).isEqualTo("foo");
 	}
 
+	@Test
+	public void shouldRemoveTimestampAndDurationForNonRemoteSharedSpan() {
+		Span span = Span.builder()
+				.name("foo")
+				.exportable(false)
+				.remote(false)
+				.shared(true)
+				.build();
+
+		zipkin.Span result = this.spanListener.convert(span);
+
+		assertThat(result.duration).isNull();
+		assertThat(result.timestamp).isNull();
+	}
+
+	@Test
+	public void shouldNotRemoveTimestampAndDurationForNonRemoteNonSharedSpan() {
+		Span span = Span.builder()
+				.name("foo")
+				.exportable(false)
+				.remote(false)
+				.shared(false)
+				.build();
+		span.stop();
+
+		zipkin.Span result = this.spanListener.convert(span);
+
+		assertThat(result.duration).isNotNull();
+		assertThat(result.timestamp).isNotNull();
+	}
+
 	@Configuration
 	@EnableAutoConfiguration
 	protected static class TestConfiguration {


### PR DESCRIPTION
whenever
- a span or trace id get generated when a request / message arrives
- child span is created

we set the field to false

whenever we find ids in the incoming request / message we set the field to true

fixes #696