### PR TITLE
Adds spring.sleuth.supports-join to disable span ID sharing

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
@@ -29,6 +29,8 @@ public class SleuthProperties {
 	private boolean enabled = true;
 	/** When true, generate 128-bit trace IDs instead of 64-bit ones. */
 	private boolean traceId128 = false;
+	/** When true, your tracing system allows sharing a span ID between a client and server span */
+	private boolean supportsJoin = true;
 
 	public boolean isEnabled() {
 		return this.enabled;
@@ -44,5 +46,13 @@ public class SleuthProperties {
 
 	public void setTraceId128(boolean traceId128) {
 		this.traceId128 = traceId128;
+	}
+
+	public boolean isSupportsJoin() {
+		return this.supportsJoin;
+	}
+
+	public void setSupportsJoin(boolean supportsJoin) {
+		this.supportsJoin = supportsJoin;
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterAlwaysSamplerIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterAlwaysSamplerIntegrationTests.java
@@ -17,6 +17,7 @@ import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
 import org.springframework.cloud.sleuth.instrument.DefaultTestAutoConfiguration;
 import org.springframework.cloud.sleuth.instrument.web.common.AbstractMvcIntegrationTest;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
@@ -71,6 +72,7 @@ public class TraceFilterAlwaysSamplerIntegrationTests extends AbstractMvcIntegra
 		BeanFactory beanFactory = Mockito.mock(BeanFactory.class);
 		BDDMockito.given(beanFactory.getBean(TraceWebAutoConfiguration.SkipPatternProvider.class))
 				.willThrow(new NoSuchBeanDefinitionException("foo"));
+		BDDMockito.given(beanFactory.getBean(SleuthProperties.class)).willReturn(this.properties);
 		BDDMockito.given(beanFactory.getBean(Tracer.class)).willReturn(this.tracer);
 		BDDMockito.given(beanFactory.getBean(TraceKeys.class)).willReturn(this.traceKeys);
 		BDDMockito.given(beanFactory.getBean(HttpSpanExtractor.class)).willReturn(this.spanExtractor);

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterMockChainIntegrationTests.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.SpanReporter;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
 import org.springframework.cloud.sleuth.log.NoOpSpanLogger;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.cloud.sleuth.trace.DefaultTracer;
@@ -54,6 +55,7 @@ public class TraceFilterMockChainIntegrationTests {
 			new Random(), new DefaultSpanNamer(),
 			new NoOpSpanLogger(), new NoOpSpanReporter(), new TraceKeys());
 	private TraceKeys traceKeys = new TraceKeys();
+	private SleuthProperties properties = new SleuthProperties();
 	private HttpTraceKeysInjector keysInjector = new HttpTraceKeysInjector(this.tracer, this.traceKeys);
 
 	private MockHttpServletRequest request;
@@ -94,6 +96,7 @@ public class TraceFilterMockChainIntegrationTests {
 
 	private BeanFactory beanFactory() {
 		BeanFactory beanFactory = Mockito.mock(BeanFactory.class);
+		BDDMockito.given(beanFactory.getBean(SleuthProperties.class)).willReturn(this.properties);
 		BDDMockito.given(beanFactory.getBean(Tracer.class)).willReturn(this.tracer);
 		BDDMockito.given(beanFactory.getBean(TraceKeys.class)).willReturn(this.traceKeys);
 		BDDMockito.given(beanFactory.getBean(HttpSpanExtractor.class))

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/AbstractMvcIntegrationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/common/AbstractMvcIntegrationTest.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.sleuth.instrument.web.common;
 
 import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
 import org.springframework.cloud.sleuth.instrument.web.HttpSpanExtractor;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
@@ -30,6 +31,7 @@ public abstract class AbstractMvcIntegrationTest {
 
 	@Autowired protected WebApplicationContext webApplicationContext;
 	protected MockMvc mockMvc;
+	@Autowired protected SleuthProperties properties;
 	@Autowired protected Tracer tracer;
 	@Autowired protected TraceKeys traceKeys;
 	@Autowired protected HttpSpanExtractor spanExtractor;


### PR DESCRIPTION
This adds the ability to opt out of span sharing between the client and
server side of an RPC. This is important when reporting to systems that
do not share span IDs, such as Google Stackdriver and Amazon X-Ray.

Note: this still defaults to true, in favor of existing Zipkin
implementations. See https://github.com/openzipkin/zipkin/issues/1480

See #395
See #459