### PR TITLE
Non-ASCII characters included in X-SPAN-NAME header.

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
@@ -66,7 +66,9 @@ abstract class AbstractTraceHttpRequestInterceptor {
 	}
 
 	private String getName(URI uri) {
-		return SpanNameUtil.shorten(uriScheme(uri) + ":" + uri.getPath());
+		// The returned name should comply with RFC 882 - Section 3.1.2.
+		// i.e Header values must composed of printable ASCII values.
+		return SpanNameUtil.shorten(uriScheme(uri) + ":" + uri.getRawPath());
 	}
 
 	private String uriScheme(URI uri) {


### PR DESCRIPTION
When the X-SPAN-NAME HTTP Header is built from a URI that contains non ASCII characters (in its decoded form), Sleuth generates a value for the header that violates RFC 822 (Section 3.1.2) which states the value "may be composed of any ASCII characters, except CR or LF.  (While CR and/or LF may be present  in the actual text, they are removed by the action of unfolding the field.)" When Apache 2 is used as proxy server in the same environment this results in the following errors.

[Mon Oct 09 11:22:15.421634 2017] [core:debug] [pid 9550] protocol.c(1151):
[client 10.104.87.215:39868] AH02427: Request header value is malformed:
https:/rowSets/cas~fs~åˆ’
[Mon Oct 09 11:22:15.421664 2017] [core:debug] [pid 9550] protocol.c(1309):
[client 10.104.87.215:39868] AH00567: request failed: error reading the headers


Currently, Sleuth calls java.net.URI.getPath() when building the span name value in AbstractTraceHttpRequestInterceptor. The getPath method returns the path in decoded form (which results in non-ASCII characters being included).My proposed fix is to call URI.getRawPath() which will return the path in encoded form (assuming the originally URI was encoded).

 
