### PR TITLE
Misaligns Zipkin v1 from sharing the same version number as v2

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -14,7 +14,9 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<zipkin.version>2.2.1</zipkin.version>
+		<!-- misaligned intentionally https://github.com/spring-projects/spring-boot/issues/10778-->
+		<zipkin.version>2.2.0</zipkin.version>
+		<zipkin2.version>2.2.1</zipkin2.version>
 		<zipkin-reporter.version>1.1.2</zipkin-reporter.version>
 		<zipkin-reporter2.version>2.1.3</zipkin-reporter2.version>
 	</properties>
@@ -73,7 +75,7 @@
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>${zipkin.version}</version>
+				<version>${zipkin2.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.java</groupId>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -55,18 +55,8 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>io.zipkin.java</groupId>
-				<artifactId>zipkin</artifactId>
-				<version>2.2.1</version>
-			</dependency>
-			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>2.2.1</version>
-			</dependency>
-			<dependency>
-				<groupId>io.zipkin.java</groupId>
-				<artifactId>zipkin-server</artifactId>
 				<version>2.2.1</version>
 			</dependency>
 		</dependencies>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-feign/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-feign/pom.xml
@@ -68,7 +68,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
+			<artifactId>spring-cloud-sleuth-zipkin2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-feign/src/main/java/sample/SampleFeignApplication.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-feign/src/main/java/sample/SampleFeignApplication.java
@@ -22,10 +22,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
-import org.springframework.cloud.sleuth.zipkin.ZipkinSpanReporter;
 import org.springframework.context.annotation.Bean;
 
-import zipkin.Span;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
 
 /**
  * @author Spencer Gibb
@@ -43,8 +43,8 @@ public class SampleFeignApplication {
 	// Use this for debugging (or if there is no Zipkin server running on port 9411)
 	@Bean
 	@ConditionalOnProperty(value = "sample.zipkin.enabled", havingValue = "false")
-	public ZipkinSpanReporter spanCollector() {
-		return new ZipkinSpanReporter() {
+	public Reporter<Span> spanReporter() {
+		return new Reporter<Span>() {
 			@Override
 			public void report(Span span) {
 				logger.info(span);

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/pom.xml
@@ -82,7 +82,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
+			<artifactId>spring-cloud-sleuth-zipkin2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/src/test/java/integration/IntegrationTestZipkinSpanReporter.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/src/test/java/integration/IntegrationTestZipkinSpanReporter.java
@@ -20,16 +20,16 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
-import org.springframework.cloud.sleuth.zipkin.ZipkinSpanReporter;
 
-import zipkin.Span;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
 
 /**
  * Span Collector that logs spans and adds Spans to a list
  *
  * @author Marcin Grzejszczak
  */
-public class IntegrationTestZipkinSpanReporter implements ZipkinSpanReporter {
+public class IntegrationTestZipkinSpanReporter implements Reporter<Span> {
 
 	private static final Log log = org.apache.commons.logging.LogFactory
 			.getLog(IntegrationTestZipkinSpanReporter.class);

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/pom.xml
@@ -70,7 +70,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
+			<artifactId>spring-cloud-sleuth-zipkin2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/src/main/java/sample/SampleRibbonApplication.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/src/main/java/sample/SampleRibbonApplication.java
@@ -22,12 +22,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
-import org.springframework.cloud.sleuth.zipkin.ZipkinSpanReporter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
 
-import zipkin.Span;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
 
 /**
  * @author Spencer Gibb
@@ -51,8 +51,8 @@ public class SampleRibbonApplication {
 	// Use this for debugging (or if there is no Zipkin server running on port 9411)
 	@Bean
 	@ConditionalOnProperty(value = "sample.zipkin.enabled", havingValue = "false")
-	public ZipkinSpanReporter spanCollector() {
-		return new ZipkinSpanReporter() {
+	public Reporter<Span> spanReporter() {
+		return new Reporter<Span>() {
 			@Override
 			public void report(Span span) {
 				logger.info(span);

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/pom.xml
@@ -105,7 +105,7 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.zipkin.java</groupId>
+			<groupId>io.zipkin.zipkin2</groupId>
 			<artifactId>zipkin</artifactId>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/AbstractIntegrationTest.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/AbstractIntegrationTest.java
@@ -15,18 +15,7 @@
  */
 package tools;
 
-import zipkin.Codec;
-import zipkin.Span;
-
 import java.lang.invoke.MethodHandles;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.awaitility.Awaitility;
@@ -34,15 +23,9 @@ import org.awaitility.core.ConditionFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.springframework.cloud.sleuth.trace.IntegrationTestSpanContextHolder;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.BDDAssertions.then;
 
 /**
  * @author Marcin Grzejszczak
@@ -65,57 +48,6 @@ public abstract class AbstractIntegrationTest {
 		IntegrationTestSpanContextHolder.removeCurrentSpan();
 	}
 
-	public static ConditionFactory await() {
-		return Awaitility.await().pollInterval(POLL_INTERVAL, SECONDS).atMost(TIMEOUT, SECONDS);
-	}
-
-	protected Runnable zipkinServerIsUp() {
-		return checkServerHealth("Zipkin Stream Server", this::endpointToCheckZipkinServerHealth);
-	}
-
-	protected Runnable checkServerHealth(String appName, RequestExchanger requestExchanger) {
-		return () -> {
-			ResponseEntity<String> response = requestExchanger.exchange();
-			log.info(String.format("Response from the [%s] health endpoint is [%s]", appName, response));
-			then(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-			log.info(String.format("[%s] is up!", appName));
-		};
-	}
-
-	private interface RequestExchanger {
-		ResponseEntity<String> exchange();
-	}
-
-	protected ResponseEntity<String> endpointToCheckZipkinServerHealth() {
-		URI uri = URI.create("http://localhost:" +getZipkinServerPort()+"/health");
-		log.info(String.format("Sending request to the Zipkin Server [%s]", uri));
-		return exchangeRequest(uri);
-	}
-
-	protected int getZipkinServerPort() {
-		return 9411;
-	}
-
-	protected ResponseEntity<String> checkStateOfTheTraceId(long traceId) {
-		URI uri = URI.create(getZipkinTraceQueryUrl() + Long.toHexString(traceId));
-		log.info(String.format("Sending request to the Zipkin query service [%s]. "
-				+ "Checking presence of trace id [%d]", uri, traceId));
-		return exchangeRequest(uri);
-	}
-
-	protected ResponseEntity<String> exchangeRequest(URI uri) {
-		return this.restTemplate.exchange(
-				new RequestEntity<>(new HttpHeaders(), HttpMethod.GET, uri), String.class
-		);
-	}
-
-	protected String getZipkinTraceQueryUrl() {
-		return "http://localhost:"+getZipkinServerPort()+"/api/v1/trace/";
-	}
-
-	protected String getZipkinServicesQueryUrl() {
-		return "http://localhost:"+getZipkinServerPort()+"/api/v1/services";
-	}
 
 	protected Runnable httpMessageWithTraceIdInHeadersIsSuccessfullySent(String endpoint, long traceId) {
 		return new RequestSendingRunnable(this.restTemplate, endpoint, traceId, null);
@@ -125,68 +57,7 @@ public abstract class AbstractIntegrationTest {
 		return new RequestSendingRunnable(this.restTemplate, endpoint, traceId, spanId);
 	}
 
-	protected Runnable allSpansWereRegisteredInZipkinWithTraceIdEqualTo(long traceId) {
-		return () -> {
-			ResponseEntity<String> response = checkStateOfTheTraceId(traceId);
-			log.info(String.format("Response from the Zipkin query service about the "
-					+ "trace id [%s] for trace with id [%d]", response, traceId));
-			then(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-			then(response.hasBody()).isTrue();
-			List<Span> spans = Codec.JSON.readSpans(response.getBody().getBytes());
-			List<String> serviceNamesNotFoundInZipkin = serviceNamesNotFoundInZipkin(spans);
-			List<String> spanNamesNotFoundInZipkin = annotationsNotFoundInZipkin(spans);
-			log.info(String.format("The following services were not found in Zipkin [%s]", serviceNamesNotFoundInZipkin));
-			log.info(String.format("The following annotations were not found in Zipkin [%s]", spanNamesNotFoundInZipkin));
-			then(serviceNamesNotFoundInZipkin).isEmpty();
-			then(spanNamesNotFoundInZipkin).isEmpty();
-			log.info("Zipkin tracing is working! Sleuth is working! Let's be happy!");
-		};
+	public static ConditionFactory await() {
+		return Awaitility.await().pollInterval(POLL_INTERVAL, SECONDS).atMost(TIMEOUT, SECONDS);
 	}
-
-	protected List<String> serviceNamesNotFoundInZipkin(List<zipkin.Span> spans) {
-		List<String> serviceNamesFoundInAnnotations = spans.stream()
-				.filter(span -> span.annotations != null)
-				.map(span -> span.annotations)
-				.flatMap(Collection::stream)
-				.filter(span -> span.endpoint != null)
-				.map(annotation -> annotation.endpoint)
-				.map(endpoint -> endpoint.serviceName)
-				.distinct()
-				.collect(Collectors.toList());
-		List<String> serviceNamesFoundInBinaryAnnotations = spans.stream()
-				.filter(span -> span.binaryAnnotations != null)
-				.map(span -> span.binaryAnnotations)
-				.flatMap(Collection::stream)
-				.filter(span -> span.endpoint != null)
-				.map(annotation -> annotation.endpoint)
-				.map(endpoint -> endpoint.serviceName)
-				.distinct()
-				.collect(Collectors.toList());
-		List<String> names = new ArrayList<>();
-		names.addAll(serviceNamesFoundInAnnotations);
-		names.addAll(serviceNamesFoundInBinaryAnnotations);
-		return names.contains(getAppName()) ? Collections.emptyList() : names;
-	}
-
-	protected String getAppName() {
-		return "unknown";
-	}
-
-	protected List<String> annotationsNotFoundInZipkin(List<zipkin.Span> spans) {
-		String binaryAnnotationName = getRequiredBinaryAnnotationName();
-		Optional<String> names = spans.stream()
-				.filter(span -> span.binaryAnnotations != null)
-				.map(span -> span.binaryAnnotations)
-				.flatMap(Collection::stream)
-				.filter(span -> span.endpoint != null)
-				.map(annotation -> annotation.key)
-				.filter(binaryAnnotationName::equals)
-				.findFirst();
-		return names.isPresent() ? Collections.emptyList() : Collections.singletonList(binaryAnnotationName);
-	}
-
-	protected String getRequiredBinaryAnnotationName() {
-		return "random-sleep-millis";
-	}
-
 }

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-websocket/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-websocket/pom.xml
@@ -82,7 +82,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-sleuth-zipkin</artifactId>
+			<artifactId>spring-cloud-sleuth-zipkin2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin2/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin2/pom.xml
@@ -98,19 +98,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.zipkin.java</groupId>
-			<artifactId>zipkin-server</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>io.zipkin.java</groupId>
-			<artifactId>zipkin-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- otherwise spring boot's version of okhttp kicks zipkin-junit's deps out of alignment -->
-		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
+			<artifactId>mockwebserver</artifactId>
 			<version>3.9.0</version>
 			<scope>test</scope>
 		</dependency>

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -70,6 +70,10 @@
 			<artifactId>zipkin</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.zipkin.zipkin2</groupId>
+			<artifactId>zipkin</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.zipkin.reporter</groupId>
 			<artifactId>zipkin-reporter</artifactId>
 		</dependency>

--- a/spring-cloud-sleuth-zipkin2/pom.xml
+++ b/spring-cloud-sleuth-zipkin2/pom.xml
@@ -107,20 +107,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.zipkin.java</groupId>
-			<artifactId>zipkin-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- otherwise spring boot's version of okhttp kicks zipkin-junit's deps out of alignment -->
-		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
-			<version>3.9.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-sleuth-zipkin2/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinDiscoveryClientTests.java
+++ b/spring-cloud-sleuth-zipkin2/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinDiscoveryClientTests.java
@@ -1,14 +1,12 @@
 package org.springframework.cloud.sleuth.zipkin2;
 
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.cloud.sleuth.zipkin2.ZipkinDiscoveryClientTests.ZIPKIN_RULE;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
+import okhttp3.mockwebserver.MockWebServer;
 import org.awaitility.Awaitility;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -17,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.ServiceInstance;
-import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerRequest;
 import org.springframework.cloud.sleuth.Span;
@@ -26,8 +23,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import zipkin.junit.ZipkinRule;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ZipkinDiscoveryClientTests.Config.class, properties = {
 		"spring.zipkin.baseUrl=http://zipkin/",
@@ -35,7 +30,7 @@ import zipkin.junit.ZipkinRule;
 })
 public class ZipkinDiscoveryClientTests {
 
-	@ClassRule public static ZipkinRule ZIPKIN_RULE = new ZipkinRule();
+	@ClassRule public static MockWebServer ZIPKIN_RULE = new MockWebServer();
 
 	@Autowired SpanReporter spanReporter;
 
@@ -46,7 +41,7 @@ public class ZipkinDiscoveryClientTests {
 
 		this.spanReporter.report(span);
 
-		Awaitility.await().untilAsserted(() -> then(ZIPKIN_RULE.httpRequestCount()).isGreaterThan(0));
+		Awaitility.await().untilAsserted(() -> then(ZIPKIN_RULE.getRequestCount()).isGreaterThan(0));
 	}
 
 	@Configuration
@@ -85,7 +80,7 @@ public class ZipkinDiscoveryClientTests {
 
 						@Override
 						public int getPort() {
-							return URI.create(ZIPKIN_RULE.httpUrl()).getPort();
+							return ZIPKIN_RULE.url("/").port();
 						}
 
 						@Override
@@ -95,7 +90,7 @@ public class ZipkinDiscoveryClientTests {
 
 						@Override
 						public URI getUri() {
-							return URI.create(ZIPKIN_RULE.httpUrl());
+							return ZIPKIN_RULE.url("/").uri();
 						}
 
 						@Override


### PR DESCRIPTION
This does two things: ensures samples don't use Zipkin v1 in any way,
and misaligns the version numbers of zipkin v1 and zipkin v2 apis.

This is an attempt to walk around the gradle plugin issue, which only
exists when someone is using both versions of zipkin.

See https://github.com/spring-projects/spring-boot/issues/10778