### PR TITLE
JavaDoc fix to match implementation

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
@@ -30,11 +30,6 @@ import org.springframework.core.env.PropertySource;
  * Adds default properties for the application:
  * <ul>
  *     <li>logging pattern level that prints trace information (e.g. trace ids)</li>
- *     <li>enables usage of subclass-based (CGLIB) proxies are to be created as opposed
- * to standard Java interface-based proxies</li>
- *     It's required for the tracing aspects like
- *     {@link org.springframework.cloud.sleuth.instrument.async.TraceAsyncAspect TraceAsyncAspect} or
- *     {@link org.springframework.cloud.sleuth.instrument.scheduling.TraceSchedulingAspect TraceSchedulingAspect}.
  * </ul>
  *
  * @author Dave Syer


### PR DESCRIPTION
The JavaDoc and implementation have drifted, since the previously included logic for aspects is no longer needed in 2.x. This removes mention of the aspects from the class JavaDoc.