### PR TITLE
The AbstractTraceHttpRequestInterceptor has been enhanced in order to…

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/HttpTraceKeysInjector.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.TraceKeys;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 
 /**
@@ -60,6 +61,14 @@ public class HttpTraceKeysInjector {
 			Map<String, ? extends Collection<String>> headers) {
 		addRequestTags(url, host, path, method);
 		addRequestTagsFromHeaders(headers);
+	}
+
+	/**
+	 * Adds tags from the HTTP repos to the given Span
+	 *
+	 */
+	public void addResponseTags(Span span, HttpStatus httpStatus) {
+		tagSpan(span, this.traceKeys.getHttp().getStatusCode(), String.valueOf(httpStatus.value()));
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/AbstractTraceHttpRequestInterceptor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 
@@ -27,6 +28,8 @@ import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.instrument.web.HttpTraceKeysInjector;
 import org.springframework.cloud.sleuth.util.SpanNameUtil;
 import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
 /**
  * Abstraction over classes that interact with Http requests. Allows you
  * to enrich the request headers with trace related information.
@@ -65,6 +68,17 @@ abstract class AbstractTraceHttpRequestInterceptor {
 		}
 	}
 
+	/**
+	 * Tracks the http response using proper tags
+	 */
+	protected void publishFinishEvent(ClientHttpResponse response) {
+		addResponseTags(response);
+
+		if (log.isDebugEnabled()) {
+			log.debug("Span [" + this.tracer.getCurrentSpan() + "] finished");
+		}
+	}
+
 	private String getName(URI uri) {
 		// The returned name should comply with RFC 882 - Section 3.1.2.
 		// i.e Header values must composed of printable ASCII values.
@@ -84,6 +98,17 @@ abstract class AbstractTraceHttpRequestInterceptor {
 				request.getURI().getPath(),
 				request.getMethod().name(),
 				request.getHeaders());
+	}
+
+	/**
+	 * Adds HTTP response tags to the client side span
+	 */
+	protected void addResponseTags(ClientHttpResponse response) {
+		try {
+			this.keysInjector.addResponseTags(this.tracer.getCurrentSpan(), response.getStatusCode());
+		} catch (IOException e) {
+			log.error(e);
+		}
 	}
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRestTemplateInterceptor.java
@@ -52,7 +52,11 @@ public class TraceRestTemplateInterceptor extends AbstractTraceHttpRequestInterc
 	public ClientHttpResponse intercept(HttpRequest request, byte[] body,
 			ClientHttpRequestExecution execution) throws IOException {
 		publishStartEvent(request);
-		return response(request, body, execution);
+
+		ClientHttpResponse response = response(request, body, execution);
+		publishFinishEvent(response);
+
+		return response;
 	}
 
 	private ClientHttpResponse response(HttpRequest request, byte[] body,


### PR DESCRIPTION
Current implementation of RestTemplate interceptor allows to track the http **request** but doesn't allow to track the http **response**.
The main reason of this pull request is to extend the current implementation so that it will be possible to send the information about http response status and then to visualize it on zipkin.