### PR TITLE
Moves to significantly more performant zipkin-reporter

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -14,9 +14,9 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<zipkin.version>2.3.1</zipkin.version>
+		<zipkin.version>2.4.1</zipkin.version>
 		<zipkin-reporter.version>1.1.2</zipkin-reporter.version>
-		<zipkin-reporter2.version>2.1.4</zipkin-reporter2.version>
+		<zipkin-reporter2.version>2.2.0</zipkin-reporter2.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -69,7 +69,7 @@
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
 				<!-- misaligned intentionally https://github.com/spring-projects/spring-boot/issues/10778-->
-				<version>2.3.0</version>
+				<version>2.4.0</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -57,7 +57,7 @@
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>2.3.1</version>
+				<version>2.4.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/pom.xml
@@ -55,6 +55,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>1.16</version>
 				<configuration>
 					<skip>true</skip>
 					<signature>

--- a/spring-cloud-sleuth-zipkin-legacy/pom.xml
+++ b/spring-cloud-sleuth-zipkin-legacy/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.9.0</version>
+			<version>3.9.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -114,7 +114,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>3.9.0</version>
+			<version>3.9.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Under load, the previous version of zipkin-reporter's AsyncReporter
caused a lot of overhead. This version fixes that by ensuring encoding
is deferred and not done inside a lock.

```
# Old AsyncReporter under load 100% sampling

± |master ?:1 ✗| → wrk -t4 -c64 -d30s http://localhost:8081
Running 30s test @ http://localhost:8081
  4 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   137.99ms  147.36ms   1.19s    85.00%
    Req/Sec   204.56    139.00   656.00     67.53%
  18963 requests in 30.05s, 2.57MB read
Requests/sec:    631.10
Transfer/sec:     87.61KB

# Same app new AsyncReporter under load 100% sampling

± |master ?:1 ✗| → wrk -t4 -c64 -d30s http://localhost:8081
Running 30s test @ http://localhost:8081
  4 threads and 64 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    41.72ms   30.04ms 280.43ms   67.68%
    Req/Sec   411.32     79.74   616.00     71.29%
  49220 requests in 30.10s, 6.67MB read
Requests/sec:   1635.28
Transfer/sec:    227.04KB
```