### PR TITLE
Optimize default endpoint ip address resolution

### DIFF
--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocator.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.sleuth.zipkin2;
 
 import java.lang.invoke.MethodHandles;
+import java.net.InetAddress;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -53,9 +54,9 @@ public class DefaultEndpointLocator implements EndpointLocator,
 	private final Registration registration;
 	private final ServerProperties serverProperties;
 	private final Environment environment;
-	private final InetUtils inetUtils;
 	private final ZipkinProperties zipkinProperties;
 	private Integer port;
+	private InetAddress firstNonLoopbackAddress;
 
 	public DefaultEndpointLocator(Registration registration, ServerProperties serverProperties,
 			Environment environment, ZipkinProperties zipkinProperties, InetUtils inetUtils) {
@@ -63,11 +64,14 @@ public class DefaultEndpointLocator implements EndpointLocator,
 		this.serverProperties = serverProperties;
 		this.environment = environment;
 		this.zipkinProperties = zipkinProperties;
+		this.firstNonLoopbackAddress = findFirstNonLoopbackAddress(inetUtils);
+	}
+
+	private InetAddress findFirstNonLoopbackAddress(InetUtils inetUtils) {
 		if (inetUtils == null) {
-			this.inetUtils = new InetUtils(new InetUtilsProperties());
-		} else {
-			this.inetUtils = inetUtils;
+			inetUtils = new InetUtils(new InetUtilsProperties());
 		}
+		return inetUtils.findFirstNonLoopbackAddress();
 	}
 
 	@Override
@@ -124,7 +128,7 @@ public class DefaultEndpointLocator implements EndpointLocator,
 			return builder;
 		}
 		else {
-			return builder.ip(this.inetUtils.findFirstNonLoopbackAddress());
+			return builder.ip(this.firstNonLoopbackAddress);
 		}
 	}
 }


### PR DESCRIPTION
Hi guys
I facing a big performance issue after adding sleuth and zipkin to my application. 
Application is very basic - simple communication between two microservices using Feign (demo: https://github.com/kamnowisz/spring-cloud-sleuth-overhead)

localhost:8080/ ---feign---> localhost:8081/hi

Without spring-cloud-sleuth-zipkin dependency "/" API takes  ~30 ms in comparison to ~450 ms with it. 
![image](https://user-images.githubusercontent.com/18535648/35194199-de10e80e-feaf-11e7-9e88-67429149957c.png)

After logs investigation it turned out that hundreds of miliseconds are spend on resolving default endpoint IP address (InetUtils.findFirstNonLoopbackAddress() method) 

```
2018-01-21 13:10:05.024  INFO [master,4686e643eac5f3f5,4686e643eac5f3f5,true] 9080 --- [nio-8080-exec-1] pl.demo.SampleController                 : INDEX started
2018-01-21 13:10:05.025 DEBUG [master,4686e643eac5f3f5,4686e643eac5f3f5,true] 9080 --- [nio-8080-exec-1] o.s.b.f.s.DefaultListableBeanFactory     : Returning cached instance of singleton bean 'sleuthTracer'
2018-01-21 13:10:05.025 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.sleuth.log.Slf4jSpanLogger     : Starting span: [Trace: 4686e643eac5f3f5, Span: 7bf47f20a71fe49f, Parent: 4686e643eac5f3f5, exportable:true]
2018-01-21 13:10:05.025 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.sleuth.log.Slf4jSpanLogger     : With parent: [Trace: 4686e643eac5f3f5, Span: 4686e643eac5f3f5, Parent: null, exportable:true]
2018-01-21 13:10:05.025 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.sleuth.log.Slf4jSpanLogger     : Continued span: [Trace: 4686e643eac5f3f5, Span: 7bf47f20a71fe49f, Parent: 4686e643eac5f3f5, exportable:true]
2018-01-21 13:10:05.025 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.sleuth.trace.SpanContextHolder     : Setting current span [Trace: 4686e643eac5f3f5, Span: 7bf47f20a71fe49f, Parent: 4686e643eac5f3f5, exportable:true]
2018-01-21 13:10:05.026 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.s.i.w.c.feign.TraceFeignClient     : Created new Feign span [Trace: 4686e643eac5f3f5, Span: 7bf47f20a71fe49f, Parent: 4686e643eac5f3f5, exportable:true]
2018-01-21 13:10:05.027 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.b.f.s.DefaultListableBeanFactory     : Returning cached instance of singleton bean 'httpSpanInjector'
2018-01-21 13:10:05.029 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.b.f.s.DefaultListableBeanFactory     : Returning cached instance of singleton bean 'httpTraceKeysInjector'
2018-01-21 13:10:05.029 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.s.i.w.c.feign.TraceFeignClient     : The modified request equals GET http://localhost:8081/hi HTTP/1.1
X-B3-ParentSpanId: 4686e643eac5f3f5
X-B3-Sampled: 1
X-B3-TraceId: 4686e643eac5f3f5
X-Span-Name: http:/hi
X-B3-SpanId: 7bf47f20a71fe49f

2018-01-21 13:10:05.059 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.s.i.w.c.feign.TraceFeignClient     : Closing Feign span and logging CR [Trace: 4686e643eac5f3f5, Span: 7bf47f20a71fe49f, Parent: 4686e643eac5f3f5, exportable:true]
2018-01-21 13:10:05.059 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.s.i.w.c.feign.TraceFeignClient     : Closing Feign span [Trace: 4686e643eac5f3f5, Span: 7bf47f20a71fe49f, Parent: 4686e643eac5f3f5, exportable:true]
2018-01-21 13:10:05.060 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'spring.application.name' in PropertySource 'server.ports'
2018-01-21 13:10:05.060 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'spring.application.name' in PropertySource 'configurationProperties'
2018-01-21 13:10:05.061 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Found key 'spring.application.name' in PropertySource 'configurationProperties' with value of type String
2018-01-21 13:10:05.062 DEBUG [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.s.zipkin2.DefaultEndpointLocator   : Span will contain serviceName [master]
2018-01-21 13:10:05.387 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.commons.util.InetUtils         : Testing interface: Software Loopback Interface 1
2018-01-21 13:10:05.391 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.commons.util.InetUtils         : Testing interface: Hyper-V Virtual Ethernet Adapter
2018-01-21 13:10:05.392 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.commons.util.InetUtils         : Found non-loopback interface: Hyper-V Virtual Ethernet Adapter
2018-01-21 13:10:05.427 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.commons.util.InetUtils         : Testing interface: Intel(R) Dual Band Wireless-N 7260
2018-01-21 13:10:05.516 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.cloud.commons.util.InetUtils         : Testing interface: Hyper-V Virtual Ethernet Adapter #2
2018-01-21 13:10:05.527 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'vcap.application.instance_id' in PropertySource 'server.ports'
2018-01-21 13:10:05.527 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'vcap.application.instance_id' in PropertySource 'configurationProperties'
2018-01-21 13:10:05.527 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'vcap.application.instance_id' in PropertySource 'servletConfigInitParams'
2018-01-21 13:10:05.527 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'vcap.application.instance_id' in PropertySource 'servletContextInitParams'
2018-01-21 13:10:05.528 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'vcap.application.instance_id' in PropertySource 'systemProperties'
2018-01-21 13:10:05.528 TRACE [master,4686e643eac5f3f5,7bf47f20a71fe49f,true] 9080 --- [nio-8080-exec-1] o.s.c.e.PropertySourcesPropertyResolver  : Searching for key 'vcap.application.instance_id' in PropertySource 'systemEnvironment'
```

What do you think about initializing ip address during application startup and reusing it? For me it is too much effort to wait hundreds of milliseconds in order to resolve IP for every span