### PR TITLE
Fixed NPE when the passed message is null.

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptor.java
@@ -43,11 +43,13 @@ import org.springframework.util.ClassUtils;
  * This starts and propagates {@link Span.Kind#PRODUCER} span for each message sent (via native
  * headers. It also extracts or creates a {@link Span.Kind#CONSUMER} span for each message
  * received. This span is injected onto each message so it becomes the parent when a handler later
- * calls {@link MessageHandler#handleMessage(Message)}, or a another processing library calls {@link #nextSpan(Message)}.
+ * calls {@link MessageHandler#handleMessage(Message)}, or another processing library calls {@link #nextSpan(Message)}.
  * <p>
  * <p>This implementation uses {@link ThreadLocalSpan} to propagate context between callbacks. This
  * is an alternative to {@code ThreadStatePropagationChannelInterceptor} which is less sensitive
  * to message manipulation by other interceptors.
+ *
+ * @author Tim Ysewyn
  */
 public final class TracingChannelInterceptor extends ChannelInterceptorAdapter
 		implements ExecutorChannelInterceptor {
@@ -99,21 +101,25 @@ public final class TracingChannelInterceptor extends ChannelInterceptorAdapter
 	 * Starts and propagates {@link Span.Kind#PRODUCER} span for each message sent.
 	 */
 	@Override public Message<?> preSend(Message<?> message, MessageChannel channel) {
-		MessageHeaderAccessor headers = mutableHeaderAccessor(message);
-		TraceContextOrSamplingFlags extracted = this.extractor.extract(headers);
-		Span span = this.threadLocalSpan.next(extracted);
-		MessageHeaderPropagation
-				.removeAnyTraceHeaders(headers, this.tracing.propagation().keys());
-		this.injector.inject(span.context(), headers);
-		if (!span.isNoop()) {
-			span.kind(Span.Kind.PRODUCER).name("send").start();
-			addTags(message, span, channel);
+		Message<?> returnedMessage = message;
+		if (shouldTraceMessage(message)) {
+			MessageHeaderAccessor headers = mutableHeaderAccessor(message);
+			TraceContextOrSamplingFlags extracted = this.extractor.extract(headers);
+			Span span = this.threadLocalSpan.next(extracted);
+			MessageHeaderPropagation
+					.removeAnyTraceHeaders(headers, this.tracing.propagation().keys());
+			this.injector.inject(span.context(), headers);
+			if (!span.isNoop()) {
+				span.kind(Span.Kind.PRODUCER).name("send").start();
+				addTags(message, span, channel);
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("Created a new span in pre send" + span);
+			}
+			headers.setImmutable();
+			returnedMessage = new GenericMessage<>(message.getPayload(), headers.getMessageHeaders());
 		}
-		if (log.isDebugEnabled()) {
-			log.debug("Created a new span in pre send" + span);
-		}
-		headers.setImmutable();
-		return new GenericMessage<>(message.getPayload(), headers.getMessageHeaders());
+		return returnedMessage;
 	}
 
 	@Override public void afterSendCompletion(Message<?> message, MessageChannel channel,
@@ -129,30 +135,36 @@ public final class TracingChannelInterceptor extends ChannelInterceptorAdapter
 	 * placing it in scope until the receive completes.
 	 */
 	@Override public Message<?> postReceive(Message<?> message, MessageChannel channel) {
-		MessageHeaderAccessor headers = mutableHeaderAccessor(message);
-		TraceContextOrSamplingFlags extracted = this.extractor.extract(headers);
-		Span span = this.threadLocalSpan.next(extracted);
-		MessageHeaderPropagation
-				.removeAnyTraceHeaders(headers, this.tracing.propagation().keys());
-		this.injector.inject(span.context(), headers);
-		if (!span.isNoop()) {
-			span.kind(Span.Kind.CONSUMER).name("receive").start();
-			addTags(message, span, channel);
+		Message<?> returnedMessage = message;
+		if (shouldTraceMessage(message)) {
+			MessageHeaderAccessor headers = mutableHeaderAccessor(message);
+			TraceContextOrSamplingFlags extracted = this.extractor.extract(headers);
+			Span span = this.threadLocalSpan.next(extracted);
+			MessageHeaderPropagation
+					.removeAnyTraceHeaders(headers, this.tracing.propagation().keys());
+			this.injector.inject(span.context(), headers);
+			if (!span.isNoop()) {
+				span.kind(Span.Kind.CONSUMER).name("receive").start();
+				addTags(message, span, channel);
+			}
+			if (log.isDebugEnabled()) {
+				log.debug("Created a new span in post receive " + span);
+			}
+			headers.setImmutable();
+			returnedMessage = new GenericMessage<>(message.getPayload(), headers.getMessageHeaders());
 		}
-		if (log.isDebugEnabled()) {
-			log.debug("Created a new span in post receive " + span);
-		}
-		headers.setImmutable();
-		return new GenericMessage<>(message.getPayload(), headers.getMessageHeaders());
+		return returnedMessage;
 	}
 
 	@Override
 	public void afterReceiveCompletion(Message<?> message, MessageChannel channel,
 			Exception ex) {
-		if (log.isDebugEnabled()) {
-			log.debug("Will finish the current span after receive completion " + this.tracer.currentSpan());
+		if (shouldTraceMessage(message)) {
+			if (log.isDebugEnabled()) {
+				log.debug("Will finish the current span after receive completion " + this.tracer.currentSpan());
+			}
+			finishSpan(ex);
 		}
-		finishSpan(ex);
 	}
 
 	/**
@@ -161,38 +173,45 @@ public final class TracingChannelInterceptor extends ChannelInterceptorAdapter
 	 */
 	@Override public Message<?> beforeHandle(Message<?> message, MessageChannel channel,
 			MessageHandler handler) {
-		MessageHeaderAccessor headers = mutableHeaderAccessor(message);
-		TraceContextOrSamplingFlags extracted = this.extractor.extract(headers);
-		// Start and finish a consumer span as we will immediately process it.
-		Span consumerSpan = this.tracer.nextSpan(extracted);
-		if (!consumerSpan.isNoop()) {
-			consumerSpan.kind(Span.Kind.CONSUMER).start();
-			addTags(message, consumerSpan, channel);
-			consumerSpan.finish();
+		Message<?> returnedMessage = message;
+		if (shouldTraceMessage(message)) {
+			MessageHeaderAccessor headers = mutableHeaderAccessor(message);
+			TraceContextOrSamplingFlags extracted = this.extractor.extract(headers);
+			// Start and finish a consumer span as we will immediately process it.
+			Span consumerSpan = this.tracer.nextSpan(extracted);
+			if (!consumerSpan.isNoop()) {
+				consumerSpan.kind(Span.Kind.CONSUMER).start();
+				addTags(message, consumerSpan, channel);
+				consumerSpan.finish();
+			}
+			// create and scope a span for the message processor
+			this.threadLocalSpan.next(TraceContextOrSamplingFlags.create(consumerSpan.context()))
+					.name("handle").start();
+			// remove any trace headers, but don't re-inject as we are synchronously processing the
+			// message and can rely on scoping to access this span later.
+			MessageHeaderPropagation
+					.removeAnyTraceHeaders(headers, this.tracing.propagation().keys());
+			if (log.isDebugEnabled()) {
+				log.debug("Created a new span in before handle" + consumerSpan);
+			}
+			if (message instanceof ErrorMessage) {
+				return new ErrorMessage((Throwable) message.getPayload(), headers.getMessageHeaders());
+			} else {
+				headers.setImmutable();
+				returnedMessage = new GenericMessage<>(message.getPayload(), headers.getMessageHeaders());
+			}
 		}
-		// create and scope a span for the message processor
-		this.threadLocalSpan.next(TraceContextOrSamplingFlags.create(consumerSpan.context()))
-				.name("handle").start();
-		// remove any trace headers, but don't re-inject as we are synchronously processing the
-		// message and can rely on scoping to access this span later.
-		MessageHeaderPropagation
-				.removeAnyTraceHeaders(headers, this.tracing.propagation().keys());
-		if (log.isDebugEnabled()) {
-			log.debug("Created a new span in before handle" + consumerSpan);
-		}
-		if (message instanceof ErrorMessage) {
-			return new ErrorMessage((Throwable) message.getPayload(), headers.getMessageHeaders());
-		}
-		headers.setImmutable();
-		return new GenericMessage<>(message.getPayload(), headers.getMessageHeaders());
+		return returnedMessage;
 	}
 
 	@Override public void afterMessageHandled(Message<?> message, MessageChannel channel,
 			MessageHandler handler, Exception ex) {
-		if (log.isDebugEnabled()) {
-			log.debug("Will finish the current span after message handled " + this.tracer.currentSpan());
+		if (shouldTraceMessage(message)) {
+			if (log.isDebugEnabled()) {
+				log.debug("Will finish the current span after message handled " + this.tracer.currentSpan());
+			}
+			finishSpan(ex);
 		}
-		finishSpan(ex);
 	}
 
 	/**
@@ -253,5 +272,9 @@ public final class TracingChannelInterceptor extends ChannelInterceptorAdapter
 			return e.getFailedMessage();
 		}
 		return message;
+	}
+
+	private boolean shouldTraceMessage(Message<?> message) {
+		return message != null && message.getPayload() != null;
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptorTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptorTest.java
@@ -16,26 +16,21 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import brave.Tracing;
 import brave.propagation.StrictCurrentTraceContext;
-import zipkin2.Span;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
-import org.springframework.messaging.support.ExecutorChannelInterceptor;
-import org.springframework.messaging.support.ExecutorSubscribableChannel;
-import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.messaging.support.NativeMessageHeaderAccessor;
+import org.springframework.messaging.support.*;
+import zipkin2.Span;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.messaging.support.NativeMessageHeaderAccessor.NATIVE_HEADERS;
@@ -194,6 +189,13 @@ public class TracingChannelInterceptorTest {
 
 		assertThat(spans).flatExtracting(Span::kind)
 				.containsExactly(Span.Kind.CONSUMER, null, Span.Kind.PRODUCER);
+	}
+
+	@Test public void pollingReceive_emptyQueue() {
+		channel.addInterceptor(consumerSideOnly(interceptor));
+
+		assertThat(channel.receive(0)).isNull();
+		assertThat(spans).hasSize(0);
 	}
 
 	ChannelInterceptor producerSideOnly(ChannelInterceptor delegate) {


### PR DESCRIPTION
This is the case when working with a QueueChannel and a Poller, which will emit a null message when the queue is empty.