### PR TITLE
Prefers "plain bean names" for community instrumentation

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -61,7 +61,8 @@ public class TraceAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	Tracing sleuthTracing(@Value("${spring.zipkin.service.name:${spring.application.name:default}}") String serviceName,
+	// NOTE: stable bean name as might be used outside sleuth
+	Tracing tracing(@Value("${spring.zipkin.service.name:${spring.application.name:default}}") String serviceName,
 			Propagation.Factory factory,
 			CurrentTraceContext currentTraceContext,
 			Reporter<zipkin2.Span> reporter,
@@ -86,7 +87,8 @@ public class TraceAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	Tracer sleuthTracer(Tracing tracing) {
+	// NOTE: stable bean name as might be used outside sleuth
+	Tracer tracer(Tracing tracing) {
 		return tracing.tracer();
 	}
 
@@ -144,7 +146,8 @@ public class TraceAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	CurrentSpanCustomizer sleuthCurrentSpanCustomizer(Tracing tracing) {
+	// NOTE: stable bean name as might be used outside sleuth
+	CurrentSpanCustomizer spanCustomizer(Tracing tracing) {
 		return CurrentSpanCustomizer.create(tracing);
 	}
 }


### PR DESCRIPTION
Instrumentation around brave is more likely to use a simple bean name
like "tracing" vs "sleuthTracing". This changes the commodity beans to
simple names so that we can avoid having to teach naming prefixes unless
necessary.

This affects the following beans:
* httpTracing
* tracing
* tracer
* spanCustomizer

This came up when integrating dubbo, as their [extension loader](https://github.com/alibaba/dubbo/blob/master/dubbo-config/dubbo-config-spring/src/main/java/com/alibaba/dubbo/config/spring/extension/SpringExtensionFactory.java#L43) prefers
stable bean names. For example, loading `brave.Tracing` with their
spring extension silently failed because our bean was named
"sleuthTracing". Even if we can provide instructions to override this,
seems best to dodge.