### PR TITLE
Adds test to make sure RestTemplate sender doesn't mess with json

### DIFF
--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -149,6 +149,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.zipkin.zipkin2</groupId>
+			<artifactId>zipkin</artifactId>
+			<type>test-jar</type>
+			<version>${zipkin.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjrt</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/sender/RestTemplateSenderTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/sender/RestTemplateSenderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.zipkin2.sender;
+
+import java.util.stream.Stream;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.web.client.RestTemplate;
+import zipkin2.Call;
+import zipkin2.Span;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.TestObjects.UTF_8;
+import static zipkin2.codec.SpanBytesEncoder.JSON_V2;
+
+public class RestTemplateSenderTest {
+
+  @Rule public MockWebServer server = new MockWebServer();
+
+  String endpoint = server.url("/api/v2/spans").toString();
+  RestTemplateSender sender = new RestTemplateSender(new RestTemplate(), endpoint, JSON_V2);
+
+  /** Tests that json is not manipulated as a side-effect of using rest template. */
+  @Test public void jsonIsNormal() throws Exception {
+    server.enqueue(new MockResponse());
+
+    send(CLIENT_SPAN).execute();
+
+    assertThat(server.takeRequest().getBody().readUtf8())
+        .isEqualTo("[" + new String(JSON_V2.encode(CLIENT_SPAN), UTF_8) + "]");
+  }
+
+  Call<Void> send(Span... spans) {
+    return sender.sendSpans(Stream.of(spans)
+        .map(JSON_V2::encode)
+        .collect(toList()));
+  }
+}


### PR DESCRIPTION
There was some doubt on gitter about sleuth generating spans with floating-point
rendered timestamps. While this shouldn't break people we certainly shouldn't
create json like this.

This was presumed to be caused by sleuth's rest template sender by @mojsha who
was trying Jaeger. Jaeger's parser doesn't give any errors with a 400.
```json
[
{
"traceId": "a65dac9d8bbb57f8",
"parentId": "a65dac9d8bbb57f8",
"id": "f223bb97e1eba9b2",
"kind": "SERVER",
"name": "https:\/hello3",
"timestamp": 1.521027116604e+15,
"duration": 1525,
"localEndpoint": {
"serviceName": "${spring.application.name}",
"ipv4": "10.128.6.98",
"port": 8443
},
```

I added a test to make sure it is not the case.