### PR TITLE
Handle sleuth headers sent from spring-kafka as byte[] in Spring Cloud

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagation.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagation.java
@@ -130,7 +130,7 @@ enum MessageHeaderPropagation
 		Object result = accessor.getHeader(key);
 		if (result != null) {
 			if (result instanceof byte[]) {
-				return new String((byte[])result, UTF_8);
+				return new String((byte[]) result, UTF_8);
 			}
 			return result.toString();
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagation.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagation.java
@@ -29,6 +29,7 @@ import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.StringUtils;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.springframework.messaging.support.NativeMessageHeaderAccessor.NATIVE_HEADERS;
 
 /**
@@ -127,7 +128,13 @@ enum MessageHeaderPropagation
 			}
 		}
 		Object result = accessor.getHeader(key);
-		return result != null ? result.toString() : null;
+		if (result != null) {
+			if (result instanceof byte[]) {
+				return new String((byte[])result, UTF_8);
+			}
+			return result.toString();
+		}
+		return null;
 	}
 
 	static void removeAnyTraceHeaders(MessageHeaderAccessor accessor,

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagationTest.java
@@ -19,7 +19,12 @@ package org.springframework.cloud.sleuth.instrument.messaging;
 import java.util.Collections;
 
 import brave.propagation.Propagation;
+import org.junit.Assert;
+import org.junit.Test;
 import org.springframework.messaging.support.MessageHeaderAccessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 
 public class MessageHeaderPropagationTest
 		extends PropagationSetterTest<MessageHeaderAccessor, String> {
@@ -42,5 +47,30 @@ public class MessageHeaderPropagationTest
 		return result != null ?
 				Collections.singleton(result.toString()) :
 				Collections.emptyList();
+	}
+	
+	@Test
+	public void testGetByteArrayValue() {
+		MessageHeaderAccessor carrier = carrier();
+		byte[] bytes = "48485a3953bb6124".getBytes();
+		carrier.setHeader("X-B3-TraceId", bytes);
+		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "X-B3-TraceId");
+		assertEquals("48485a3953bb6124", value);
+	}
+	
+	@Test
+	public void testGetStringValue() {
+		MessageHeaderAccessor carrier = carrier();
+		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124");
+		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "X-B3-TraceId");
+		assertEquals("48485a3953bb6124", value);
+	}
+	
+	@Test
+	public void testGetNullValue() {
+		MessageHeaderAccessor carrier = carrier();
+		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124");
+		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "non existent key");
+		assertNull(value);
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagationTest.java
@@ -52,24 +52,26 @@ public class MessageHeaderPropagationTest
 	@Test
 	public void testGetByteArrayValue() {
 		MessageHeaderAccessor carrier = carrier();
-		byte[] bytes = "48485a3953bb6124".getBytes();
-		carrier.setHeader("X-B3-TraceId", bytes);
+		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124".getBytes());
+		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124000000".getBytes());
 		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "X-B3-TraceId");
-		assertEquals("48485a3953bb6124", value);
+		assertEquals("48485a3953bb6124000000", value);
 	}
 	
 	@Test
 	public void testGetStringValue() {
 		MessageHeaderAccessor carrier = carrier();
 		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124");
+		carrier.setHeader("X-B3-TraceId", "48485a3953bb61240000000");
 		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "X-B3-TraceId");
-		assertEquals("48485a3953bb6124", value);
+		assertEquals("48485a3953bb61240000000", value);
 	}
 	
 	@Test
 	public void testGetNullValue() {
 		MessageHeaderAccessor carrier = carrier();
 		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124");
+		carrier.setHeader("X-B3-TraceId", "48485a3953bb61240000000");
 		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "non existent key");
 		assertNull(value);
 	}


### PR DESCRIPTION
Handle sleuth tracing headers sent from spring-kafka as byte[] in Spring Cloud Stream sleuth tracing so propagation works as expected.

Similar to https://github.com/openzipkin/brave/blob/master/instrumentation/kafka-clients/src/main/java/brave/kafka/clients/KafkaPropagation.java#L21