### PR TITLE
Moves to latest Zipkin and formally deprecates the stream server

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<zipkin.version>2.6.1</zipkin.version>
+		<zipkin.version>2.7.0</zipkin.version>
 		<zipkin-reporter.version>1.1.2</zipkin-reporter.version>
 		<zipkin-reporter2.version>2.5.0</zipkin-reporter2.version>
 	</properties>
@@ -69,7 +69,7 @@
 				<groupId>io.zipkin.java</groupId>
 				<artifactId>zipkin</artifactId>
 				<!-- misaligned intentionally https://github.com/spring-projects/spring-boot/issues/10778-->
-				<version>2.6.0</version>
+				<version>2.6.1</version>
 			</dependency>
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -57,7 +57,7 @@
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>2.6.1</version>
+				<version>2.7.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-zipkin-stream/README.md
+++ b/spring-cloud-sleuth-zipkin-stream/README.md
@@ -1,3 +1,8 @@
+# This project is deprecated
+
+Please switch to the normal Zipkin server which supports RabbitMQ and Kafka.
+See [our documentation](https://cloud.spring.io/spring-cloud-sleuth/single/spring-cloud-sleuth.html#_sleuth_with_zipkin_over_rabbitmq_or_kafka) for more.
+
 # Running Zipkin Server
 
 There are 3 parts to Zipkin: the instrumented client apps, the backend database and the Zipkin server. The database for this implementation is MySQL.

--- a/spring-cloud-sleuth-zipkin-stream/pom.xml
+++ b/spring-cloud-sleuth-zipkin-stream/pom.xml
@@ -19,6 +19,8 @@
 		<docker.image.prefix>springio</docker.image.prefix>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -136,13 +138,17 @@
 					</resources>
 				</configuration>
 			</plugin>
+			<!-- Manually disable animal sniffer as somehow maven profile mistakes JDK 8 for JDK 7 -->
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>1.14</version>
+					<executions>
+						<execution>
+							<id>enforce-java-7</id>
+							<phase>none</phase>
+						</execution>
+					</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/EnableZipkinStreamServer.java
+++ b/spring-cloud-sleuth-zipkin-stream/src/main/java/org/springframework/cloud/sleuth/zipkin/stream/EnableZipkinStreamServer.java
@@ -18,12 +18,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.springframework.cloud.sleuth.stream.SleuthSink;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.context.annotation.Import;
-
-import zipkin.server.EnableZipkinServer;
+import zipkin.server.internal.EnableZipkinServer;
 
 /**
  * When enabled, instrumented apps will transport spans over a
@@ -33,7 +31,10 @@ import zipkin.server.EnableZipkinServer;
  * @since 1.0.0
  *
  * @see ZipkinMessageListener
+ * @deprecated Please switch to the normal Zipkin server which supports RabbitMQ and Kafka.
+ * See <a href="https://cloud.spring.io/spring-cloud-sleuth/single/spring-cloud-sleuth.html#_sleuth_with_zipkin_over_rabbitmq_or_kafka">our documentation</a> for more.
  */
+@Deprecated
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented


### PR DESCRIPTION
Our docs deprecated the spring-cloud-sleuth-zipkin-stream, but the
project didn't.