### PR TITLE
Sleuth no longer corrupts Error message in Spring Integration

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagation.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagation.java
@@ -137,6 +137,17 @@ enum MessageHeaderPropagation
 		return null;
 	}
 
+	static Map<String, ?> propagationHeaders(Map<String, ?> headers,
+			List<String> propagationHeaders) {
+		Map<String, Object> headersToCopy = new HashMap<>();
+		for (Map.Entry<String, ?> entry : headers.entrySet()) {
+			if (propagationHeaders.contains(entry.getKey())) {
+				headersToCopy.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return headersToCopy;
+	}
+
 	static void removeAnyTraceHeaders(MessageHeaderAccessor accessor,
 			List<String> keysToRemove) {
 		for (String keyToRemove : keysToRemove) {


### PR DESCRIPTION
when getting an `ErrorMessage` we have 2 pairs of headers. The headers from the `ErrorMessage` and the headers from the payload which also is a message. The payload that happens to be a message contains the tracing headers. We need to extract these to retrieve the tracing context. HOWEVER these are the only headers we are interested in. We MUST NOT copy any other headers than the tracing ones to a new message that we will return from the method.

fixes gh-946