### PR TITLE
Skip tracing root Actuator endpoint

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 public class SleuthWebProperties {
 
 	public static final String DEFAULT_SKIP_PATTERN =
-			"/api-docs.*|/autoconfig|/configprops|/dump|/health|/info|/metrics.*|/mappings|/trace|/swagger.*|.*\\.png|.*\\.css|.*\\.js|.*\\.html|/favicon.ico|/hystrix.stream|/application/.*|/actuator/.*|/cloudfoundryapplication";
+			"/api-docs.*|/autoconfig|/configprops|/dump|/health|/info|/metrics.*|/mappings|/trace|/swagger.*|.*\\.png|.*\\.css|.*\\.js|.*\\.html|/favicon.ico|/hystrix.stream|/application/.*|/actuator.*|/cloudfoundryapplication";
 
 	/**
 	 * When true enables instrumentation for web applications


### PR DESCRIPTION
Updates the default skip pattern to include the Spring Boot 2 root Actuator endpoint `/actuator`.

See #737