### PR TITLE
Updates to Brave 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 		<spring-cloud-stream.version>Elmhurst.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<spring-cloud-netflix.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-openfeign.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-openfeign.version>
-		<brave.version>4.19.2</brave.version>
+		<brave.version>5.0.0</brave.version>
 		<spring-security-boot-autoconfigure.version>2.0.0.RELEASE</spring-security-boot-autoconfigure.version>
 	</properties>
 

--- a/spring-cloud-sleuth-core/pom.xml
+++ b/spring-cloud-sleuth-core/pom.xml
@@ -209,14 +209,6 @@
 			<artifactId>spring-security-oauth2-autoconfigure</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<!-- to compile against Span.remoteEndpoint(zipkin.Span) -->
-		<dependency>
-			<groupId>io.zipkin.java</groupId>
-			<artifactId>zipkin</artifactId>
-			<!-- misaligned intentionally https://github.com/spring-projects/spring-boot/issues/10778-->
-                        <version>2.8.0</version>
-			<optional>true</optional>
-		</dependency>
 		<!-- BRAVE -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpClientParserTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpClientParserTests.java
@@ -90,8 +90,4 @@ class TestSpanCustomizer implements SpanCustomizer {
 	@Override public SpanCustomizer annotate(String value) {
 		return this;
 	}
-
-	@Override public SpanCustomizer annotate(long timestamp, String value) {
-		return this;
-	}
 }

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -30,7 +30,7 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<brave.opentracing.version>0.30.3</brave.opentracing.version>
+		<brave.opentracing.version>0.31.0</brave.opentracing.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -73,7 +73,7 @@
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>2.8.1</version>
+				<version>2.8.4</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
same as Brave 4, but without any deprecated methods (or deprecated dependencies like io.zipkin.java:zipkin)