### PR TITLE
Adjusts expectations of data reporting of loopback spans

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersHook.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersHook.java
@@ -128,7 +128,7 @@ class SleuthRxJavaSchedulersHook extends RxJavaSchedulersHook {
 			Span span = this.parent;
 			boolean created = false;
 			if (span != null) {
-				span = this.tracer.joinSpan(this.parent.context());
+				span = this.tracer.toSpan(this.parent.context());
 			} else {
 				span = this.tracer.nextSpan().name(RXJAVA_COMPONENT).start();
 				span.tag(THREAD_NAME_KEY, Thread.currentThread().getName());

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
@@ -173,7 +173,7 @@ public class SpringCloudSleuthDocTests {
 						// tag::manual_span_continuation[]
 						// let's assume that we're in a thread Y and we've received
 						// the `initialSpan` from thread X
-						Span continuedSpan = this.tracer.joinSpan(newSpan.context());
+						Span continuedSpan = this.tracer.toSpan(newSpan.context());
 						try {
 							// ...
 							// You can tag a span

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SpringDataInstrumentationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SpringDataInstrumentationTests.java
@@ -81,10 +81,10 @@ public class SpringDataInstrumentationTests {
 		then(noOfNames).isEqualTo(8);
 		then(this.reporter.getSpans()).isNotEmpty();
 		Awaitility.await().untilAsserted(() -> {
-			then(this.reporter.getSpans()).hasSize(1);
-			zipkin2.Span storedSpan = this.reporter.getSpans().get(0);
-			then(storedSpan.name()).isEqualTo("http:/reservations");
-			then(storedSpan.tags()).containsKey("mvc.controller.class");
+			then(this.reporter.getSpans()).hasSize(2 /* server completes, then client completes */);
+			zipkin2.Span clientSpan = this.reporter.getSpans().get(1);
+			then(clientSpan.name()).isEqualTo("http:/reservations");
+			then(clientSpan.tags()).containsKey("mvc.controller.class");
 		});
 		then(this.tracer.currentSpan()).isNull();
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/multiple/MultipleHopsIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/multiple/MultipleHopsIntegrationTests.java
@@ -77,7 +77,7 @@ public class MultipleHopsIntegrationTests {
 		this.restTemplate.getForObject("http://localhost:" + this.config.port + "/greeting", String.class);
 
 		await().atMost(5, SECONDS).untilAsserted(() -> {
-			then(this.reporter.getSpans()).hasSize(13);
+			then(this.reporter.getSpans()).hasSize(14);
 		});
 		then(this.reporter.getSpans().stream().map(zipkin2.Span::name)
 				.collect(toList())).containsAll(asList("http:/greeting", "send"));

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/src/test/java/integration/MessagingApplicationTests.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/src/test/java/integration/MessagingApplicationTests.java
@@ -129,7 +129,7 @@ public class MessagingApplicationTests extends AbstractIntegrationTest {
 		Optional<Span> lastHttpSpansParent = findLastHttpSpansParent();
 		// "http:/parent/" -> "message:messages" -> "http:/foo" (CS + CR) -> "http:/foo" (SS)
 		thenAllSpansArePresent(firstHttpSpan, eventSpans, lastHttpSpansParent, eventSentSpan, producerSpan);
-		then(this.integrationTestSpanCollector.hashedSpans).as("There were 5 spans").hasSize(5);
+		then(this.integrationTestSpanCollector.hashedSpans).as("There were 6 spans").hasSize(6);
 		log.info("Checking the parent child structure");
 		List<Optional<Span>> parentChild = this.integrationTestSpanCollector.hashedSpans.stream()
 				.filter(span -> span.parentId() != null)


### PR DESCRIPTION
The latest version of Brave corrects a data merge problem where shared
spans (created via Tracer.joinSpan) would lose some data. Along the way,
this fixes some misuse of `Tracer.joinSpan` which should only be used
for RPC server spans.

See https://github.com/openzipkin/brave/pull/734 applied in Brave 5.1.3