### PR TITLE
ability to disable instrumentation in ThreadPoolTaskExecutor

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.async;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration}
+ * that wraps an existing custom {@link AsyncConfigurer} in a {@link LazyTraceAsyncCustomizer}
+ *
+ * @author Jesus Alonso
+ * @since 2.0.1
+ */
+
+@Configuration
+@EnableConfigurationProperties(AsyncProperties.class)
+public class AsyncAutoConfiguration {
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
  * that wraps an existing custom {@link AsyncConfigurer} in a {@link LazyTraceAsyncCustomizer}
  *
  * @author Jesus Alonso
- * @since 2.0.1
+ * @since 2.1.0
  */
 
 @Configuration

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Settings for disable instrumentation of ThreadPoolTaskExecutors
  *
  * @author Jesus Alonso
- * @since 2.0.1
+ * @since 2.1.0
  */
 
 @ConfigurationProperties(prefix = "spring.sleuth.async")
@@ -34,7 +34,7 @@ public class AsyncProperties {
 	private List<String> ignoredBeans = Collections.emptyList();
 
 	public List<String> getIgnoredBeans() {
-		return ignoredBeans;
+		return this.ignoredBeans;
 	}
 	public void setIgnoredBeans(List<String> ignoredBeans) {
 		this.ignoredBeans = ignoredBeans;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.async;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Settings for disable instrumentation of ThreadPoolTaskExecutors
+ *
+ * @author Jesus Alonso
+ * @since 2.0.1
+ */
+
+@ConfigurationProperties(prefix = "spring.sleuth.async")
+public class AsyncProperties {
+	
+	private List<String> ignoredBeans = Collections.emptyList();
+
+	public List<String> getIgnoredBeans() {
+		return ignoredBeans;
+	}
+	public void setIgnoredBeans(List<String> ignoredBeans) {
+		this.ignoredBeans = ignoredBeans;
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ExecutorBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ExecutorBeanPostProcessor.java
@@ -80,17 +80,21 @@ class ExecutorBeanPostProcessor implements BeanPostProcessor {
 				throw e;
 			}
 		} else if (bean instanceof ThreadPoolTaskExecutor) {
-			boolean classFinal = Modifier.isFinal(bean.getClass().getModifiers());
-			boolean cglibProxy = !classFinal;
-			ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) bean;
-			AsyncProperties asyncProperties = asyncConfigurationProperties();
-			if (!asyncProperties.getIgnoredBeans().contains(beanName)) {
+			if (isProxyNeeded(beanName)) {
+				boolean classFinal = Modifier.isFinal(bean.getClass().getModifiers());
+				boolean cglibProxy = !classFinal;
+				ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) bean;
 				return createThreadPoolTaskExecutorProxy(bean, cglibProxy, executor);
 			} else {
 				log.info("Not instrumenting bean " + beanName);
 			}
 		}
 		return bean;
+	}
+
+	boolean isProxyNeeded(String beanName) {
+		AsyncProperties asyncProperties = asyncConfigurationProperties();
+		return !asyncProperties.getIgnoredBeans().contains(beanName);
 	}
 
 	Object createThreadPoolTaskExecutorProxy(Object bean, boolean cglibProxy,
@@ -119,7 +123,7 @@ class ExecutorBeanPostProcessor implements BeanPostProcessor {
 		if (this.asyncProperties == null) {
 			this.asyncProperties = this.beanFactory.getBean(AsyncProperties.class);
 		}
-		return asyncProperties;
+		return this.asyncProperties;
 	}
 }
 

--- a/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
@@ -8,6 +8,7 @@ org.springframework.cloud.sleuth.instrument.web.TraceWebAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceWebServletAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.client.TraceWebClientAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.client.TraceWebAsyncClientAutoConfiguration,\
+org.springframework.cloud.sleuth.instrument.async.AsyncAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.async.AsyncCustomAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.async.AsyncDefaultAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.scheduling.TraceSchedulingAutoConfiguration,\


### PR DESCRIPTION
We have a spring-boot application (spring-boot-starter-parent-2.0.0.RELEASE) using spring-cloud-starter-zipkin for writing "spans" to zipkin.

We use spring-integration too (through spring-boot-starter-integration) and we have added an integration flow with a PollableChannel to be used within a poller:

```
@Bean
public PollableChannel pollableChannel() {
    return new QueueChannel(100);
}

@Bean
@ServiceActivator(poller = @Poller(taskExecutor="batchTaskExecutor"), 
                  inputChannel= "pollableChannel")
public MyHandler myHandler() {
    return new MyHandler();
}
```

Since adding this configuration, we are having an "asynch" span every second. I raised a question in stackoverflow -> https://stackoverflow.com/questions/51438273/zipkin-asynch-span-every-second. So after investigating the issue, it turned out the span comes from the ThreadPoolTaskExecutor that the @Poller uses to check if there are new items.

I've made an improvement to disable instrumentation of ThreadPoolTaskExecutor based on the name of the executor. You can use spring.sleuth.async.ignoredBeans to configure a list of executors without instrumentation.

For instance, in the previous example:

```
spring:
  sleuth:
    async:
      ignoredBeans: batchTaskExecutor 
```