### PR TITLE
Added an option to filter out outbound requests

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
@@ -82,6 +82,10 @@ public class SleuthWebProperties {
 	}
 
 	public static class Client {
+		/**
+		 * Pattern for URLs that should be skipped in client side tracing
+		 */
+		private String skipPattern;
 
 		/**
 		 * Enable interceptor injecting into {@link org.springframework.web.client.RestTemplate}
@@ -94,6 +98,14 @@ public class SleuthWebProperties {
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public String getSkipPattern() {
+			return this.skipPattern;
+		}
+
+		public void setSkipPattern(String skipPattern) {
+			this.skipPattern = skipPattern;
 		}
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
@@ -85,7 +85,7 @@ public class SleuthWebProperties {
 		/**
 		 * Pattern for URLs that should be skipped in client side tracing
 		 */
-		private String skipPattern;
+		private String skipPattern = "";
 
 		/**
 		 * Enable interceptor injecting into {@link org.springframework.web.client.RestTemplate}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.java
@@ -112,8 +112,7 @@ public class TraceHttpAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(name = ClientSampler.NAME)
 	HttpSampler sleuthClientSampler(SleuthWebProperties sleuthWebProperties) {
-		return new CompositeHttpSampler(new PathMatchingHttpSampler(
-				sleuthWebProperties), HttpSampler.TRACE_ID);
+		return new PathMatchingHttpSampler(sleuthWebProperties);
 	}
 }
 


### PR DESCRIPTION
without this change there's no way to filter outbound requests basing on the path via a property.
with this change we're introducing that

fixes gh-1047