### PR TITLE
Replace InMemoryReporterMetrics with No Op Reporter Metrics

### DIFF
--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
@@ -22,7 +22,6 @@ import brave.sampler.Sampler;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.InMemoryReporterMetrics;
 import zipkin2.reporter.Reporter;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.Sender;
@@ -104,7 +103,7 @@ public class ZipkinAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	ReporterMetrics sleuthReporterMetrics() {
-		return new InMemoryReporterMetrics(); 
+		return ReporterMetrics.NOOP_METRICS;
 	}
 	
 	@Configuration


### PR DESCRIPTION
This was causing a memory leak in a production service where the Zipkin service was unavailable as InMemoryReporterMetrics kept incrementing the messagesDropped.

Since InMemoryReporterMetrics should be used for troubleshooting I think a no-op one is a more sensible default.

This is a trivial chance and I first want some feedback, so I'm not sure if signing a contributor license agreement is required.