### PR TITLE
Bumps to latest brave

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
 		<spring-cloud-stream.version>Fishtown.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<spring-cloud-netflix.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-openfeign.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-openfeign.version>
-		<brave.version>5.4.2</brave.version>
+		<brave.version>5.4.3</brave.version>
 		<spring-security-boot-autoconfigure.version>2.0.4.RELEASE</spring-security-boot-autoconfigure.version>
 	</properties>
 

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -30,7 +30,7 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<brave.opentracing.version>0.33.3</brave.opentracing.version>
+		<brave.opentracing.version>0.33.4</brave.opentracing.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -73,7 +73,7 @@
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>2.11.6</version>
+				<version>2.11.7</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Notably, this fixes a bug in b3 single propagation when 128bit trace
IDs are in use.