### PR TITLE
Optimize Reactor Instrumentation

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
@@ -16,21 +16,20 @@
 
 package org.springframework.cloud.sleuth.instrument.reactor;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
+import brave.Span;
 import brave.Tracing;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
 import reactor.core.Scannable;
-import reactor.core.publisher.ConnectableFlux;
-import reactor.core.publisher.GroupedFlux;
 import reactor.core.publisher.Operators;
 import reactor.util.context.Context;
 
@@ -60,58 +59,63 @@ public abstract class ReactorSleuth {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T> Function<? super Publisher<T>, ? extends Publisher<T>> scopePassingSpanOperator(
-			ConfigurableApplicationContext beanFactory) {
+			BeanFactory beanFactory) {
 		if (log.isTraceEnabled()) {
 			log.trace("Scope passing operator [" + beanFactory + "]");
 		}
-		return (sourcePub -> {
-			// TODO: Remove this once Reactor 3.1.8 is released
-			// do the checks directly on actual original Publisher
-			if (sourcePub instanceof ConnectableFlux // Operators.lift can't handle that
-					|| sourcePub instanceof GroupedFlux // Operators.lift can't handle
-														// that
-			) {
-				return sourcePub;
-			}
-			// no more POINTCUT_FILTER since mechanism is broken
-			Function<? super Publisher<T>, ? extends Publisher<T>> lift = Operators
-					.lift((scannable, sub) -> {
-						// rest of the logic unchanged...
-						if (beanFactory.isActive()) {
-							if (log.isTraceEnabled()) {
-								log.trace("Spring Context [" + beanFactory
-										+ "] already refreshed. Creating a scope "
-										+ "passing span subscriber with Reactor Context "
-										+ "[" + sub.currentContext() + "] and name ["
-										+ scannable.name() + "]");
-							}
-							return scopePassingSpanSubscription(beanFactory, scannable,
-									sub).get();
-						}
-						if (log.isTraceEnabled()) {
-							log.trace("Spring Context [" + beanFactory
-									+ "] is not yet refreshed, falling back to lazy span subscriber. Reactor Context is ["
-									+ sub.currentContext() + "] and name is ["
-									+ scannable.name() + "]");
-						}
-						return new LazySpanSubscriber<T>(scopePassingSpanSubscription(
-								beanFactory, scannable, sub));
-					});
 
-			return lift.apply(sourcePub);
+		//Adapt if lazy bean factory
+		BooleanSupplier isActive =
+				beanFactory instanceof ConfigurableApplicationContext ?
+						((ConfigurableApplicationContext) beanFactory)::isActive :
+						() -> true;
+
+		return Operators.liftPublisher((p, sub) -> {
+			//if Flux/Mono #just, #empty, #error
+			if (p instanceof Fuseable.ScalarCallable) {
+				return sub;
+			}
+			Scannable scannable = Scannable.from(p);
+			// rest of the logic unchanged...
+			if (isActive.getAsBoolean()) {
+				if (log.isTraceEnabled()) {
+					log.trace("Spring Context [" + beanFactory
+							+ "] already refreshed. Creating a scope "
+							+ "passing span subscriber with Reactor Context "
+							+ "[" + sub.currentContext() + "] and name ["
+							+ scannable.name() + "]");
+				}
+
+				return scopePassingSpanSubscription(beanFactory.getBean(Tracing.class), sub);
+			}
+			if (log.isTraceEnabled()) {
+				log.trace("Spring Context [" + beanFactory
+						+ "] is not yet refreshed, falling back to lazy span subscriber. Reactor Context is ["
+						+ sub.currentContext() + "] and name is ["
+						+ scannable.name() + "]");
+			}
+			return new LazySpanSubscriber<>(lazyScopePassingSpanSubscription(beanFactory, scannable, sub));
 		});
 	}
 
-	private static <T> SpanSubscriptionProvider<T> scopePassingSpanSubscription(
+	static <T> SpanSubscriptionProvider<T> lazyScopePassingSpanSubscription(
 			BeanFactory beanFactory, Scannable scannable, CoreSubscriber<? super T> sub) {
-		return new SpanSubscriptionProvider<T>(beanFactory, sub, sub.currentContext(),
-				scannable.name()) {
-			@Override
-			SpanSubscription newCoreSubscriber(Tracing tracing) {
-				return new ScopePassingSpanSubscriber<T>(sub,
-						sub != null ? sub.currentContext() : Context.empty(), tracing);
-			}
-		};
+		return new SpanSubscriptionProvider<>(beanFactory, sub, sub.currentContext(), scannable.name());
+	}
+
+
+	static <T> CoreSubscriber<? super T> scopePassingSpanSubscription(
+			Tracing tracing, CoreSubscriber<? super T> sub) {
+
+		Context context = sub.currentContext();
+
+		Span root = context.hasKey(Span.class) ? context.get(Span.class) : tracing.tracer().currentSpan();
+		if (root != null) {
+			return new ScopePassingSpanSubscriber<>(sub, context, tracing, root);
+		}
+		else {
+			return sub; //no need to trace
+		}
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
@@ -51,7 +51,7 @@ public abstract class ReactorSleuth {
 	 * Return a span operator pointcut given a {@link Tracing}. This can be used in
 	 * reactor via {@link reactor.core.publisher.Flux#transform(Function)},
 	 * {@link reactor.core.publisher.Mono#transform(Function)},
-	 * {@link reactor.core.publisher.Hooks#onEachOperator(Function)} or
+	 * {@link reactor.core.publisher.Hooks#onLastOperator(Function)} or
 	 * {@link reactor.core.publisher.Hooks#onLastOperator(Function)}. The Span operator
 	 * pointcut will pass the Scope of the Span without ever creating any new spans.
 	 * @param beanFactory - {@link BeanFactory}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriptionProvider.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriptionProvider.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.instrument.reactor;
 
 import java.util.function.Supplier;
 
+import brave.Span;
 import brave.Tracing;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,7 +32,7 @@ import reactor.util.context.Context;
  * @param <T> type of returned subscription
  * @author Marcin Grzejszczak
  */
-class SpanSubscriptionProvider<T> implements Supplier<SpanSubscription<T>> {
+final class SpanSubscriptionProvider<T> implements Supplier<SpanSubscription<T>> {
 
 	private static final Log log = LogFactory.getLog(SpanSubscriptionProvider.class);
 
@@ -63,7 +64,8 @@ class SpanSubscriptionProvider<T> implements Supplier<SpanSubscription<T>> {
 	}
 
 	SpanSubscription<T> newCoreSubscriber(Tracing tracing) {
-		return new ScopePassingSpanSubscriber<>(this.subscriber, this.context, tracing);
+		Span root = context.hasKey(Span.class) ? context.get(Span.class) : tracing.tracer().currentSpan();
+		return new ScopePassingSpanSubscriber<>(this.subscriber, this.context, tracing, root);
 	}
 
 	private Tracing tracing() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
@@ -85,7 +85,7 @@ public class TraceReactorAutoConfiguration {
 			if (log.isTraceEnabled()) {
 				log.trace("Cleaning up hooks");
 			}
-			Hooks.resetOnEachOperator(SLEUTH_TRACE_REACTOR_KEY);
+			Hooks.resetOnLastOperator(SLEUTH_TRACE_REACTOR_KEY);
 			Schedulers.resetFactory();
 		}
 
@@ -115,7 +115,7 @@ class HookRegisteringBeanDefinitionRegistryPostProcessor
 	}
 
 	void setupHooks(BeanFactory beanFactory) {
-		Hooks.onEachOperator(
+		Hooks.onLastOperator(
 				TraceReactorAutoConfiguration.TraceReactorConfiguration.SLEUTH_TRACE_REACTOR_KEY,
 				ReactorSleuth.scopePassingSpanOperator(this.context));
 		Schedulers.setFactory(factoryInstance(beanFactory));

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
@@ -590,8 +590,7 @@ public class SleuthSpanCreatorAspectFluxTests {
 
 		@Override
 		public Flux<Long> newSpanInTraceContext() {
-			Long id = id(tracer);
-			return Flux.defer(() -> Flux.just(id));
+			return Flux.defer(() -> Flux.just(id(tracer)));
 		}
 
 		@Override

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriberTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriberTests.java
@@ -258,7 +258,7 @@ public class SpanSubscriberTests {
 
 	@AfterClass
 	public static void cleanup() {
-		Hooks.resetOnEachOperator();
+		Hooks.resetOnLastOperator();
 		Schedulers.resetFactory();
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriberTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriberTests.java
@@ -17,31 +17,25 @@
 package org.springframework.cloud.sleuth.instrument.reactor;
 
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import brave.Span;
 import brave.Tracer;
 import brave.sampler.Sampler;
-import org.reactivestreams.Subscriber;
-import reactor.core.CoreSubscriber;
-import reactor.core.Scannable;
-import reactor.core.publisher.BaseSubscriber;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Hooks;
-import reactor.core.publisher.Mono;
-import reactor.core.publisher.Operators;
-import reactor.core.scheduler.Schedulers;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.awaitility.Awaitility;
-import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -212,8 +206,8 @@ public class SpanSubscriberTests {
 			    }).map(d -> d + 1).blockLast();
 
 			Awaitility.await().untilAsserted(() -> {
-				then(spanInOperation.get().context().spanId())
-						.isEqualTo(span.context().spanId());
+				then(spanInOperation.get().context().traceId())
+						.isEqualTo(span.context().traceId());
 			});
 			then(this.tracer.currentSpan()).isEqualTo(span);
 		}
@@ -233,8 +227,8 @@ public class SpanSubscriberTests {
 
 			then(this.tracer.currentSpan()).isEqualTo(foo2);
 			// parent cause there's an async span in the meantime
-			then(spanInOperation.get().context().spanId())
-					.isEqualTo(foo2.context().spanId());
+			then(spanInOperation.get().context().traceId())
+					.isEqualTo(foo2.context().traceId());
 		}
 		finally {
 			foo2.finish();
@@ -307,12 +301,6 @@ public class SpanSubscriberTests {
 		}
 
 		then(spanInSubscriberContext).hasValue(initSpan.context().spanId()); // ok here
-	}
-
-	@AfterClass
-	public static void cleanup() {
-		Hooks.resetOnLastOperator();
-		Schedulers.resetFactory();
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriberTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/SpanSubscriberTests.java
@@ -17,10 +17,15 @@
 package org.springframework.cloud.sleuth.instrument.reactor;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import brave.Span;
 import brave.Tracer;
 import brave.sampler.Sampler;
+import org.reactivestreams.Subscriber;
+import reactor.core.CoreSubscriber;
+import reactor.core.Scannable;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
@@ -35,13 +40,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
+
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
 @RunWith(SpringRunner.class)
@@ -52,6 +61,9 @@ public class SpanSubscriberTests {
 
 	@Autowired
 	Tracer tracer;
+
+	@Autowired
+	ConfigurableApplicationContext factory;
 
 	@Test
 	public void should_pass_tracing_info_when_using_reactor() {
@@ -82,10 +94,10 @@ public class SpanSubscriberTests {
 
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(span)) {
 			Mono.just(1).flatMap(d -> Flux.just(d + 1).collectList().map(p -> p.get(0)))
-					.map(d -> d + 1).map((d) -> {
-						spanInOperation.set(this.tracer.currentSpan());
-						return d + 1;
-					}).map(d -> d + 1).subscribe(System.out::println);
+			    .map(d -> d + 1).map((d) -> {
+				spanInOperation.set(this.tracer.currentSpan());
+				return d + 1;
+			}).map(d -> d + 1).subscribe(System.out::println);
 		}
 		finally {
 			span.finish();
@@ -98,49 +110,90 @@ public class SpanSubscriberTests {
 	@Test
 	public void should_not_trace_scalar_flows() {
 		Span span = this.tracer.nextSpan().name("foo").start();
-		final AtomicReference<Subscription> spanInOperation = new AtomicReference<>();
 		log.info("Hello");
 
+		//Disable global hooks for local hook testing
+		Hooks.resetOnLastOperator();
+
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(span)) {
-			Mono.just(1).subscribe(new BaseSubscriber<Integer>() {
-				@Override
-				protected void hookOnSubscribe(Subscription subscription) {
-					spanInOperation.set(subscription);
-				}
-			});
 
-			then(this.tracer.currentSpan()).isNotNull();
-			then(spanInOperation.get()).isInstanceOf(ScopePassingSpanSubscriber.class);
+			Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer =
+					ReactorSleuth.scopePassingSpanOperator(factory);
 
-			Mono.<Integer>error(new Exception()).subscribe(new BaseSubscriber<Integer>() {
+			Subscriber<Object> assertNoSpanSubscriber = new CoreSubscriber<Object>() {
 				@Override
-				protected void hookOnSubscribe(Subscription subscription) {
-					spanInOperation.set(subscription);
+				public void onSubscribe(Subscription s) {
+					s.request(Long.MAX_VALUE);
+					assertThat(s).isNotInstanceOf(ScopePassingSpanSubscriber.class);
 				}
 
 				@Override
-				protected void hookOnError(Throwable throwable) {
+				public void onNext(Object o) {
+
 				}
-			});
 
-			then(this.tracer.currentSpan()).isNotNull();
-			then(spanInOperation.get()).isInstanceOf(ScopePassingSpanSubscriber.class);
-
-			Mono.<Integer>empty().subscribe(new BaseSubscriber<Integer>() {
 				@Override
-				protected void hookOnSubscribe(Subscription subscription) {
-					spanInOperation.set(subscription);
-				}
-			});
+				public void onError(Throwable t) {
 
-			then(this.tracer.currentSpan()).isNotNull();
-			then(spanInOperation.get()).isEqualTo(Operators.emptySubscription());
+				}
+
+				@Override
+				public void onComplete() {
+
+				}
+			};
+
+			Subscriber<Object> assertSpanSubscriber = new CoreSubscriber<Object>() {
+				@Override
+				public void onSubscribe(Subscription s) {
+					s.request(Long.MAX_VALUE);
+					assertThat(s).isInstanceOf(ScopePassingSpanSubscriber.class);
+				}
+
+				@Override
+				public void onNext(Object o) {
+
+				}
+
+				@Override
+				public void onError(Throwable t) {
+
+				}
+
+				@Override
+				public void onComplete() {
+
+				}
+			};
+			transformer.apply(Mono.just(1).hide())
+			           .subscribe(assertSpanSubscriber);
+
+			transformer.apply(Mono.just(1))
+			           .subscribe(assertNoSpanSubscriber);
+
+			transformer.apply(Mono.<Integer>error(new Exception()).hide())
+			           .subscribe(assertSpanSubscriber);
+
+
+			transformer.apply(Mono.error(new Exception()))
+			           .subscribe(assertNoSpanSubscriber);
+
+			transformer.apply(Mono.<Integer>empty().hide())
+			           .subscribe(assertSpanSubscriber);
+
+			transformer.apply(Mono.empty())
+			           .subscribe(assertNoSpanSubscriber);
+
+
+
 		}
 		finally {
 			span.finish();
 		}
 
-		then(this.tracer.currentSpan()).isNull();
+		Awaitility.await().untilAsserted(() -> {
+			then(this.tracer.currentSpan()).isNull();
+		});
 	}
 
 	@Test
@@ -151,12 +204,12 @@ public class SpanSubscriberTests {
 
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(span)) {
 			Flux.just(1, 2, 3).publishOn(Schedulers.single()).log("reactor.1")
-					.map(d -> d + 1).map(d -> d + 1)
-					.publishOn(Schedulers.newSingle("secondThread")).log("reactor.2")
-					.map((d) -> {
-						spanInOperation.set(this.tracer.currentSpan());
-						return d + 1;
-					}).map(d -> d + 1).blockLast();
+			    .map(d -> d + 1).map(d -> d + 1)
+			    .publishOn(Schedulers.newSingle("secondThread")).log("reactor.2")
+			    .map((d) -> {
+				    spanInOperation.set(this.tracer.currentSpan());
+				    return d + 1;
+			    }).map(d -> d + 1).blockLast();
 
 			Awaitility.await().untilAsserted(() -> {
 				then(spanInOperation.get().context().spanId())
@@ -173,10 +226,10 @@ public class SpanSubscriberTests {
 
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(foo2)) {
 			Flux.just(1, 2, 3).publishOn(Schedulers.single()).log("reactor.")
-					.map(d -> d + 1).map(d -> d + 1).map((d) -> {
-						spanInOperation.set(this.tracer.currentSpan());
-						return d + 1;
-					}).map(d -> d + 1).blockLast();
+			    .map(d -> d + 1).map(d -> d + 1).map((d) -> {
+				spanInOperation.set(this.tracer.currentSpan());
+				return d + 1;
+			}).map(d -> d + 1).blockLast();
 
 			then(this.tracer.currentSpan()).isEqualTo(foo2);
 			// parent cause there's an async span in the meantime
@@ -196,11 +249,11 @@ public class SpanSubscriberTests {
 		log.info("Hello");
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(parentSpan)) {
 			final Long spanId = Mono.fromCallable(tracer::currentSpan)
-					.map(span -> span.context().spanId()).block();
+			                        .map(span -> span.context().spanId()).block();
 			then(spanId).isNotNull();
 
 			final Long secondSpanId = Mono.fromCallable(tracer::currentSpan)
-					.map(span -> span.context().spanId()).block();
+			                              .map(span -> span.context().spanId()).block();
 			then(secondSpanId).isEqualTo(spanId); // different trace ids here
 		}
 	}
@@ -213,19 +266,19 @@ public class SpanSubscriberTests {
 
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(initSpan)) {
 			Mono.fromCallable(tracer::currentSpan).map(span -> span.context().spanId())
-					.doOnNext(spanInOperation::set)
-					.zipWith(Mono.fromCallable(tracer::currentSpan)
-							.map(span -> span.context().spanId())
-							.doOnNext(spanInZipOperation::set))
-					.block();
+			    .doOnNext(spanInOperation::set)
+			    .zipWith(Mono.fromCallable(tracer::currentSpan)
+			                 .map(span -> span.context().spanId())
+			                 .doOnNext(spanInZipOperation::set))
+			    .block();
 		}
 
 		then(spanInZipOperation).hasValue(initSpan.context().spanId()); // ok here
 		then(spanInOperation).hasValue(initSpan.context().spanId()); // Expecting
-																		// <AtomicReference[null]>
-																		// to have value:
-																		// <1L> but did
-																		// not.
+		// <AtomicReference[null]>
+		// to have value:
+		// <1L> but did
+		// not.
 	}
 
 	// #646
@@ -236,8 +289,8 @@ public class SpanSubscriberTests {
 
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(initSpan)) {
 			Mono.just("value1")
-					.flatMap(request -> Mono.just("value2").then(Mono.just("foo")))
-					.map(a -> "qwe").block();
+			    .flatMap(request -> Mono.just("value2").then(Mono.just("foo")))
+			    .map(a -> "qwe").block();
 		}
 	}
 
@@ -249,8 +302,8 @@ public class SpanSubscriberTests {
 
 		try (Tracer.SpanInScope ws = this.tracer.withSpanInScope(initSpan)) {
 			Mono.subscriberContext()
-					.map(context -> tracer.currentSpan().context().spanId())
-					.doOnNext(spanInSubscriberContext::set).block();
+			    .map(context -> tracer.currentSpan().context().spanId())
+			    .doOnNext(spanInSubscriberContext::set).block();
 		}
 
 		then(spanInSubscriberContext).hasValue(initSpan.context().spanId()); // ok here

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
@@ -18,7 +18,7 @@ public class TraceReactorAutoConfigurationAccessorConfiguration {
 			log.trace("Cleaning up hooks");
 		}
 		new TraceReactorAutoConfiguration.TraceReactorConfiguration().cleanupHooks();
-		Hooks.resetOnEachOperator();
+		Hooks.resetOnLastOperator();
 		Hooks.resetOnLastOperator();
 		Schedulers.resetFactory();
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxTests.java
@@ -544,17 +544,15 @@ class TestBean {
 	@NewSpan(name = "newSpanInTraceContext")
 	public Mono<Long> newSpanInTraceContext() {
 		log.info("New Span in Trace Context");
-		Long span = tracer.currentSpan().context().spanId();
-		return Mono.defer(() -> Mono.just(span));
+		return Mono.defer(() -> Mono.just(tracer.currentSpan().context().spanId()));
 	}
 
 	@NewSpan(name = "newSpanInSubscriberContext")
 	public Mono<Long> newSpanInSubscriberContext() {
 		log.info("New Span in Subscriber Context");
-		Long span = tracer.currentSpan().context().spanId();
 		return Mono.subscriberContext()
 				.doOnSuccess(context -> log.info("New Span in deferred Trace Context"))
-				.flatMap(context -> Mono.defer(() -> Mono.just(span)));
+				.flatMap(context -> Mono.defer(() -> Mono.just(tracer.currentSpan().context().spanId())));
 	}
 
 }


### PR DESCRIPTION
- Use onLastOperator instead of onEachOperator
- Do not instrument scalar publishers
- Do not inject ScopePassingSubscriber if there is no span.
- Revisit ReactorSleuthMethodInvocationProcessor to reduce ops overhead
- Use only one operator for the MethodInvocationProcessor
- Warning Behavior Change: @NewSpan will defer Span creation/context

```java
@NewSpan Mono<Long> method() {
  //before this was working
  //tracer.currentSpan().context().spanId();

  //Now it is deferred by subscribe
  return Mono.defer(() -> Mono.just(tracer.currentSpan().context().spanId()));
}

//The reason being you want to start a new span for each subscribe:
Mono<Long> m = method();
m.subscribe(); //span1
m.subscribe(); //span2

@ContinueSpan Mono<Long> method() {
  //Note this is still working
  Long span = tracer.currentSpan().context().spanId();
  return Mono.defer(() -> Mono.just(span));
}

```