### PR TITLE
Only wrap executors when context is refreshed

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -19,12 +19,10 @@ package org.springframework.cloud.sleuth.instrument.async;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.AsyncConfigurer;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
- * Auto-configuration} that wraps an existing custom {@link AsyncConfigurer} in a
- * {@link LazyTraceAsyncCustomizer}.
+ * Auto-configuration} for asynchronous communication.
  *
  * @author Jesus Alonso
  * @since 2.1.0

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.sleuth.instrument.async;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 
@@ -31,5 +32,10 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
 @Configuration
 @EnableConfigurationProperties(SleuthAsyncProperties.class)
 public class AsyncAutoConfiguration {
+
+	@Bean
+	ContextRefreshedListener traceContextRefreshedListener() {
+		return new ContextRefreshedListener();
+	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executor;
 
 import brave.Tracer;
 import brave.Tracing;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextRefreshedListener.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextRefreshedListener.java
@@ -18,11 +18,11 @@ package org.springframework.cloud.sleuth.instrument.async;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.springframework.context.ApplicationListener;
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.SmartApplicationListener;
 
-class ContextRefreshedListener extends AtomicBoolean
-		implements ApplicationListener<ContextRefreshedEvent> {
+class ContextRefreshedListener extends AtomicBoolean implements SmartApplicationListener {
 
 	ContextRefreshedListener(boolean initialValue) {
 		super(initialValue);
@@ -31,8 +31,16 @@ class ContextRefreshedListener extends AtomicBoolean
 	ContextRefreshedListener() {
 	}
 
-	public void onApplicationEvent(ContextRefreshedEvent event) {
-		set(true);
+	@Override
+	public boolean supportsEventType(Class<? extends ApplicationEvent> eventType) {
+		return ContextRefreshedEvent.class.isAssignableFrom(eventType);
+	}
+
+	@Override
+	public void onApplicationEvent(ApplicationEvent event) {
+		if (event instanceof ContextRefreshedEvent) {
+			set(true);
+		}
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextRefreshedListener.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextRefreshedListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.async;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+class ContextRefreshedListener extends AtomicBoolean
+		implements ApplicationListener<ContextRefreshedEvent> {
+
+	ContextRefreshedListener(boolean initialValue) {
+		super(initialValue);
+	}
+
+	ContextRefreshedListener() {
+	}
+
+	public void onApplicationEvent(ContextRefreshedEvent event) {
+		set(true);
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextUtil.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextUtil.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.sleuth.instrument.async;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -26,7 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.BeanFactory;
 
 /**
- * Internal class
+ * Utility class that verifies that context is in creation.
  *
  * @author Marcin Grzejszczak
  * @since 2.1.0

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextUtil.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/ContextUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.async;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.BeanFactory;
+
+/**
+ * Internal class
+ *
+ * @author Marcin Grzejszczak
+ * @since 2.1.0
+ */
+class ContextUtil {
+
+	private static final Log log = LogFactory.getLog(ContextUtil.class);
+
+	private static Map<BeanFactory, ContextRefreshedListener> CACHE = new ConcurrentHashMap<>();
+
+	static boolean isContextInCreation(BeanFactory beanFactory) {
+		ContextRefreshedListener bean = CACHE.compute(beanFactory,
+				(beanFactory1, contextRefreshedListener) -> {
+					if (contextRefreshedListener != null) {
+						return contextRefreshedListener;
+					}
+					return beanFactory.getBean(ContextRefreshedListener.class);
+				});
+		boolean contextRefreshed = bean.get();
+		if (!contextRefreshed && log.isDebugEnabled()) {
+			log.debug("Context is not ready yet");
+		}
+		return !contextRefreshed;
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
@@ -44,31 +44,37 @@ public class TraceableScheduledExecutorService extends TraceableExecutorService
 
 	@Override
 	public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-		Runnable r = new TraceRunnable(tracing(), spanNamer(), command);
-		return getScheduledExecutorService().schedule(r, delay, unit);
+		return getScheduledExecutorService().schedule(
+				ContextUtil.isContextInCreation(this.beanFactory) ? command
+						: new TraceRunnable(tracing(), spanNamer(), command),
+				delay, unit);
 	}
 
 	@Override
 	public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay,
 			TimeUnit unit) {
-		Callable<V> c = new TraceCallable<>(tracing(), spanNamer(), callable);
-		return getScheduledExecutorService().schedule(c, delay, unit);
+		return getScheduledExecutorService().schedule(
+				ContextUtil.isContextInCreation(this.beanFactory) ? callable
+						: new TraceCallable<>(tracing(), spanNamer(), callable),
+				delay, unit);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
 			long period, TimeUnit unit) {
-		Runnable r = new TraceRunnable(tracing(), spanNamer(), command);
-		return getScheduledExecutorService().scheduleAtFixedRate(r, initialDelay, period,
-				unit);
+		return getScheduledExecutorService().scheduleAtFixedRate(
+				ContextUtil.isContextInCreation(this.beanFactory) ? command
+						: new TraceRunnable(tracing(), spanNamer(), command),
+				initialDelay, period, unit);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
 			long delay, TimeUnit unit) {
-		Runnable r = new TraceRunnable(tracing(), spanNamer(), command);
-		return getScheduledExecutorService().scheduleWithFixedDelay(r, initialDelay,
-				delay, unit);
+		return getScheduledExecutorService().scheduleWithFixedDelay(
+				ContextUtil.isContextInCreation(this.beanFactory) ? command
+						: new TraceRunnable(tracing(), spanNamer(), command),
+				initialDelay, delay, unit);
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/ExecutorBeanPostProcessorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/ExecutorBeanPostProcessorTests.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import brave.Tracer;
 import brave.Tracing;
 import org.aopalliance.aop.Advice;
 import org.junit.After;
@@ -41,14 +40,13 @@ import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.aop.framework.AopConfigException;
 import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.sleuth.DefaultSpanNamer;
-import org.springframework.cloud.sleuth.SpanName;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.ClassUtils;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -76,6 +74,8 @@ public class ExecutorBeanPostProcessorTests {
 		Mockito.when(this.beanFactory.getBean(Tracing.class)).thenReturn(this.tracing);
 		Mockito.when(this.beanFactory.getBean(SpanNamer.class))
 				.thenReturn(new DefaultSpanNamer());
+		Mockito.when(this.beanFactory.getBean(ContextRefreshedListener.class))
+				.thenReturn(new ContextRefreshedListener(true));
 	}
 
 	@After

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorServiceTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorServiceTests.java
@@ -77,8 +77,8 @@ public class TraceableExecutorServiceTests {
 
 	@Before
 	public void setup() {
-		this.traceManagerableExecutorService = new TraceableExecutorService(beanFactory(true),
-				this.executorService);
+		this.traceManagerableExecutorService = new TraceableExecutorService(
+				beanFactory(true), this.executorService);
 		this.reporter.clear();
 		this.spanVerifyingRunnable.clear();
 	}
@@ -211,8 +211,7 @@ public class TraceableExecutorServiceTests {
 		CompletableFuture<Long> completableFuture = CompletableFuture.supplyAsync(() -> {
 			// perform some logic
 			return 1_000_000L;
-		}, new TraceableExecutorService(beanFactory, executorService,
-				"calculateTax"));
+		}, new TraceableExecutorService(beanFactory, executorService, "calculateTax"));
 
 		then(completableFuture.get()).isEqualTo(1_000_000L);
 		then(this.tracer.currentSpan()).isNull();

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
@@ -109,7 +109,8 @@ public class TraceableScheduledExecutorServiceTest {
 	}
 
 	@Test
-	public void should_not_schedule_a_trace_runnable_when_context_not_ready() throws Exception {
+	public void should_not_schedule_a_trace_runnable_when_context_not_ready()
+			throws Exception {
 		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
 				.willReturn(new ContextRefreshedListener(false));
 		this.traceableScheduledExecutorService.schedule(aRunnable(), 1L, TimeUnit.DAYS);
@@ -121,7 +122,8 @@ public class TraceableScheduledExecutorServiceTest {
 	}
 
 	@Test
-	public void should_not_schedule_a_trace_callable_when_context_not_ready() throws Exception {
+	public void should_not_schedule_a_trace_callable_when_context_not_ready()
+			throws Exception {
 		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
 				.willReturn(new ContextRefreshedListener(false));
 		this.traceableScheduledExecutorService.schedule(aCallable(), 1L, TimeUnit.DAYS);
@@ -133,7 +135,8 @@ public class TraceableScheduledExecutorServiceTest {
 	}
 
 	@Test
-	public void should_not_schedule_at_fixed_rate_a_trace_runnable_when_context_not_ready() throws Exception {
+	public void should_not_schedule_at_fixed_rate_a_trace_runnable_when_context_not_ready()
+			throws Exception {
 		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
 				.willReturn(new ContextRefreshedListener(false));
 		this.traceableScheduledExecutorService.scheduleAtFixedRate(aRunnable(), 1L, 1L,
@@ -146,7 +149,8 @@ public class TraceableScheduledExecutorServiceTest {
 	}
 
 	@Test
-	public void should_not_schedule_with_fixed_delay_a_trace_runnable_when_context_not_ready() throws Exception {
+	public void should_not_schedule_with_fixed_delay_a_trace_runnable_when_context_not_ready()
+			throws Exception {
 		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
 				.willReturn(new ContextRefreshedListener(false));
 		this.traceableScheduledExecutorService.scheduleWithFixedDelay(aRunnable(), 1L, 1L,

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.sleuth.SpanNamer;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 /**
  * @author Marcin Grzejszczak
@@ -107,6 +108,56 @@ public class TraceableScheduledExecutorServiceTest {
 				anyLong(), anyLong(), any(TimeUnit.class));
 	}
 
+	@Test
+	public void should_not_schedule_a_trace_runnable_when_context_not_ready() throws Exception {
+		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
+				.willReturn(new ContextRefreshedListener(false));
+		this.traceableScheduledExecutorService.schedule(aRunnable(), 1L, TimeUnit.DAYS);
+
+		then(this.scheduledExecutorService).should(never()).schedule(
+				BDDMockito.argThat(
+						matcher(Runnable.class, instanceOf(TraceRunnable.class))),
+				anyLong(), any(TimeUnit.class));
+	}
+
+	@Test
+	public void should_not_schedule_a_trace_callable_when_context_not_ready() throws Exception {
+		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
+				.willReturn(new ContextRefreshedListener(false));
+		this.traceableScheduledExecutorService.schedule(aCallable(), 1L, TimeUnit.DAYS);
+
+		then(this.scheduledExecutorService).should(never()).schedule(
+				BDDMockito.argThat(
+						matcher(Callable.class, instanceOf(TraceCallable.class))),
+				anyLong(), any(TimeUnit.class));
+	}
+
+	@Test
+	public void should_not_schedule_at_fixed_rate_a_trace_runnable_when_context_not_ready() throws Exception {
+		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
+				.willReturn(new ContextRefreshedListener(false));
+		this.traceableScheduledExecutorService.scheduleAtFixedRate(aRunnable(), 1L, 1L,
+				TimeUnit.DAYS);
+
+		then(this.scheduledExecutorService).should(never()).scheduleAtFixedRate(
+				BDDMockito.argThat(
+						matcher(Runnable.class, instanceOf(TraceRunnable.class))),
+				anyLong(), anyLong(), any(TimeUnit.class));
+	}
+
+	@Test
+	public void should_not_schedule_with_fixed_delay_a_trace_runnable_when_context_not_ready() throws Exception {
+		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
+				.willReturn(new ContextRefreshedListener(false));
+		this.traceableScheduledExecutorService.scheduleWithFixedDelay(aRunnable(), 1L, 1L,
+				TimeUnit.DAYS);
+
+		then(this.scheduledExecutorService).should(never()).scheduleWithFixedDelay(
+				BDDMockito.argThat(
+						matcher(Runnable.class, instanceOf(TraceRunnable.class))),
+				anyLong(), anyLong(), any(TimeUnit.class));
+	}
+
 	Predicate<Object> instanceOf(Class clazz) {
 		return (argument) -> argument.getClass().isAssignableFrom(clazz);
 	}
@@ -129,6 +180,8 @@ public class TraceableScheduledExecutorServiceTest {
 				.willReturn(this.tracing);
 		BDDMockito.given(this.beanFactory.getBean(SpanNamer.class))
 				.willReturn(new DefaultSpanNamer());
+		BDDMockito.given(this.beanFactory.getBean(ContextRefreshedListener.class))
+				.willReturn(new ContextRefreshedListener(true));
 		return this.beanFactory;
 	}
 

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfigurationTests.java
@@ -69,7 +69,8 @@ public class ZipkinAutoConfigurationTests {
 	@Test
 	public void defaultsToV2Endpoint() throws Exception {
 		this.context = new AnnotationConfigApplicationContext();
-		environment().setProperty("spring.zipkin.base-url", this.server.url("/").toString());
+		environment().setProperty("spring.zipkin.base-url",
+				this.server.url("/").toString());
 		this.context.register(ZipkinAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class, TraceAutoConfiguration.class,
 				Config.class);
@@ -79,8 +80,8 @@ public class ZipkinAutoConfigurationTests {
 
 		span.finish();
 
-		Awaitility.await()
-				.untilAsserted(() -> then(this.server.getRequestCount()).isGreaterThan(0));
+		Awaitility.await().untilAsserted(
+				() -> then(this.server.getRequestCount()).isGreaterThan(0));
 		RecordedRequest request = this.server.takeRequest();
 		then(request.getPath()).isEqualTo("/api/v2/spans");
 		then(request.getBody().readUtf8()).contains("localEndpoint");
@@ -94,7 +95,8 @@ public class ZipkinAutoConfigurationTests {
 	@Test
 	public void encoderDirectsEndpoint() throws Exception {
 		this.context = new AnnotationConfigApplicationContext();
-		environment().setProperty("spring.zipkin.base-url", this.server.url("/").toString());
+		environment().setProperty("spring.zipkin.base-url",
+				this.server.url("/").toString());
 		environment().setProperty("spring.zipkin.encoder", "JSON_V1");
 		this.context.register(ZipkinAutoConfiguration.class,
 				PropertyPlaceholderAutoConfiguration.class, TraceAutoConfiguration.class,
@@ -105,8 +107,8 @@ public class ZipkinAutoConfigurationTests {
 
 		span.finish();
 
-		Awaitility.await()
-				.untilAsserted(() -> then(this.server.getRequestCount()).isGreaterThan(0));
+		Awaitility.await().untilAsserted(
+				() -> then(this.server.getRequestCount()).isGreaterThan(0));
 		RecordedRequest request = this.server.takeRequest();
 		then(request.getPath()).isEqualTo("/api/v1/spans");
 		then(request.getBody().readUtf8()).contains("binaryAnnotations");


### PR DESCRIPTION
without this change, for deferred JPA bootstrap, we're trying to get a bean very early and we have a deadlock
with this change, we only do it once the context is refreshed

the concept was such that I have a bean `ContextRefreshedListener` which is also an `AtomicBoolean`. Now, before we wrap any executor related logic, we use the `ContextUtil` to verify if the context is in the creation or not. There, we retrieve the `ContextRefreshedListener` bean and cache it. Only after `ContextRefreshedEvent` was received, will we start wrapping the executor services.

fixes #1128