### PR TITLE
Fixes a problem where leaked spans didn't end up in Zipkin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
 		<spring-cloud-stream.version>Fishtown.BUILD-SNAPSHOT</spring-cloud-stream.version>
 		<spring-cloud-netflix.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-openfeign.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-openfeign.version>
-		<brave.version>5.4.4</brave.version>
+		<brave.version>5.5.1</brave.version>
 		<spring-security-boot-autoconfigure.version>2.0.4.RELEASE</spring-security-boot-autoconfigure.version>
 	</properties>
 

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -30,7 +30,7 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<brave.opentracing.version>0.33.5</brave.opentracing.version>
+		<brave.opentracing.version>0.33.7</brave.opentracing.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
This moves to latest Brave which fixes a regression. Basically, if you used an instrumentation which leaks spans or adds data after a span was finished... this abandoned data wouldn't end up flushed to zipkin. This was found in OpenTracing instrumentation.


Note: I don't know if the prior version used by Sleuth had the regression or not, but I know 5.3.3 did not.

cc @tutufool who identified the problem.