### PR TITLE
Skip only Actuator endpoints when context path set

### DIFF
--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 
@@ -80,7 +82,9 @@ public class SkipPatternProviderConfigTest {
 	public void should_return_empty_when_server_props_have_no_context_path()
 			throws Exception {
 		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ServerSkipPatternProviderConfig()
-				.skipPatternForServerProperties(new ServerProperties()).skipPattern();
+				.skipPatternForServerProperties(new ServerProperties(),
+						new WebEndpointProperties())
+				.skipPattern();
 
 		then(pattern).isEmpty();
 	}
@@ -91,10 +95,11 @@ public class SkipPatternProviderConfigTest {
 		properties.getServlet().setContextPath("foo");
 
 		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ServerSkipPatternProviderConfig()
-				.skipPatternForServerProperties(properties).skipPattern();
+				.skipPatternForServerProperties(properties, new WebEndpointProperties())
+				.skipPattern();
 
 		then(pattern).isNotEmpty();
-		then(pattern.get().pattern()).isEqualTo("foo.*");
+		then(pattern.get().pattern()).isEqualTo("foo/actuator.*");
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/issues/issue971/DemoSleuthSkipApplicationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/issues/issue971/DemoSleuthSkipApplicationTests.java
@@ -30,6 +30,8 @@ import org.springframework.cloud.sleuth.util.ArrayListSpanReporter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -60,10 +62,25 @@ public class DemoSleuthSkipApplicationTests {
 		then(this.accumulator.getSpans()).hasSize(0);
 	}
 
+	@Test
+	public void should_sample_non_actuator_endpoint_with_context_path() {
+		new RestTemplate().getForObject(
+				"http://localhost:" + this.port + "/context-path/something",
+				String.class);
+
+		then(this.tracer.currentSpan()).isNull();
+		then(this.accumulator.getSpans()).hasSize(1);
+	}
+
 	@EnableAutoConfiguration(exclude = RabbitAutoConfiguration.class)
 	@Configuration
 	@DisableSecurity
+	@RestController
 	public static class Config {
+
+		@GetMapping("something")
+		void doNothing() {
+		}
 
 		@Bean
 		ArrayListSpanReporter reporter() {


### PR DESCRIPTION
Previously, all endpoints under the set context path would be skipped. Instead, this skips only Actuator endpoints under the set context-path.

Resolves #1146

---

We might want to reconsider the current approach, though. Previously, the management context path was appended to the default pattern instead of added as an OR to the pattern. The default pattern includes more things than just the Actuator endpoints, which won't be skipped if a context path is set currently. Also, if the Actuator base path is set to `/` then the approach in this change will have issues because it will again skip all endpoints for the application. This should be an improvement in most cases, though.