### PR TITLE
Allow customizing the base Propagation.Factory

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/BasePropagationFactoryProvider.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/BasePropagationFactoryProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.propagation;
+
+import brave.propagation.Propagation;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Provides a {@link brave.propagation.Propagation.Factory} that Sleuth customizes with baggage and propagated key
+ * configuration.
+ *
+ * @author Brian Devins-Suresh
+ * @since 2.1.0
+ */
+public interface BasePropagationFactoryProvider {
+
+	/**
+	 * Gives the Sleuth autoconfiguration an instance of {@link brave.propagation.Propagation.Factory} to customize
+	 *
+	 * @return The {@link brave.propagation.Propagation.Factory} to customize based on user properties
+	 */
+	@NotNull
+	Propagation.Factory get();
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/DefaultBasePropagationFactoryProvider.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/DefaultBasePropagationFactoryProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.propagation;
+
+import brave.propagation.B3Propagation;
+import brave.propagation.Propagation;
+
+/**
+ * Provides the default {@link brave.propagation.Propagation.Factory}
+ *
+ * @author Brian Devins-Suresh
+ * @since 2.1.0
+ */
+public class DefaultBasePropagationFactoryProvider implements BasePropagationFactoryProvider {
+	@Override
+	public Propagation.Factory get() {
+		return B3Propagation.FACTORY;
+	}
+}


### PR DESCRIPTION
In order to use the Sleuth propagation customization with a propagation mechanism other than B3 it requires copying the entire bean definition. To make user customization not able to fall behind the official implementation of this bean it would be good to be able to customize the base implementation.

This PR adds an interface to facilitate that, ideally we could allow the user to just create an instance of `Propagation.Factory` and maybe set a property to enable a wrapping behavior. I'll play with that idea, but for now this gets the idea out for feedback.