### PR TITLE
sleuth extra propagation fields to tags feature.

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfiguration.java
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.sleuth.log;
+package org.springframework.cloud.sleuth.propagation;
 
-import brave.propagation.CurrentTraceContext;
-import org.slf4j.MDC;
+import brave.handler.FinishedSpanHandler;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
@@ -28,34 +26,25 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
- * Auto-configuration} adds a {@link Slf4jScopeDecorator} that prints tracing information
- * in the logs.
- * <p>
- *
- * @author Spencer Gibb
- * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @author Taras Danylchuk
+ * @since 2.1.0
  */
 @Configuration
 @ConditionalOnProperty(value = "spring.sleuth.enabled", matchIfMissing = true)
 @AutoConfigureBefore(TraceAutoConfiguration.class)
-public class SleuthLogAutoConfiguration {
+public class SleuthTagPropagationAutoConfiguration {
 
-	/**
-	 * Configuration for Slfj4
-	 */
 	@Configuration
-	@ConditionalOnClass(MDC.class)
-	@EnableConfigurationProperties(SleuthSlf4jProperties.class)
-	protected static class Slf4jConfiguration {
+	@ConditionalOnProperty(value = "spring.sleuth.propagation.tag.enabled", matchIfMissing = true)
+	@EnableConfigurationProperties(SleuthTagPropagationProperties.class)
+	protected static class TagPropagationConfiguration {
 
 		@Bean
-		@ConditionalOnProperty(value = "spring.sleuth.log.slf4j.enabled", matchIfMissing = true)
-		public CurrentTraceContext.ScopeDecorator slf4jSpanDecorator(
-				SleuthProperties sleuthProperties,
-				SleuthSlf4jProperties sleuthSlf4jProperties) {
-			return new Slf4jScopeDecorator(sleuthProperties, sleuthSlf4jProperties);
+		@ConditionalOnProperty(value = "spring.sleuth.propagation.tag.whitelisted-keys")
+		public FinishedSpanHandler finishedSpanHandler(SleuthProperties sleuthProperties,
+													   SleuthTagPropagationProperties tagPropagationProperties) {
+			return new TagPropagationFinishedSpanHandler(sleuthProperties,
+					tagPropagationProperties);
 		}
 
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.propagation;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration properties of tag propagation.
+ *
+ * @author Taras Danylchuk
+ * @since 2.1.0
+ */
+@ConfigurationProperties("spring.sleuth.propagation.tag")
+public class SleuthTagPropagationProperties {
+
+	/**
+	 * Enables a {@link TagPropagationFinishedSpanHandler} that adds extra propagated
+	 * fields to span tags.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * A list of keys to be put from extra propagation fields to span tags.
+	 */
+	private List<String> whitelistedKeys = new ArrayList<>();
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public List<String> getWhitelistedKeys() {
+		return whitelistedKeys;
+	}
+
+	public void setWhitelistedKeys(List<String> whitelistedKeys) {
+		this.whitelistedKeys = whitelistedKeys;
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/TagPropagationFinishedSpanHandler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/TagPropagationFinishedSpanHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.propagation;
+
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.TraceContext;
+import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static java.util.Objects.nonNull;
+
+/**
+ * Finish span handler which adds extra propagation fields to span tags, so spans could be
+ * looked up by its baggage.
+ *
+ * @author Taras Danylchuk
+ * @since 2.1.0
+ */
+public class TagPropagationFinishedSpanHandler extends FinishedSpanHandler {
+
+	private final SleuthProperties sleuthProperties;
+
+	private final SleuthTagPropagationProperties tagPropagationProperties;
+
+	public TagPropagationFinishedSpanHandler(SleuthProperties sleuthProperties,
+											 SleuthTagPropagationProperties tagPropagationProperties) {
+		this.sleuthProperties = sleuthProperties;
+		this.tagPropagationProperties = tagPropagationProperties;
+	}
+
+	@Override
+	public boolean handle(TraceContext context, MutableSpan span) {
+		Stream.of(sleuthProperties.getBaggageKeys(), sleuthProperties.getPropagationKeys())
+				.flatMap(Collection::stream)
+				.filter(key -> this.tagPropagationProperties.getWhitelistedKeys().contains(key))
+				.map(baggageItemKey -> new AbstractMap.SimpleEntry<>(baggageItemKey,
+						ExtraFieldPropagation.get(context, baggageItemKey)))
+				.filter(entry -> nonNull(entry.getValue()))
+				.forEach(entry -> span.tag(entry.getKey(), entry.getValue()));
+		return true;
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
@@ -3,6 +3,7 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.sleuth.annotation.SleuthAnnotationAutoConfiguration,\
 org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration,\
 org.springframework.cloud.sleuth.log.SleuthLogAutoConfiguration,\
+org.springframework.cloud.sleuth.propagation.SleuthTagPropagationAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceHttpAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceWebAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceWebServletAutoConfiguration,\

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfigurationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.sleuth.propagation;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class SleuthTagPropagationAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(SleuthTagPropagationAutoConfiguration.class));
+
+	@Test
+	public void shouldNotCreateHandler() {
+		this.contextRunner
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean(TagPropagationFinishedSpanHandler.class);
+				});
+	}
+
+	@Test
+	public void shouldNotCreateHandlerByDisablingIt() {
+		this.contextRunner
+				.withPropertyValues("spring.sleuth.propagation.tag.whitelisted-keys=some-key")
+				.withPropertyValues("spring.sleuth.propagation.tag.enabled=false")
+				.withUserConfiguration(TraceAutoConfiguration.class)
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean(TagPropagationFinishedSpanHandler.class);
+				});
+	}
+
+	@Test
+	public void shouldCreateHandler() {
+		this.contextRunner
+				.withPropertyValues("spring.sleuth.propagation.tag.whitelisted-keys=some-key")
+				.withUserConfiguration(TraceAutoConfiguration.class)
+				.run((context) -> {
+					assertThat(context).hasSingleBean(TagPropagationFinishedSpanHandler.class);
+				});
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/propagation/TagPropagationFinishedSpanHandlerTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/propagation/TagPropagationFinishedSpanHandlerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.sleuth.propagation;
+
+import brave.ScopedSpan;
+import brave.Tracer;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.TraceContext;
+import brave.sampler.Sampler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.sleuth.util.ArrayListSpanReporter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Taras Danylchuk
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+		"spring.sleuth.baggage-keys=my-baggage",
+		"spring.sleuth.propagation-keys=my-propagation,others-propagation",
+		"spring.sleuth.propagation.tag.whitelisted-keys=my-baggage,my-propagation"},
+		classes = TagPropagationFinishedSpanHandlerTest.TestConfiguration.class)
+public class TagPropagationFinishedSpanHandlerTest {
+
+	private static final String BAGGAGE_KEY = "my-baggage";
+	private static final String BAGGAGE_VALUE = "332323";
+
+	private static final String PROPAGATION_KEY = "my-propagation";
+	private static final String PROPAGATION_VALUE = "332323";
+
+	@Autowired
+	private Tracer tracer;
+
+	@Autowired
+	private ArrayListSpanReporter arrayListSpanReporter;
+
+	private ScopedSpan span;
+
+	@Before
+	public void setUp() {
+		arrayListSpanReporter.clear();
+		span = tracer.startScopedSpan("my-scoped-span");
+		TraceContext context = span.context();
+		ExtraFieldPropagation.set(context, BAGGAGE_KEY, BAGGAGE_VALUE);
+		ExtraFieldPropagation.set(context, PROPAGATION_KEY, PROPAGATION_VALUE);
+		ExtraFieldPropagation.set(context, "others-propagation", "some value");
+	}
+
+	@Test
+	public void shouldReportWithBaggageInTags() {
+		span.finish();
+
+		List<zipkin2.Span> spans = arrayListSpanReporter.getSpans();
+		assertThat(spans).hasSize(1);
+		Map<String, String> tags = spans.get(0).tags();
+		assertThat(tags).hasSize(2);
+		assertThat(tags).containsEntry(BAGGAGE_KEY, BAGGAGE_VALUE);
+		assertThat(tags).containsEntry(PROPAGATION_KEY, PROPAGATION_VALUE);
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	public static class TestConfiguration {
+
+		@Bean
+		public ArrayListSpanReporter arrayListSpanReporter() {
+			return new ArrayListSpanReporter();
+		}
+
+		@Bean
+		public Sampler alwaysSampler() {
+			return Sampler.ALWAYS_SAMPLE;
+		}
+
+	}
+
+}


### PR DESCRIPTION
As part of this conversation - https://github.com/spring-cloud/spring-cloud-sleuth/issues/1071#issuecomment-415447228

by default this feature is disabled, but if someone what to propagate baggage to spans in order to enable filtering by it - they could use this feature, by just adding needed property.

In this way we are omitting changing code as described here - https://cloud.spring.io/spring-cloud-sleuth/single/spring-cloud-sleuth.html#_baggage_versus_span_tags