### PR TITLE
gRPC spring boot version 3.0.1 (gRPC 1.16.1)

### DIFF
--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -31,7 +31,7 @@
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
 		<brave.opentracing.version>0.33.10</brave.opentracing.version>
-		<grpc.spring.boot.version>3.0.0</grpc.spring.boot.version>
+		<grpc.spring.boot.version>3.0.1</grpc.spring.boot.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
gRPC spring boot version 3.0.1 (gRPC 1.16.1).

Fixes #1186. With this change, `io.github.lognet:grpc-spring-boot-starter:3.0.1` and `io.zipkin.brave:brave-instrumentation-grpc:5.6.0` have same gRPC version.