### PR TITLE
Remove cycles from auto configuration

### DIFF
--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
@@ -8,8 +8,11 @@ import org.assertj.core.api.BDDAssertions;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.sleuth.instrument.web.TraceHttpAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.TraceWebAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
 
 public class TraceAutoConfigurationPropagationCustomizationTests {
 
@@ -40,6 +43,18 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 				.run((context) -> {
 					BDDAssertions.then(context.getBean(Propagation.Factory.class))
 							.isEqualTo(B3Propagation.FACTORY);
+				});
+	}
+
+	@Test
+	public void hasNoCycles() {
+		this.contextRunner
+				.withConfiguration(AutoConfigurations.of(TraceWebAutoConfiguration.class,
+						TraceHttpAutoConfiguration.class))
+				.withInitializer(c -> ((GenericApplicationContext) c)
+						.setAllowCircularReferences(false))
+				.run((context) -> {
+					BDDAssertions.then(context.isRunning()).isEqualTo(true);
 				});
 	}
 


### PR DESCRIPTION
I work on the app that had in the past problems with deployment reproducibility. The app couldn't boot due to unresolved cycles between beans. After inspecting the problem, it turned out to be related to jar packaging. The order of classes within jar had an impact on Spring beans loading, so if you took jar known to have cycles and run it multiple times, you got always unresolved cycles. If you took it and repackaged classes and run, it was quite common for an app to boot properly. 

My solution to that problem was to disable resolving circular references between beans altogether and fix each cycle by hand by remodelling relationships between beans or delaying bean creation. This pr removes cycles in configuration classes so that Sleuth can be used by apps with `setAllowCircularReferences` set to false.