### PR TITLE
Check if management server (actuator) is running on different port while constructing skip patterns

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -152,6 +152,7 @@ public class TraceWebAutoConfiguration {
 		
 		@Bean
 		@ConditionalOnManagementPort(ManagementPortType.DIFFERENT)
+		@ConditionalOnProperty(name = "management.server.servlet.context-path", havingValue = "/", matchIfMissing = true)
 		public SingleSkipPattern skipPatternForActuatorEndpointsDifferentPort(
 				final ServerProperties serverProperties,
 				final WebEndpointProperties webEndpointProperties,


### PR DESCRIPTION
The Issue
======

While `Spring Cloud Sleuth` is constructing the skip patterns, the management/actuator web endpoints should be excluded from traces (addressed in https://github.com/spring-cloud/spring-cloud-sleuth/pull/1150/files and related PRs). However, when the management/actuator server is running on a different (from the application server) port, the skip patterns are still constructed using the application server context path.

Example:
```
server.port = 8080
server.servlet.contextPath = /api
management.server.port = 9080
management.endpoints.web.base-path = /mgt
```

The expected skip patterns (for `/info` and `health|` endpoints): 
```
/mgt/(info|info/.*|health|health/.*)
```

The current skip patterns (for `/info` and `health|` endpoints) are still using application context path: 
```
/api/mgt/(info|info/.*|health|health/.*)
```

Another  issue shows up when the management/actuator web endpoints are bound to root context '/', for example:

```
server.port = 8080
server.servlet.contextPath = /api
management.server.port = 9080
management.endpoints.web.base-path = /
```

In this case, the some application resources are going to be ignored by `SleuthHttpSampler` since the generated skip patterns will include `/api/(info|info/.*|health|health/.*)`


Suggested Solution
======
Take the management/actuator server port configuration into account and adjust the skip patterns accordingly.

Thank you!

PS: Not sure if this is still required, but the contributor agreement has been signed.