### PR TITLE
Refactored SkipPatternProviderConfigTest to use WebApplicationContextRunner instead of manually instantiated configurations

### DIFF
--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
@@ -17,20 +17,31 @@
 package org.springframework.cloud.sleuth.instrument.web;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.health.HealthIndicatorAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
-import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.EndpointsSupplier;
 import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
-import org.springframework.boot.actuate.endpoint.web.WebOperation;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -39,26 +50,32 @@ import static org.assertj.core.api.BDDAssertions.then;
  */
 public class SkipPatternProviderConfigTest {
 
+	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(TraceAutoConfiguration.class,
+					TraceWebAutoConfiguration.class));
+
 	@Test
 	public void should_pick_skip_pattern_from_sleuth_properties() throws Exception {
-		SleuthWebProperties sleuthWebProperties = new SleuthWebProperties();
-		sleuthWebProperties.setSkipPattern("foo.*|bar.*");
-		Pattern pattern = new TraceWebAutoConfiguration.DefaultSkipPatternConfig()
-				.defaultSkipPatternBean(sleuthWebProperties).skipPattern().get();
-
-		then(pattern.pattern()).isEqualTo("foo.*|bar.*");
+		contextRunner.withPropertyValues("spring.sleuth.web.skip-pattern=foo.*|bar.*")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern()).isEqualTo("foo.*|bar.*");
+				});
 	}
 
 	@Test
-	public void should_combine_skip_pattern_and_additional_pattern_when_all_are_not_empty()
-			throws Exception {
-		SleuthWebProperties sleuthWebProperties = new SleuthWebProperties();
-		sleuthWebProperties.setSkipPattern("foo.*|bar.*");
-		sleuthWebProperties.setAdditionalSkipPattern("baz.*|faz.*");
-		Pattern pattern = new TraceWebAutoConfiguration.DefaultSkipPatternConfig()
-				.defaultSkipPatternBean(sleuthWebProperties).skipPattern().get();
-
-		then(pattern.pattern()).isEqualTo("foo.*|bar.*|baz.*|faz.*");
+	public void should_combine_skip_pattern_and_additional_pattern_when_all_are_not_empty() {
+		contextRunner
+				.withPropertyValues("spring.sleuth.web.skip-pattern=foo.*|bar.*",
+						"spring.sleuth.web.additional-skip-pattern=baz.*|faz.*")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern()).isEqualTo("foo.*|bar.*|baz.*|faz.*");
+				});
 	}
 
 	@Test
@@ -74,14 +91,16 @@ public class SkipPatternProviderConfigTest {
 
 	@Test
 	public void should_return_management_context_with_context_path() throws Exception {
-		ManagementServerProperties properties = new ManagementServerProperties();
-		properties.getServlet().setContextPath("foo");
-
-		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ManagementSkipPatternProviderConfig()
-				.skipPatternForManagementServerProperties(properties).skipPattern();
-
-		then(pattern).isNotEmpty();
-		then(pattern.get().pattern()).isEqualTo("foo.*");
+		contextRunner
+				.withConfiguration(UserConfigurations.of(
+						ManagementContextAutoConfiguration.class, EndpointConfig.class))
+				.withPropertyValues("management.server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern()).contains("|foo.*");
+				});
 	}
 
 	@Test
@@ -97,190 +116,163 @@ public class SkipPatternProviderConfigTest {
 
 	@Test
 	public void should_return_endpoints_without_context_path() {
-		ServerProperties properties = new ServerProperties();
-		WebEndpointProperties webEndpointProperties = new WebEndpointProperties();
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = () -> {
-			ExposableWebEndpoint infoEndpoint = createEndpoint("info");
-			ExposableWebEndpoint healthEndpoint = createEndpoint("health");
-
-			return Arrays.asList(infoEndpoint, healthEndpoint);
-		};
-
-		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsSamePort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(pattern).isNotEmpty();
-		then(pattern.get().pattern())
-				.isEqualTo("/actuator/(info|info/.*|health|health/.*)");
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("/actuator/(health|health/.*|info|info/.*)");
+				});
 	}
 
 	@Test
 	public void should_return_endpoints_with_context_path() {
-		WebEndpointProperties webEndpointProperties = new WebEndpointProperties();
-		ServerProperties properties = new ServerProperties();
-		properties.getServlet().setContextPath("foo");
-
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = () -> {
-			ExposableWebEndpoint infoEndpoint = createEndpoint("info");
-			ExposableWebEndpoint healthEndpoint = createEndpoint("health");
-
-			return Arrays.asList(infoEndpoint, healthEndpoint);
-		};
-
-		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsSamePort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(pattern).isNotEmpty();
-		then(pattern.get().pattern())
-				.isEqualTo("foo/actuator/(info|info/.*|health|health/.*)");
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("foo/actuator/(health|health/.*|info|info/.*)");
+				});
 	}
 
 	@Test
 	public void should_return_endpoints_without_context_path_and_base_path_set_to_root() {
-		ServerProperties properties = new ServerProperties();
-		WebEndpointProperties webEndpointProperties = new WebEndpointProperties();
-		webEndpointProperties.setBasePath("/");
-
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = () -> {
-			ExposableWebEndpoint infoEndpoint = createEndpoint("info");
-			ExposableWebEndpoint healthEndpoint = createEndpoint("health");
-
-			return Arrays.asList(infoEndpoint, healthEndpoint);
-		};
-
-		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsSamePort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(pattern).isNotEmpty();
-		then(pattern.get().pattern()).isEqualTo("/(info|info/.*|health|health/.*)");
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"management.endpoints.web.base-path=/")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern()).contains("/(health|health/.*|info|info/.*)");
+				});
 	}
 
 	@Test
 	public void should_return_endpoints_with_context_path_and_base_path_set_to_root() {
-		WebEndpointProperties webEndpointProperties = new WebEndpointProperties();
-		webEndpointProperties.setBasePath("/");
-		ServerProperties properties = new ServerProperties();
-		properties.getServlet().setContextPath("foo");
-
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = () -> {
-			ExposableWebEndpoint infoEndpoint = createEndpoint("info");
-			ExposableWebEndpoint healthEndpoint = createEndpoint("health");
-
-			return Arrays.asList(infoEndpoint, healthEndpoint);
-		};
-
-		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsSamePort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(pattern).isNotEmpty();
-		then(pattern.get().pattern()).isEqualTo("foo/(info|info/.*|health|health/.*)");
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"management.endpoints.web.base-path=/",
+						"server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("foo/(health|health/.*|info|info/.*)");
+				});
 	}
 
 	@Test
-	public void should_return_endpoints_with_actuator_context_path_set_to_root() {
-		WebEndpointProperties webEndpointProperties = new WebEndpointProperties();
-		webEndpointProperties.setBasePath("/");
-		ServerProperties properties = new ServerProperties();
-		properties.getServlet().setContextPath("foo");
-
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = () -> {
-			ExposableWebEndpoint infoEndpoint = createEndpoint("info");
-			ExposableWebEndpoint healthEndpoint = createEndpoint("health");
-
-			return Arrays.asList(infoEndpoint, healthEndpoint);
-		};
-
-		Optional<Pattern> patternDifferentPort = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsDifferentPort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(patternDifferentPort).isNotEmpty();
-		then(patternDifferentPort.get().pattern())
-				.isEqualTo("/(info|info/.*|health|health/.*)");
-
-		Optional<Pattern> patternSamePort = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsSamePort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(patternSamePort).isNotEmpty();
-		then(patternSamePort.get().pattern())
-				.isEqualTo("foo/(info|info/.*|health|health/.*)");
+	public void should_return_endpoints_with_context_path_and_base_path_set_to_root_different_port() {
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"management.endpoints.web.base-path=/",
+						"management.servet.port=0", "server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern()).contains("/(health|health/.*|info|info/.*)");
+				});
 	}
 
 	@Test
 	public void should_return_endpoints_with_actuator_context_path_only() {
-		WebEndpointProperties webEndpointProperties = new WebEndpointProperties();
-		webEndpointProperties.setBasePath("/mgt");
-		ServerProperties properties = new ServerProperties();
-		properties.getServlet().setContextPath("foo");
-
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = () -> {
-			ExposableWebEndpoint infoEndpoint = createEndpoint("info");
-			ExposableWebEndpoint healthEndpoint = createEndpoint("health");
-
-			return Arrays.asList(infoEndpoint, healthEndpoint);
-		};
-
-		Optional<Pattern> patternDifferentPort = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsDifferentPort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(patternDifferentPort).isNotEmpty();
-		then(patternDifferentPort.get().pattern())
-				.isEqualTo("/mgt/(info|info/.*|health|health/.*)");
-
-		Optional<Pattern> patternSamePort = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsSamePort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(patternSamePort).isNotEmpty();
-		then(patternSamePort.get().pattern())
-				.isEqualTo("foo/mgt/(info|info/.*|health|health/.*)");
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"management.endpoints.web.base-path=/mgt",
+						"server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("foo/mgt/(health|health/.*|info|info/.*)");
+				});
 	}
 
 	@Test
 	public void should_return_endpoints_with_actuator_default_context_path() {
-		WebEndpointProperties webEndpointProperties = new WebEndpointProperties();
-		ServerProperties properties = new ServerProperties();
-		properties.getServlet().setContextPath("/foo");
-		properties.setPort(8080);
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("foo/actuator/(health|health/.*|info|info/.*)");
+				});
+	}
 
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = () -> {
-			ExposableWebEndpoint infoEndpoint = createEndpoint("info");
-			ExposableWebEndpoint healthEndpoint = createEndpoint("health");
+	@Test
+	public void should_return_endpoints_with_actuator_default_context_path_different_port() {
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"management.servet.port=0", "server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("/actuator/(health|health/.*|info|info/.*)");
+				});
+	}
 
-			return Arrays.asList(infoEndpoint, healthEndpoint);
-		};
+	@Test
+	public void should_return_endpoints_with_actuator_context_path_only_different_port() {
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"management.endpoints.web.base-path=/mgt",
+						"management.servet.port=0", "server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("/mgt/(health|health/.*|info|info/.*)");
+				});
+	}
 
-		Optional<Pattern> patternDifferentPort = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsDifferentPort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(patternDifferentPort).isNotEmpty();
-		then(patternDifferentPort.get().pattern())
-				.isEqualTo("/actuator/(info|info/.*|health|health/.*)");
-
-		Optional<Pattern> patternSamePort = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
-				.skipPatternForActuatorEndpointsSamePort(properties,
-						webEndpointProperties, endpointsSupplier)
-				.skipPattern();
-
-		then(patternSamePort).isNotEmpty();
-		then(patternSamePort.get().pattern())
-				.isEqualTo("/foo/actuator/(info|info/.*|health|health/.*)");
+	@Test
+	public void should_return_endpoints_with_context_path_different_port() {
+		contextRunner.withConfiguration(UserConfigurations.of(EndpointConfig.class))
+				.withPropertyValues("management.endpoint.health.enabled=true",
+						"management.endpoint.info.enabled=true",
+						"management.endpoints.web.exposure.include=info,health",
+						"management.servet.port=0", "server.servlet.context-path=foo")
+				.run(context -> {
+					SkipPatternProvider skipPatternProvider = context
+							.getBean(SkipPatternProvider.class);
+					Pattern pattern = skipPatternProvider.skipPattern();
+					then(pattern.pattern())
+							.contains("/actuator/(health|health/.*|info|info/.*)");
+				});
 	}
 
 	@Test
@@ -301,29 +293,13 @@ public class SkipPatternProviderConfigTest {
 		return () -> Optional.of(Pattern.compile("bar"));
 	}
 
-	private ExposableWebEndpoint createEndpoint(final String name) {
-		return new ExposableWebEndpoint() {
+	@Configuration
+	@ImportAutoConfiguration({ DispatcherServletAutoConfiguration.class,
+			InfoEndpointAutoConfiguration.class, HealthIndicatorAutoConfiguration.class,
+			HealthEndpointAutoConfiguration.class, EndpointAutoConfiguration.class,
+			WebEndpointAutoConfiguration.class })
+	@EnableConfigurationProperties(ServerProperties.class)
+	static class EndpointConfig {
 
-			@Override
-			public String getRootPath() {
-				return name;
-			}
-
-			@Override
-			public EndpointId getEndpointId() {
-				return EndpointId.of(name);
-			}
-
-			@Override
-			public boolean isEnableByDefault() {
-				return false;
-			}
-
-			@Override
-			public Collection<WebOperation> getOperations() {
-				return null;
-			}
-		};
 	}
-
 }


### PR DESCRIPTION
Hey @marcingrzejszczak , @shakuzen !

As discussed (in https://github.com/spring-cloud/spring-cloud-sleuth/pull/1208), it would be good to switch the  `SkipPatternProviderConfigTest ` to use application context runner instead of manually instantiated configurations classes.

Thanks!