### PR TITLE
Fix NullPointerException

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
@@ -161,7 +161,7 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 			AtomicReference reference = req.currentContext()
 					.getOrDefault(AtomicReference.class, new AtomicReference());
 			Span span = handler().handleSend(injector(), req.requestHeaders(), req,
-					(Span) reference.get());
+					reference.get() == null ? handler().nextSpan(req) : (Span) reference.get());
 			reference.set(span);
 		}
 


### PR DESCRIPTION
We are using `spring-cloud-gateway`(Greenwich.RELEASE), and with `spring-cloud-starter-zipkin` together, and we are using `HttpClient` like the following:

```
import reactor.netty.http.client.HttpClient;

@Compoment
public class InitClass{
    @Resource
    private HttpClient httpClient; 

    @PostConstruct
    public void initSomeThing(){
         httpClient.request(HttpMethod.GET).uri("http://ip:port")
                .responseContent().aggregate().asString(Charset.defaultCharset())
                .subscribe(s -> System.out.println(s));
    }
}
```

When executing this code,  the following error occurs:

```
13:15:17.002 WARN  [reactor-http-kqueue-3,,,,172.16.61.86] i.n.u.c.AbstractEventExecutor[AbstractEventExecutor.java:165] -> A task raised an exception. Task: reactor.netty.resources.PooledConnectionProvider$DisposableAcquire@65a15442
java.lang.NullPointerException: null
        at brave.http.HttpClientHandler.handleSend(HttpClientHandler.java:96)
        at org.springframework.cloud.sleuth.instrument.web.client.HttpClientBeanPostProcessor$TracingDoOnRequest.accept(HttpClientBeanPostProcessor.java:136)
        at org.springframework.cloud.sleuth.instrument.web.client.HttpClientBeanPostProcessor$TracingDoOnRequest.accept(HttpClientBeanPostProcessor.java:88)
        at reactor.netty.http.client.HttpClientDoOn.onStateChange(HttpClientDoOn.java:62)
        at reactor.netty.ReactorNetty$CompositeConnectionObserver.onStateChange(ReactorNetty.java:358)
        at reactor.netty.resources.PooledConnectionProvider$DisposableAcquire.onStateChange(PooledConnectionProvider.java:514)
        at reactor.netty.resources.PooledConnectionProvider$DisposableAcquire.run(PooledConnectionProvider.java:544)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute$$$capture(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.kqueue.KQueueEventLoop.run(KQueueEventLoop.java:271)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:909)
        at java.lang.Thread.run(Thread.java:745)
```

This PR try to fix this issue.