### PR TITLE
URL Cleanup

### DIFF
--- a/1.2.x/spring-cloud-sleuth.xml
+++ b/1.2.x/spring-cloud-sleuth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc maxdepth="8"?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Sleuth</title>
 <date>2018-07-20</date>
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1392,7 +1392,7 @@ Stream based span reporting).</simpara>
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1485,7 +1485,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1674,13 +1674,13 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
 
-Traverson traverson = new Traverson(URI.create("http://some/address"),
+Traverson traverson = new Traverson(URI.create("https://some/address"),
     MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON_UTF8).setRestOperations(restTemplate);
 // use Traverson</programlisting>
 </section>
@@ -1773,7 +1773,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1794,10 +1794,10 @@ To disable Zuul support set the <literal>spring.sleuth.zuul.enabled</literal> pr
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-web.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/1.3.x/spring-cloud-sleuth.xml
+++ b/1.3.x/spring-cloud-sleuth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc maxdepth="8"?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Sleuth</title>
 <date>2019-03-25</date>
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span:</emphasis> The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an
 RPC. Span&#8217;s are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span
 is a part of.  Spans also have other data, such as descriptions, timestamped events, key-value
@@ -200,7 +200,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
 <simpara>If you&#8217;re using a log aggregating tool like <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>,
-<link xl:href="http://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
+<link xl:href="https://www.splunk.com/">Splunk</link> etc. you can order the events that took place. An example of
 Kibana would look like this:</simpara>
 <informalfigure>
 <mediaobject>
@@ -1309,7 +1309,7 @@ on <literal>spring-rabbit</literal> or <literal>spring-kafka</literal> your app 
 when the span is closed, it will be sent to Zipkin over HTTP. The communication
 is asynchronous. You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal>
 property as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin via service discovery it&#8217;s enough to pass the
 Zipkin&#8217;s service id inside the URL. If you want to disable this feature
 just set <literal>spring.zipkin.discoveryClientEnabled</literal> to <literal>false.
@@ -1351,7 +1351,7 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 <chapter xml:id="_span_data_as_messages">
 <title>Span Data as Messages</title>
 <simpara>You can accumulate and send span data over
-<link xl:href="http://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
+<link xl:href="https://cloud.spring.io/spring-cloud-stream">Spring Cloud Stream</link> by
 including the <literal>spring-cloud-sleuth-stream</literal> jar as a dependency, and
 adding a Channel Binder implementation
 (e.g. <literal>spring-cloud-starter-stream-rabbit</literal> for RabbitMQ or
@@ -1450,7 +1450,7 @@ public static class CustomPollerConfiguration {
 <chapter xml:id="_metrics">
 <title>Metrics</title>
 <simpara>Currently Spring Cloud Sleuth registers very simple metrics related to spans.
-It&#8217;s using the <link xl:href="http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
+It&#8217;s using the <link xl:href="https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html#production-ready-recording-metrics">Spring Boot&#8217;s metrics support</link>
 to calculate the number of accepted and dropped spans. Each time a span gets
 sent to Zipkin the number of accepted spans will increase. If there&#8217;s an error then
 the number of dropped spans will get increased.</simpara>
@@ -1639,13 +1639,13 @@ static class Config {
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you&#8217;re using the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
+<simpara>If you&#8217;re using the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library
 it&#8217;s enough for you to inject a <literal>RestTemplate</literal> as a bean into your Traverson object. Since <literal>RestTemplate</literal>
 is already intercepted, you will get full support of tracing in your client. Below you can find a pseudo code
 of how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
 
-Traverson traverson = new Traverson(URI.create("http://some/address"),
+Traverson traverson = new Traverson(URI.create("https://some/address"),
     MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON_UTF8).setRestOperations(restTemplate);
 // use Traverson</programlisting>
 </section>
@@ -1741,7 +1741,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 </section>
 <section xml:id="_messaging">
 <title>Messaging</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>. It creates spans for publish and
 subscribe events. To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to false.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly
 provide the names of channels that you want to include for tracing. By default all channels
@@ -1790,10 +1790,10 @@ class ReporterConfiguration {
 <simpara>You can find the running examples deployed in the <link xl:href="https://run.pivotal.io/">Pivotal Web Services</link>. Check them out in the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link></simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link></simpara>
 </listitem>
 </itemizedlist>
 </chapter>

--- a/2.0.x/checkstyle-checker.xml
+++ b/2.0.x/checkstyle-checker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<module name="TreeWalker">
 		<!-- this. in front of fields -->

--- a/2.0.x/spring-cloud-sleuth.xml
+++ b/2.0.x/spring-cloud-sleuth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc maxdepth="8"?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Sleuth</title>
 <date>2019-03-25</date>
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -695,7 +695,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -822,7 +822,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1576,7 +1576,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1619,13 +1619,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1824,12 +1824,12 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
 
-Traverson traverson = new Traverson(URI.create("http://some/address"),
+Traverson traverson = new Traverson(URI.create("https://some/address"),
     MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON_UTF8).setRestOperations(restTemplate);
 // use Traverson</programlisting>
 </section>
@@ -1945,7 +1945,7 @@ static class CustomExecutorConfig extends AsyncConfigurerSupport {
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -1985,11 +1985,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/2.1.x/spring-cloud-sleuth.xml
+++ b/2.1.x/spring-cloud-sleuth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc maxdepth="8"?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Sleuth</title>
 <date>2019-03-25</date>
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -745,7 +745,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -872,7 +872,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1662,7 +1662,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1705,13 +1705,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1917,12 +1917,12 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
 
-Traverson traverson = new Traverson(URI.create("http://some/address"),
+Traverson traverson = new Traverson(URI.create("https://some/address"),
     MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON_UTF8).setRestOperations(restTemplate);
 // use Traverson</programlisting>
 </section>
@@ -2092,7 +2092,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2147,11 +2147,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>

--- a/checkstyle-checker.xml
+++ b/checkstyle-checker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<module name="TreeWalker">
 		<!-- this. in front of fields -->

--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="http://www.w3.org/2000/svg">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="https://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
 <font id="fontawesomeregular" horiz-adv-x="1536" >

--- a/spring-cloud-sleuth.xml
+++ b/spring-cloud-sleuth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc maxdepth="8"?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Sleuth</title>
 <date>2019-03-08</date>
@@ -18,10 +18,10 @@
 </preface>
 <chapter xml:id="_introduction">
 <title>Introduction</title>
-<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="http://cloud.spring.io">Spring Cloud</link>.</simpara>
+<simpara>Spring Cloud Sleuth implements a distributed tracing solution for <link xl:href="https://cloud.spring.io">Spring Cloud</link>.</simpara>
 <section xml:id="_terminology">
 <title>Terminology</title>
-<simpara>Spring Cloud Sleuth borrows <link xl:href="http://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
+<simpara>Spring Cloud Sleuth borrows <link xl:href="https://research.google.com/pubs/pub36356.html">Dapper&#8217;s</link> terminology.</simpara>
 <simpara><emphasis role="strong">Span</emphasis>: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
 Spans also have other data, such as descriptions, timestamped events, key-value annotations (tags), the ID of the span that caused them, and process IDs (normally IP addresses).</simpara>
@@ -183,7 +183,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Click here to see it live!</link></simpara>
 <simpara>The dependency graph in Zipkin should resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -202,7 +202,7 @@ However, if you want to use the legacy Sleuth approaches, you can set the <liter
 <textobject><phrase>Zipkin deployed on Pivotal Web Services</phrase></textobject>
 </mediaobject>
 </figure>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/dependency">Click here to see it live!</link></simpara>
 </section>
 <section xml:id="_log_correlation">
 <title>Log correlation</title>
@@ -214,7 +214,7 @@ service2.log:2016-02-26 11:15:47.924  INFO [service2,2485ec27856c56f4,9aa10ee6fb
 service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262ffba49d,true] 68061 --- [nio-8084-exec-1] i.s.c.sleuth.docs.service4.Application   : Hello from service4
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]</screen>
-<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="http://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
+<simpara>If you use a log aggregating tool (such as <link xl:href="https://www.elastic.co/products/kibana">Kibana</link>, <link xl:href="https://www.splunk.com/">Splunk</link>, and others), you can order the events that took place.
 An example from Kibana would resemble the following image:</simpara>
 <informalfigure>
 <mediaobject>
@@ -745,7 +745,7 @@ You can configure the location of the service by setting <literal>spring.zipkin.
 </caution>
 <itemizedlist>
 <listitem>
-<simpara>Spring Cloud Sleuth is <link xl:href="http://opentracing.io/">OpenTracing</link> compatible.</simpara>
+<simpara>Spring Cloud Sleuth is <link xl:href="https://opentracing.io/">OpenTracing</link> compatible.</simpara>
 </listitem>
 </itemizedlist>
 <important>
@@ -872,7 +872,7 @@ void userCode() {
 <section xml:id="_rpc_tracing">
 <title>RPC tracing</title>
 <tip>
-<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="http://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
+<simpara>Check for <link xl:href="https://github.com/openzipkin/brave/tree/master/instrumentation">instrumentation written here</link> and <link xl:href="https://zipkin.io/pages/existing_instrumentations.html">Zipkin&#8217;s list</link> before rolling your own RPC instrumentation.</simpara>
 </tip>
 <simpara>RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.</simpara>
 <simpara>The following example shows how to add a client span:</simpara>
@@ -1662,7 +1662,7 @@ If those are not set, we try to retrieve the host name from the network interfac
 <simpara>By default, if you add <literal>spring-cloud-starter-zipkin</literal> as a dependency to your project, when the span is closed, it is sent to Zipkin over HTTP.
 The communication is asynchronous.
 You can configure the URL by setting the <literal>spring.zipkin.baseUrl</literal> property, as follows:</simpara>
-<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://192.168.99.100:9411/</programlisting>
+<programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: https://192.168.99.100:9411/</programlisting>
 <simpara>If you want to find Zipkin through service discovery, you can pass the Zipkin&#8217;s service ID inside the URL, as shown in the following example for <literal>zipkinserver</literal> service ID:</simpara>
 <programlisting language="yaml" linenumbering="unnumbered">spring.zipkin.baseUrl: http://zipkinserver/</programlisting>
 <simpara>To disable this feature just set <literal>spring.zipkin.discoveryClientEnabled</literal> to `false.</simpara>
@@ -1705,13 +1705,13 @@ object, you will have to create a bean of <literal>zipkin2.reporter.Sender</lite
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.</simpara>
 </important>
-<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
+<simpara>If for some reason you need to create the deprecated Stream Zipkin server, see the <link xl:href="https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer">Dalston Documentation</link>.</simpara>
 </chapter>
 <chapter xml:id="_integrations">
 <title>Integrations</title>
 <section xml:id="_opentracing">
 <title>OpenTracing</title>
-<simpara>Spring Cloud Sleuth is compatible with <link xl:href="http://opentracing.io/">OpenTracing</link>.
+<simpara>Spring Cloud Sleuth is compatible with <link xl:href="https://opentracing.io/">OpenTracing</link>.
 If you have OpenTracing on the classpath, we automatically register the OpenTracing <literal>Tracer</literal> bean.
 If you wish to disable this, set <literal>spring.sleuth.opentracing.enabled</literal> to <literal>false</literal></simpara>
 </section>
@@ -1917,12 +1917,12 @@ If you create a <literal>WebClient</literal> instance with a <literal>new</liter
 </section>
 <section xml:id="_traverson">
 <title>Traverson</title>
-<simpara>If you use the <link xl:href="http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
+<simpara>If you use the <link xl:href="https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson">Traverson</link> library, you can inject a <literal>RestTemplate</literal> as a bean into your Traverson object.
 Since <literal>RestTemplate</literal> is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:</simpara>
 <programlisting language="java" linenumbering="unnumbered">@Autowired RestTemplate restTemplate;
 
-Traverson traverson = new Traverson(URI.create("http://some/address"),
+Traverson traverson = new Traverson(URI.create("https://some/address"),
     MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON_UTF8).setRestOperations(restTemplate);
 // use Traverson</programlisting>
 </section>
@@ -2092,7 +2092,7 @@ to add the <literal>@Role(BeanDefinition.ROLE_INFRASTRUCTURE)</literal> on your
 <simpara>Features from this section can be disabled by setting the <literal>spring.sleuth.messaging.enabled</literal> property with value equal to <literal>false</literal>.</simpara>
 <section xml:id="_spring_integration_and_spring_cloud_stream">
 <title>Spring Integration and Spring Cloud Stream</title>
-<simpara>Spring Cloud Sleuth integrates with <link xl:href="http://projects.spring.io/spring-integration/">Spring Integration</link>.
+<simpara>Spring Cloud Sleuth integrates with <link xl:href="https://projects.spring.io/spring-integration/">Spring Integration</link>.
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set <literal>spring.sleuth.integration.enabled</literal> to <literal>false</literal>.</simpara>
 <simpara>You can provide the <literal>spring.sleuth.integration.patterns</literal> pattern to explicitly provide the names of channels that you want to include for tracing.
@@ -2147,11 +2147,11 @@ To disable Zuul support, set the <literal>spring.sleuth.zuul.enabled</literal> p
 Check them out at the following links:</simpara>
 <itemizedlist>
 <listitem>
-<simpara><link xl:href="http://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
-a request to <link xl:href="http://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
+<simpara><link xl:href="https://docssleuth-zipkin-server.cfapps.io/">Zipkin for apps presented in the samples to the top</link>. First make
+a request to <link xl:href="https://docssleuth-service1.cfapps.io/start">Service 1</link> and then check out the trace in Zipkin.</simpara>
 </listitem>
 <listitem>
-<simpara><link xl:href="http://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
+<simpara><link xl:href="https://docsbrewing-zipkin-server.cfapps.io/">Zipkin for Brewery on PWS</link>, its <link xl:href="https://github.com/spring-cloud-samples/brewery">Github Code</link>.
 Ensure that you&#8217;ve picked the lookback period of 7 days. If there are no traces, go to <link xl:href="https://docsbrewing-presenting.cfapps.io/">Presenting application</link>
 and order some beers. Then check Zipkin for traces.</simpara>
 </listitem>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://dubbo.io/ (200) with 3 occurrences could not be migrated:  
   ([https](https://dubbo.io/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://192.168.99.100:9411/ (ConnectTimeoutException) with 4 occurrences migrated to:  
  https://192.168.99.100:9411/ ([https](https://192.168.99.100:9411/) result ConnectTimeoutException).
* [ ] http://some/address (UnknownHostException) with 5 occurrences migrated to:  
  https://some/address ([https](https://some/address) result UnknownHostException).
* [ ] http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html (404) with 3 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html ([https](https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html) result 404).
* [ ] http://docsbrewing-zipkin-web.cfapps.io/ (404) with 1 occurrences migrated to:  
  https://docsbrewing-zipkin-web.cfapps.io/ ([https](https://docsbrewing-zipkin-web.cfapps.io/) result 404).
* [ ] http://docssleuth-zipkin-server.cfapps.io/dependency (404) with 3 occurrences migrated to:  
  https://docssleuth-zipkin-server.cfapps.io/dependency ([https](https://docssleuth-zipkin-server.cfapps.io/dependency) result 404).
* [ ] http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 2 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).
* [ ] http://zipkin.io/pages/existing_instrumentations.html (301) with 3 occurrences migrated to:  
  https://zipkin.io/pages/existing_instrumentations.html ([https](https://zipkin.io/pages/existing_instrumentations.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io with 5 occurrences migrated to:  
  https://cloud.spring.io ([https](https://cloud.spring.io) result 200).
* [ ] http://docbook.org/ns/docbook with 5 occurrences migrated to:  
  https://docbook.org/ns/docbook ([https](https://docbook.org/ns/docbook) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html) result 200).
* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/html/ with 5 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/html/ ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/html/) result 200).
* [ ] http://docssleuth-service1.cfapps.io/start with 3 occurrences migrated to:  
  https://docssleuth-service1.cfapps.io/start ([https](https://docssleuth-service1.cfapps.io/start) result 200).
* [ ] http://opentracing.io/ with 6 occurrences migrated to:  
  https://opentracing.io/ ([https](https://opentracing.io/) result 200).
* [ ] http://projects.spring.io/spring-integration/ with 5 occurrences migrated to:  
  https://projects.spring.io/spring-integration/ ([https](https://projects.spring.io/spring-integration/) result 200).
* [ ] http://www.splunk.com/ with 5 occurrences migrated to:  
  https://www.splunk.com/ ([https](https://www.splunk.com/) result 200).
* [ ] http://www.w3.org/1999/xlink with 5 occurrences migrated to:  
  https://www.w3.org/1999/xlink ([https](https://www.w3.org/1999/xlink) result 200).
* [ ] http://www.w3.org/2000/svg with 1 occurrences migrated to:  
  https://www.w3.org/2000/svg ([https](https://www.w3.org/2000/svg) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream ([https](https://cloud.spring.io/spring-cloud-stream) result 301).
* [ ] http://research.google.com/pubs/pub36356.html with 5 occurrences migrated to:  
  https://research.google.com/pubs/pub36356.html ([https](https://research.google.com/pubs/pub36356.html) result 301).
* [ ] http://docsbrewing-zipkin-server.cfapps.io/ with 4 occurrences migrated to:  
  https://docsbrewing-zipkin-server.cfapps.io/ ([https](https://docsbrewing-zipkin-server.cfapps.io/) result 302).
* [ ] http://docssleuth-zipkin-server.cfapps.io/ with 8 occurrences migrated to:  
  https://docssleuth-zipkin-server.cfapps.io/ ([https](https://docssleuth-zipkin-server.cfapps.io/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://zipkinserver/ with 4 occurrences