### PR TITLE
URL Cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ added after the original pull request but before a merge.
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
   [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
-  [Eclipse Code Formatter Plugin](http://plugins.jetbrains.com/plugin/6546) to import the same file.
+  [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546) to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
@@ -40,6 +40,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow [these conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
+* When writing a commit message please follow [these conventions](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ image::https://badges.gitter.im/spring-cloud/spring-cloud-sleuth.svg[Gitter, lin
 
 == Spring Cloud Sleuth
 
-Spring Cloud Sleuth is a distributed tracing tool for Spring Cloud. It borrows from http://research.google.com/pubs/pub36356.html[Dapper], https://github.com/openzipkin/zipkin[Zipkin], and http://htrace.incubator.apache.org/[HTrace].
+Spring Cloud Sleuth is a distributed tracing tool for Spring Cloud. It borrows from https://research.google.com/pubs/pub36356.html[Dapper], https://github.com/openzipkin/zipkin[Zipkin], and https://htrace.incubator.apache.org/[HTrace].
 
 === Quick Start
 
@@ -49,11 +49,11 @@ IMPORTANT: If you use Zipkin, configure the probability of spans exported by set
 
 == Introduction
 
-Spring Cloud Sleuth implements a distributed tracing solution for http://cloud.spring.io[Spring Cloud].
+Spring Cloud Sleuth implements a distributed tracing solution for https://cloud.spring.io[Spring Cloud].
 
 === Terminology
 
-Spring Cloud Sleuth borrows http://research.google.com/pubs/pub36356.html[Dapper's] terminology.
+Spring Cloud Sleuth borrows https://research.google.com/pubs/pub36356.html[Dapper's] terminology.
 
 *Span*: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
@@ -171,8 +171,8 @@ However, if you want to use the legacy Sleuth approaches, you can set the `sprin
 
 .Click the Pivotal Web Services icon to see it live!
 [caption="Click the Pivotal Web Services icon to see it live!"]
-image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="http://docssleuth-zipkin-server.cfapps.io/", width=150, height=74]
-http://docssleuth-zipkin-server.cfapps.io/[Click here to see it live!]
+image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="https://docssleuth-zipkin-server.cfapps.io/", width=150, height=74]
+https://docssleuth-zipkin-server.cfapps.io/[Click here to see it live!]
 
 The dependency graph in Zipkin should resemble the following image:
 
@@ -180,8 +180,8 @@ image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branc
 
 .Click the Pivotal Web Services icon to see it live!
 [caption="Click the Pivotal Web Services icon to see it live!"]
-image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="http://docssleuth-zipkin-server.cfapps.io/dependency", width=150, height=74]
-http://docssleuth-zipkin-server.cfapps.io/dependency[Click here to see it live!]
+image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="https://docssleuth-zipkin-server.cfapps.io/dependency", width=150, height=74]
+https://docssleuth-zipkin-server.cfapps.io/dependency[Click here to see it live!]
 
 ==== Log correlation
 
@@ -196,7 +196,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]
 
-If you use a log aggregating tool (such as https://www.elastic.co/products/kibana[Kibana], http://www.splunk.com/[Splunk], and others), you can order the events that took place.
+If you use a log aggregating tool (such as https://www.elastic.co/products/kibana[Kibana], https://www.splunk.com/[Splunk], and others), you can order the events that took place.
 An example from Kibana would resemble the following image:
 
 image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/kibana.png[Log correlation with Kibana]
@@ -602,7 +602,7 @@ You can configure the location of the service by setting `spring.zipkin.baseUrl`
 
 CAUTION: `spring-cloud-sleuth-stream` is deprecated and should no longer be used.
 
-* Spring Cloud Sleuth is http://opentracing.io/[OpenTracing] compatible.
+* Spring Cloud Sleuth is https://opentracing.io/[OpenTracing] compatible.
 
 IMPORTANT: If you use Zipkin, configure the probability of spans exported by setting `spring.sleuth.sampler.probability`
 (default: 0.1, which is 10 percent). Otherwise, you might think that Sleuth is not working be cause it omits some spans.
@@ -652,7 +652,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -674,13 +674,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -741,7 +741,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -754,6 +754,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/asciidoctor.css
+++ b/asciidoctor.css
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -11,7 +11,7 @@ image::https://badges.gitter.im/spring-cloud/spring-cloud-sleuth.svg[Gitter, lin
 
 == Spring Cloud Sleuth
 
-Spring Cloud Sleuth is a distributed tracing tool for Spring Cloud. It borrows from http://research.google.com/pubs/pub36356.html[Dapper], https://github.com/openzipkin/zipkin[Zipkin], and http://htrace.incubator.apache.org/[HTrace].
+Spring Cloud Sleuth is a distributed tracing tool for Spring Cloud. It borrows from https://research.google.com/pubs/pub36356.html[Dapper], https://github.com/openzipkin/zipkin[Zipkin], and https://htrace.incubator.apache.org/[HTrace].
 
 === Quick Start
 

--- a/docs/src/main/asciidoc/features.adoc
+++ b/docs/src/main/asciidoc/features.adoc
@@ -48,7 +48,7 @@ You can configure the location of the service by setting `spring.zipkin.baseUrl`
 
 CAUTION: `spring-cloud-sleuth-stream` is deprecated and should no longer be used.
 
-* Spring Cloud Sleuth is http://opentracing.io/[OpenTracing] compatible.
+* Spring Cloud Sleuth is https://opentracing.io/[OpenTracing] compatible.
 
 IMPORTANT: If you use Zipkin, configure the probability of spans exported by setting `spring.sleuth.sampler.probability`
 (default: 0.1, which is 10 percent). Otherwise, you might think that Sleuth is not working be cause it omits some spans.

--- a/docs/src/main/asciidoc/intro.adoc
+++ b/docs/src/main/asciidoc/intro.adoc
@@ -2,11 +2,11 @@
 
 == Introduction
 
-Spring Cloud Sleuth implements a distributed tracing solution for http://cloud.spring.io[Spring Cloud].
+Spring Cloud Sleuth implements a distributed tracing solution for https://cloud.spring.io[Spring Cloud].
 
 === Terminology
 
-Spring Cloud Sleuth borrows http://research.google.com/pubs/pub36356.html[Dapper's] terminology.
+Spring Cloud Sleuth borrows https://research.google.com/pubs/pub36356.html[Dapper's] terminology.
 
 *Span*: The basic unit of work. For example, sending an RPC is a new span, as is sending a response to an RPC.
 Spans are identified by a unique 64-bit ID for the span and another 64-bit ID for the trace the span is a part of.
@@ -124,8 +124,8 @@ However, if you want to use the legacy Sleuth approaches, you can set the `sprin
 
 .Click the Pivotal Web Services icon to see it live!
 [caption="Click the Pivotal Web Services icon to see it live!"]
-image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="http://docssleuth-zipkin-server.cfapps.io/", width=150, height=74]
-http://docssleuth-zipkin-server.cfapps.io/[Click here to see it live!]
+image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="https://docssleuth-zipkin-server.cfapps.io/", width=150, height=74]
+https://docssleuth-zipkin-server.cfapps.io/[Click here to see it live!]
 
 The dependency graph in Zipkin should resemble the following image:
 
@@ -133,8 +133,8 @@ image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branc
 
 .Click the Pivotal Web Services icon to see it live!
 [caption="Click the Pivotal Web Services icon to see it live!"]
-image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="http://docssleuth-zipkin-server.cfapps.io/dependency", width=150, height=74]
-http://docssleuth-zipkin-server.cfapps.io/dependency[Click here to see it live!]
+image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/pws.png["Zipkin deployed on Pivotal Web Services", link="https://docssleuth-zipkin-server.cfapps.io/dependency", width=150, height=74]
+https://docssleuth-zipkin-server.cfapps.io/dependency[Click here to see it live!]
 
 ==== Log correlation
 
@@ -149,7 +149,7 @@ service4.log:2016-02-26 11:15:48.134  INFO [service4,2485ec27856c56f4,1b1845262f
 service2.log:2016-02-26 11:15:48.156  INFO [service2,2485ec27856c56f4,9aa10ee6fbde75fa,true] 68059 --- [nio-8082-exec-1] i.s.c.sleuth.docs.service2.Application   : Got response from service4 [Hello from service4]
 service1.log:2016-02-26 11:15:48.182  INFO [service1,2485ec27856c56f4,2485ec27856c56f4,true] 68058 --- [nio-8081-exec-1] i.s.c.sleuth.docs.service1.Application   : Got response from service2 [Hello from service2, response from service3 [Hello from service3] and from service4 [Hello from service4]]
 
-If you use a log aggregating tool (such as https://www.elastic.co/products/kibana[Kibana], http://www.splunk.com/[Splunk], and others), you can order the events that took place.
+If you use a log aggregating tool (such as https://www.elastic.co/products/kibana[Kibana], https://www.splunk.com/[Splunk], and others), you can order the events that took place.
 An example from Kibana would resemble the following image:
 
 image::https://raw.githubusercontent.com/spring-cloud/spring-cloud-sleuth/{branch}/docs/src/main/asciidoc/images/kibana.png[Log correlation with Kibana]

--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -149,7 +149,7 @@ void userCode() {
 
 ==== RPC tracing
 
-TIP: Check for https://github.com/openzipkin/sleuth/tree/master/instrumentation[instrumentation written here] and http://zipkin.io/pages/existing_instrumentations.html[Zipkin's list] before rolling your own RPC instrumentation.
+TIP: Check for https://github.com/openzipkin/sleuth/tree/master/instrumentation[instrumentation written here] and https://zipkin.io/pages/existing_instrumentations.html[Zipkin's list] before rolling your own RPC instrumentation.
 
 RPC tracing is often done automatically by interceptors. Behind the scenes, they add tags and events that relate to their role in an RPC operation.
 
@@ -884,7 +884,7 @@ You can configure the URL by setting the `spring.zipkin.baseUrl` property, as fo
 
 [source,yaml]
 ----
-spring.zipkin.baseUrl: http://192.168.99.100:9411/
+spring.zipkin.baseUrl: https://192.168.99.100:9411/
 ----
 
 If you want to find Zipkin through service discovery, you can pass the Zipkin's service ID inside the URL, as shown in the following example for `zipkinserver` service ID:
@@ -953,13 +953,13 @@ IMPORTANT: We recommend using Zipkin's native support for message-based span sen
 Starting from the Edgware release, the Zipkin Stream server is deprecated.
 In the Finchley release, it got removed.
 
-If for some reason you need to create the deprecated Stream Zipkin server, see the http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer[Dalston Documentation].
+If for some reason you need to create the deprecated Stream Zipkin server, see the https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html#_zipkin_consumer[Dalston Documentation].
 
 == Integrations
 
 === OpenTracing
 
-Spring Cloud Sleuth is compatible with http://opentracing.io/[OpenTracing].
+Spring Cloud Sleuth is compatible with https://opentracing.io/[OpenTracing].
 If you have OpenTracing on the classpath, we automatically register the OpenTracing `Tracer` bean.
 If you wish to disable this, set `spring.sleuth.opentracing.enabled` to `false`
 
@@ -1119,7 +1119,7 @@ If you create a `WebClient` instance with a `new` keyword,  the instrumentation 
 
 ==== Traverson
 
-If you use the http://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson[Traverson] library, you can inject a `RestTemplate` as a bean into your Traverson object.
+If you use the https://docs.spring.io/spring-hateoas/docs/current/reference/html/#client.traverson[Traverson] library, you can inject a `RestTemplate` as a bean into your Traverson object.
 Since `RestTemplate` is already intercepted, you get full support for tracing in your client. The following pseudo code
 shows how to do that:
 
@@ -1223,7 +1223,7 @@ Features from this section can be disabled by setting the `spring.sleuth.messagi
 
 ==== Spring Integration and Spring Cloud Stream
 
-Spring Cloud Sleuth integrates with http://projects.spring.io/spring-integration/[Spring Integration].
+Spring Cloud Sleuth integrates with https://projects.spring.io/spring-integration/[Spring Integration].
 It creates spans for publish and subscribe events.
 To disable Spring Integration instrumentation, set `spring.sleuth.integration.enabled` to `false`.
 
@@ -1261,8 +1261,8 @@ To disable Zuul support, set the `spring.sleuth.zuul.enabled` property to `false
 You can see the running examples deployed in the https://run.pivotal.io/[Pivotal Web Services].
 Check them out at the following links:
 
-* http://docssleuth-zipkin-server.cfapps.io/[Zipkin for apps presented in the samples to the top]. First make
-a request to http://docssleuth-service1.cfapps.io/start[Service 1] and then check out the trace in Zipkin.
-* http://docsbrewing-zipkin-server.cfapps.io/[Zipkin for Brewery on PWS], its https://github.com/spring-cloud-samples/brewery[Github Code].
+* https://docssleuth-zipkin-server.cfapps.io/[Zipkin for apps presented in the samples to the top]. First make
+a request to https://docssleuth-service1.cfapps.io/start[Service 1] and then check out the trace in Zipkin.
+* https://docsbrewing-zipkin-server.cfapps.io/[Zipkin for Brewery on PWS], its https://github.com/spring-cloud-samples/brewery[Github Code].
 Ensure that you've picked the lookback period of 7 days. If there are no traces, go to https://docsbrewing-presenting.cfapps.io/[Presenting application]
 and order some beers. Then check Zipkin for traces.

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSampler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSampler.java
@@ -70,7 +70,7 @@ public class ProbabilityBasedSampler extends Sampler {
 	/**
 	 * Reservoir sampling algorithm borrowed from Stack Overflow.
 	 *
-	 * http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
+	 * https://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s
 	 */
 	static BitSet randomBitSet(int size, int cardinality, Random rnd) {
 		BitSet result = new BitSet(size);

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/issues/issue502/Issue502Tests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/issues/issue502/Issue502Tests.java
@@ -100,7 +100,7 @@ class Application {
 }
 
 @FeignClient(name="foo",
-		url="http://non.existing.url")
+		url="https://non.existing.url")
 interface MyNameRemote {
 
 	@RequestMapping(value = "/", method = RequestMethod.GET)

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-websocket/src/main/resources/static/sockjs-0.3.4.js
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-websocket/src/main/resources/static/sockjs-0.3.4.js
@@ -36,7 +36,7 @@ SockJS = (function(){
  */
 
 /* Simplified implementation of DOM2 EventTarget.
- *   http://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget
+ *   https://www.w3.org/TR/DOM-Level-2-Events/events.html#Events-EventTarget
  */
 var REventTarget = function() {};
 REventTarget.prototype.addEventListener = function (eventType, listener) {
@@ -258,7 +258,7 @@ utils.userSetCode = function (code) {
     return code === 1000 || (code >= 3000 && code <= 4999);
 };
 
-// See: http://www.erg.abdn.ac.uk/~gerrit/dccp/notes/ccid2/rto_estimator/
+// See: https://erg.abdn.ac.uk/~gerrit/dccp/notes/ccid2/rto_estimator/
 // and RFC 2988.
 utils.countRTO = function (rtt) {
     var rto;
@@ -417,7 +417,7 @@ var unroll_lookup = function(escapable) {
 
 // Quote string, also taking care of unicode characters that browsers
 // often break. Especially, take care of unicode surrogates:
-//    http://en.wikipedia.org/wiki/Mapping_of_Unicode_characters#Surrogates
+//    https://en.wikipedia.org/wiki/Mapping_of_Unicode_characters#Surrogates
 utils.quote = function(string) {
     var quoted = JSONQuote(string);
 
@@ -545,7 +545,7 @@ utils.attachEvent = function(event, listener) {
         _window.addEventListener(event, listener, false);
     } else {
         // IE quirks.
-        // According to: http://stevesouders.com/misc/test-postmessage.php
+        // According to: https://stevesouders.com/misc/test-postmessage.php
         // the message gets delivered only to 'document', not 'window'.
         _document.attachEvent("on" + event, listener);
         // I get 'window' for ie8.
@@ -745,7 +745,7 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
     }
 
     // Explorer tends to keep connection open, even after the
-    // tab gets closed: http://bugs.jquery.com/ticket/5280
+    // tab gets closed: https://bugs.jquery.com/ticket/5280
     that.unload_ref = utils.unload_add(function(){that._cleanup(true);});
     try {
         that.xhr.open(method, url, true);
@@ -778,7 +778,7 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
                     var status = x.status;
                     var text = x.responseText;
                 } catch (x) {};
-                // IE returns 1223 for 204: http://bugs.jquery.com/ticket/1450
+                // IE returns 1223 for 204: https://bugs.jquery.com/ticket/1450
                 if (status === 1223) status = 204;
 
                 // IE does return readystate == 3 for 404 answers.
@@ -788,7 +788,7 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
                 break;
             case 4:
                 var status = x.status;
-                // IE returns 1223 for 204: http://bugs.jquery.com/ticket/1450
+                // IE returns 1223 for 204: https://bugs.jquery.com/ticket/1450
                 if (status === 1223) status = 204;
 
                 that.emit('finish', status, x.responseText);
@@ -842,7 +842,7 @@ XHRLocalObject.prototype = new AbstractXHRObject();
 
 // References:
 //   http://ajaxian.com/archives/100-line-ajax-wrapper
-//   http://msdn.microsoft.com/en-us/library/cc288060(v=VS.85).aspx
+//   https://msdn.microsoft.com/en-us/library/cc288060(v=VS.85).aspx
 var XDRObject = utils.XDRObject = function(method, url, payload) {
     var that = this;
     utils.delay(function(){that._start(method, url, payload);});
@@ -1470,9 +1470,9 @@ var jsonPGenericReceiver = function(url, callback) {
     // script object. Later, onreadystatechange, manually execute this
     // code. FF and Chrome doesn't work with 'event' and 'htmlFor'
     // set. For reference see:
-    //   http://jaubourg.net/2010/07/loading-script-as-onclick-handler-of.html
+    //   https://jaubourg.net/2010/07/loading-script-as-onclick-handler-of.html
     // Also, read on that about script ordering:
-    //   http://wiki.whatwg.org/wiki/Dynamic_Script_Execution_Order
+    //   https://wiki.whatwg.org/wiki/Dynamic_Script_Execution_Order
     if (typeof script.async === 'undefined' && _document.attachEvent) {
         // According to mozilla docs, in recent browsers script.async defaults
         // to 'true', so we may use it to detect a good browser:
@@ -1671,8 +1671,8 @@ XhrStreamingTransport.need_body = true;
 
 
 // According to:
-//   http://stackoverflow.com/questions/1641507/detect-browser-support-for-cross-domain-xmlhttprequests
-//   http://hacks.mozilla.org/2009/07/cross-site-xmlhttprequest-with-cors/
+//   https://stackoverflow.com/questions/1641507/detect-browser-support-for-cross-domain-xmlhttprequests
+//   https://hacks.mozilla.org/2009/07/cross-site-xmlhttprequest-with-cors/
 
 
 // xdr-streaming
@@ -1726,8 +1726,8 @@ XdrPollingTransport.roundTrips = 2; // preflight, ajax
 // remote domain. New browsers, have capabilities to communicate with
 // cross domain iframe, using postMessage(). In IE it was implemented
 // from IE 8+, but of course, IE got some details wrong:
-//    http://msdn.microsoft.com/en-us/library/cc197015(v=VS.85).aspx
-//    http://stevesouders.com/misc/test-postmessage.php
+//    https://msdn.microsoft.com/en-us/library/cc197015(v=VS.85).aspx
+//    https://stevesouders.com/misc/test-postmessage.php
 
 var IframeTransport = function() {};
 
@@ -1897,7 +1897,7 @@ SockJS.bootstrap_iframe = function() {
 
     // alert('test ticker');
     // facade = new FacadeJS();
-    // facade._transport = new FacadeJS['w-iframe-xhr-polling'](facade, 'http://host.com:9999/ticker/12/basd');
+    // facade._transport = new FacadeJS['w-iframe-xhr-polling'](facade, 'https://host.com:9999/ticker/12/basd');
 
     utils.attachMessage(onMessage);
 

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/main/resources/application.yml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     name: testsleuthzipkin
   #zipkin:
     # Uncomment to send to zipkin, replacing 192.168.99.100 with your zipkin IP address
-    # baseUrl: http://192.168.99.100:9411/
+    # baseUrl: https://192.168.99.100:9411/
   sleuth:
     sampler:
       probability: 1.0


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://ajaxian.com/archives/100-line-ajax-wrapper (200) with 1 occurrences could not be migrated:  
   ([https](https://ajaxian.com/archives/100-line-ajax-wrapper) result ConnectTimeoutException).
* [ ] http://dubbo.io/ (200) with 1 occurrences could not be migrated:  
   ([https](https://dubbo.io/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://jaubourg.net/2010/07/loading-script-as-onclick-handler-of.html (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://jaubourg.net/2010/07/loading-script-as-onclick-handler-of.html ([https](https://jaubourg.net/2010/07/loading-script-as-onclick-handler-of.html) result AnnotatedConnectException).
* [ ] http://192.168.99.100:9411/ (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://192.168.99.100:9411/ ([https](https://192.168.99.100:9411/) result ConnectTimeoutException).
* [ ] http://host.com:9999/ticker/12/basd (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://host.com:9999/ticker/12/basd ([https](https://host.com:9999/ticker/12/basd) result ConnectTimeoutException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://non.existing.url (UnknownHostException) with 1 occurrences migrated to:  
  https://non.existing.url ([https](https://non.existing.url) result UnknownHostException).
* [ ] http://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html (404) with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html ([https](https://cloud.spring.io/spring-cloud-static/Dalston.SR4/multi/multi__span_data_as_messages.html) result 404).
* [ ] http://docssleuth-zipkin-server.cfapps.io/dependency (404) with 4 occurrences migrated to:  
  https://docssleuth-zipkin-server.cfapps.io/dependency ([https](https://docssleuth-zipkin-server.cfapps.io/dependency) result 404).
* [ ] http://www.erg.abdn.ac.uk/~gerrit/dccp/notes/ccid2/rto_estimator/ (301) with 1 occurrences migrated to:  
  https://erg.abdn.ac.uk/~gerrit/dccp/notes/ccid2/rto_estimator/ ([https](https://www.erg.abdn.ac.uk/~gerrit/dccp/notes/ccid2/rto_estimator/) result 404).
* [ ] http://zipkin.io/pages/existing_instrumentations.html (301) with 1 occurrences migrated to:  
  https://zipkin.io/pages/existing_instrumentations.html ([https](https://zipkin.io/pages/existing_instrumentations.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://bugs.jquery.com/ticket/1450 with 2 occurrences migrated to:  
  https://bugs.jquery.com/ticket/1450 ([https](https://bugs.jquery.com/ticket/1450) result 200).
* [ ] http://bugs.jquery.com/ticket/5280 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/5280 ([https](https://bugs.jquery.com/ticket/5280) result 200).
* [ ] http://cloud.spring.io with 2 occurrences migrated to:  
  https://cloud.spring.io ([https](https://cloud.spring.io) result 200).
* [ ] http://docs.spring.io/spring-hateoas/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-hateoas/docs/current/reference/html/ ([https](https://docs.spring.io/spring-hateoas/docs/current/reference/html/) result 200).
* [ ] http://docssleuth-service1.cfapps.io/start with 1 occurrences migrated to:  
  https://docssleuth-service1.cfapps.io/start ([https](https://docssleuth-service1.cfapps.io/start) result 200).
* [ ] http://en.wikipedia.org/wiki/Mapping_of_Unicode_characters with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Mapping_of_Unicode_characters ([https](https://en.wikipedia.org/wiki/Mapping_of_Unicode_characters) result 200).
* [ ] http://hacks.mozilla.org/2009/07/cross-site-xmlhttprequest-with-cors/ with 1 occurrences migrated to:  
  https://hacks.mozilla.org/2009/07/cross-site-xmlhttprequest-with-cors/ ([https](https://hacks.mozilla.org/2009/07/cross-site-xmlhttprequest-with-cors/) result 200).
* [ ] http://opentracing.io/ with 3 occurrences migrated to:  
  https://opentracing.io/ ([https](https://opentracing.io/) result 200).
* [ ] http://projects.spring.io/spring-integration/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-integration/ ([https](https://projects.spring.io/spring-integration/) result 200).
* [ ] http://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s ([https](https://stackoverflow.com/questions/12817946/generate-a-random-bitset-with-n-1s) result 200).
* [ ] http://stackoverflow.com/questions/1641507/detect-browser-support-for-cross-domain-xmlhttprequests with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/1641507/detect-browser-support-for-cross-domain-xmlhttprequests ([https](https://stackoverflow.com/questions/1641507/detect-browser-support-for-cross-domain-xmlhttprequests) result 200).
* [ ] http://stevesouders.com/misc/test-postmessage.php with 2 occurrences migrated to:  
  https://stevesouders.com/misc/test-postmessage.php ([https](https://stevesouders.com/misc/test-postmessage.php) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 2 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://wiki.whatwg.org/wiki/Dynamic_Script_Execution_Order with 1 occurrences migrated to:  
  https://wiki.whatwg.org/wiki/Dynamic_Script_Execution_Order ([https](https://wiki.whatwg.org/wiki/Dynamic_Script_Execution_Order) result 200).
* [ ] http://www.splunk.com/ with 2 occurrences migrated to:  
  https://www.splunk.com/ ([https](https://www.splunk.com/) result 200).
* [ ] http://www.w3.org/TR/DOM-Level-2-Events/events.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/DOM-Level-2-Events/events.html ([https](https://www.w3.org/TR/DOM-Level-2-Events/events.html) result 200).
* [ ] http://htrace.incubator.apache.org/ with 2 occurrences migrated to:  
  https://htrace.incubator.apache.org/ ([https](https://htrace.incubator.apache.org/) result 301).
* [ ] http://msdn.microsoft.com/en-us/library/cc197015 with 1 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/library/cc197015 ([https](https://msdn.microsoft.com/en-us/library/cc197015) result 301).
* [ ] http://msdn.microsoft.com/en-us/library/cc288060 with 1 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/library/cc288060 ([https](https://msdn.microsoft.com/en-us/library/cc288060) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://research.google.com/pubs/pub36356.html with 4 occurrences migrated to:  
  https://research.google.com/pubs/pub36356.html ([https](https://research.google.com/pubs/pub36356.html) result 301).
* [ ] http://docsbrewing-zipkin-server.cfapps.io/ with 1 occurrences migrated to:  
  https://docsbrewing-zipkin-server.cfapps.io/ ([https](https://docsbrewing-zipkin-server.cfapps.io/) result 302).
* [ ] http://docssleuth-zipkin-server.cfapps.io/ with 5 occurrences migrated to:  
  https://docssleuth-zipkin-server.cfapps.io/ ([https](https://docssleuth-zipkin-server.cfapps.io/) result 302).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://abc with 1 occurrences
* http://asdasd:111/asd with 1 occurrences
* http://exceptionservice/ with 2 occurrences
* http://foo with 2 occurrences
* http://foo/ with 1 occurrences
* http://fooservice/ with 1 occurrences
* http://fooservice/nonExistent with 1 occurrences
* http://fooservice/noresponse with 1 occurrences
* http://fooservice/notrace with 9 occurrences
* http://fooservice/ok with 1 occurrences
* http://fooservice/traceid with 1 occurrences
* http://localhost with 48 occurrences
* http://localhost/?foo=bar with 4 occurrences
* http://localhost:3379 with 1 occurrences
* http://localhost:3380 with 2 occurrences
* http://localhost:3380/async with 1 occurrences
* http://localhost:3380/call with 1 occurrences
* http://localhost:3381 with 1 occurrences
* http://localhost:80/abc with 1 occurrences
* http://localhost:8080/ with 1 occurrences
* http://localhost:9411 with 1 occurrences
* http://localhost:9411/ with 1 occurrences
* http://localhost:9978 with 1 occurrences
* http://localhost:9978/hello/mikesarver with 1 occurrences
* http://localhost:9987/unknown with 1 occurrences
* http://localhost:9988/sleuth/test-not-ok with 1 occurrences
* http://localhost:9998 with 1 occurrences
* http://localhost:9998/sleuth/test-not-ok with 1 occurrences
* http://localhost:9998/sleuth/test-ok with 1 occurrences
* http://some/address with 1 occurrences
* http://zipkin/ with 1 occurrences
* http://zipkin/call with 1 occurrences
* http://zipkin/hi2 with 1 occurrences
* http://zipkinserver/ with 2 occurrences