### PR TITLE
Added a workaround for the mutability of native headers

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
@@ -161,7 +161,8 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 			AtomicReference reference = req.currentContext()
 					.getOrDefault(AtomicReference.class, new AtomicReference());
 			Span span = handler().handleSend(injector(), req.requestHeaders(), req,
-					reference.get() == null ? handler().nextSpan(req) : (Span) reference.get());
+					reference.get() == null ? handler().nextSpan(req)
+							: (Span) reference.get());
 			reference.set(span);
 		}
 

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -3,6 +3,7 @@
 	"-//Puppy Crawl//DTD Suppressions 1.1//EN"
 	"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
+	<suppress files=".*/test/.*" checks="JavadocVariable"/>
 	<suppress files=".*FinishedSpanHandlerTests.*" checks="LineLengthCheck"/>
 	<suppress files=".*GrpcTracingIntegrationTests.*" checks="LineLengthCheck"/>
 	<suppress files=".*IgnoreAutoConfiguredSkipPatternsIntegrationTests.*" checks="LineLengthCheck"/>


### PR DESCRIPTION
Since for some reason, the native headers sometimes are immutable even though the accessor says that the headers are mutable, then we have to ensure their mutability. We do so by first making a mutable copy of the native headers, then by removing the native headers from the headers map and replacing them with a mutable copy

fixes #1184