### PR TITLE
Allow using Oauth2RestTemplate

### DIFF
--- a/docs/src/main/asciidoc/intro.adoc
+++ b/docs/src/main/asciidoc/intro.adoc
@@ -429,6 +429,13 @@ To do this you can use respectively `ZipkinAutoConfiguration.REPORTER_BEAN_NAME`
 include::../../../spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfigurationTests.java[tags=override_default_beans,indent=0]
 ----
 
+Default web `Sender` uses a `RestTemplate`. 
+If you want to use OAuth2 you need to provide a bean of type `OAuth2ProtectedResourceDetails` with name `ZipkinAutoConfiguration.OAUTH2_RESOURCE_BEAN_NAME` (usually a `ClientCredentialsResourceDetails`).
+
+----
+include::../../../spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinWithOAuth2RestTemplateTests.java[tags=use_oauth2_resttemplate,indent=0]
+----
+
 == Additional Resources
 
 You can watch a video of https://twitter.com/reshmi9k[Reshmi Krishna] and https://twitter.com/mgrzejszczak[Marcin Grzejszczak] talking about Spring Cloud

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -106,7 +106,7 @@ public class TraceWebAutoConfiguration {
 
 	@Configuration
 	@ConditionalOnClass({ ServerProperties.class, EndpointsSupplier.class,
-			ExposableWebEndpoint.class })
+			ExposableWebEndpoint.class, WebEndpointProperties.class })
 	@ConditionalOnBean(ServerProperties.class)
 	@ConditionalOnProperty(value = "spring.sleuth.web.ignoreAutoConfiguredSkipPatterns",
 			havingValue = "false", matchIfMissing = true)

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -116,6 +116,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security.oauth.boot</groupId>
+			<artifactId>spring-security-oauth2-autoconfigure</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-messaging</artifactId>
 			<scope>test</scope>

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
@@ -42,6 +42,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -81,6 +83,15 @@ public class ZipkinAutoConfiguration {
 	 * systems.
 	 */
 	public static final String SENDER_BEAN_NAME = "zipkinSender";
+
+	/**
+	 * Zipkin OAuth2ProtectedResourceDetails bean name.
+	 * Declare a bean of type {@link OAuth2ProtectedResourceDetails}
+	 * with this name to configure the default zipkin web sender to use OAuth2
+	 * to authenticate to Zipkin server. Usually a bean of type
+	 * {@link ClientCredentialsResourceDetails}.
+	 */
+	public static final String OAUTH2_RESOURCE_BEAN_NAME = "zipkinOauth2ResourceDetails";
 
 	@Bean(REPORTER_BEAN_NAME)
 	@ConditionalOnMissingBean(name = REPORTER_BEAN_NAME)

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/RestSenderCondition.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/RestSenderCondition.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.zipkin2.sender;
+
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+import org.springframework.cloud.sleuth.zipkin2.ZipkinAutoConfiguration;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.ConfigurationCondition.ConfigurationPhase;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+
+class RestSenderCondition {
+
+	static class OAuth2RestSenderCondition extends AllNestedConditions {
+
+		OAuth2RestSenderCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnClass({ OAuth2ProtectedResourceDetails.class,
+			OAuth2RestTemplate.class })
+		static class Oauth2ClassesAvailables {
+
+		}
+
+		@ConditionalOnBean(value = OAuth2ProtectedResourceDetails.class, name = ZipkinAutoConfiguration.OAUTH2_RESOURCE_BEAN_NAME)
+		static class OAuth2ResourceConfigured {
+
+		}
+
+	}
+
+	static class StandardRestSenderCondition extends NoneNestedConditions {
+
+		StandardRestSenderCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@Conditional(OAuth2RestSenderCondition.class)
+		static class OAuth2SenderActivated {
+
+		}
+
+	}
+
+}

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRestTemplateSenderConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRestTemplateSenderConfiguration.java
@@ -25,8 +25,6 @@ import zipkin2.reporter.Sender;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -65,7 +63,7 @@ class ZipkinRestTemplateSenderConfiguration {
 	}
 
 	@Configuration
-	@AutoConfigureAfter(OAuth2RestTemplateSenderConfiguration.class)
+	@Conditional(RestSenderCondition.StandardRestSenderCondition.class)
 	static class DefaultRestTemplateSenderConfiguration {
 		@Autowired
 		ZipkinUrlExtractor extractor;
@@ -82,9 +80,7 @@ class ZipkinRestTemplateSenderConfiguration {
 	}
 
 	@Configuration
-	@ConditionalOnClass({ OAuth2ProtectedResourceDetails.class,
-			OAuth2RestTemplate.class })
-	@ConditionalOnBean(value = OAuth2ProtectedResourceDetails.class, name = ZipkinAutoConfiguration.OAUTH2_RESOURCE_BEAN_NAME)
+	@Conditional(RestSenderCondition.OAuth2RestSenderCondition.class)
 	static class OAuth2RestTemplateSenderConfiguration {
 
 		@Autowired

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocatorConfigurationTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocatorConfigurationTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.cloud.commons.util.InetUtils;
@@ -178,13 +179,13 @@ public class DefaultEndpointLocatorConfigurationTest {
 	}
 
 	@Configuration
-	@EnableAutoConfiguration
+	@EnableAutoConfiguration(exclude = ReactiveSecurityAutoConfiguration.class)
 	public static class EmptyConfiguration {
 
 	}
 
 	@Configuration
-	@EnableAutoConfiguration
+	@EnableAutoConfiguration(exclude = ReactiveSecurityAutoConfiguration.class)
 	public static class ConfigurationWithRegistration {
 
 		@Bean
@@ -225,7 +226,7 @@ public class DefaultEndpointLocatorConfigurationTest {
 	}
 
 	@Configuration
-	@EnableAutoConfiguration
+	@EnableAutoConfiguration(exclude = ReactiveSecurityAutoConfiguration.class)
 	public static class ConfigurationWithCustomLocator {
 
 		static EndpointLocator locator = Mockito.mock(EndpointLocator.class);

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinDiscoveryClientTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinDiscoveryClientTests.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
@@ -72,7 +73,7 @@ public class ZipkinDiscoveryClientTests {
 	}
 
 	@Configuration
-	@EnableAutoConfiguration
+	@EnableAutoConfiguration(exclude = ReactiveSecurityAutoConfiguration.class)
 	static class Config {
 
 		@Bean

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinWithDisabledSleuthTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/ZipkinWithDisabledSleuthTests.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -34,7 +36,7 @@ public class ZipkinWithDisabledSleuthTests {
 
 	}
 
-	@EnableAutoConfiguration
+	@EnableAutoConfiguration(exclude = {IntegrationAutoConfiguration.class, ReactiveSecurityAutoConfiguration.class})
 	static class Config {
 
 	}

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinWithOAuth2RestTemplateTests.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinWithOAuth2RestTemplateTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.zipkin2.sender;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import zipkin2.reporter.Sender;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration;
+import org.springframework.cloud.sleuth.zipkin2.ZipkinAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+import org.springframework.security.oauth2.client.resource.OAuth2ProtectedResourceDetails;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsResourceDetails;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = ZipkinWithOAuth2RestTemplateTests.Config.class)
+@TestPropertySource(properties = "spring.zipkin.sender.type=web")
+public class ZipkinWithOAuth2RestTemplateTests {
+
+	@Autowired
+	private Sender sender;
+
+	@Test
+	public void shouldUseOAuth2RestTemplateWhenInjectingBean() {
+		assertThat(sender).isInstanceOf(RestTemplateSender.class);
+		RestTemplateSender restTemplateSender = (RestTemplateSender) sender;
+		assertThat(restTemplateSender.restTemplate)
+				.isInstanceOf(OAuth2RestTemplate.class);
+	}
+
+	@EnableAutoConfiguration(exclude = { IntegrationAutoConfiguration.class,
+			ReactiveSecurityAutoConfiguration.class })
+	@Import(MyConfig.class)
+	static class Config {
+
+	}
+
+	// tag::use_oauth2_resttemplate[]
+
+	@Configuration
+	protected static class MyConfig {
+
+		@Bean(name = ZipkinAutoConfiguration.OAUTH2_RESOURCE_BEAN_NAME)
+		OAuth2ProtectedResourceDetails resourceDetails() {
+			return new ClientCredentialsResourceDetails();
+		}
+
+	}
+
+	// end::override_default_beans[]
+
+}


### PR DESCRIPTION
As discussed in #1327 I want to use OAuth2 to contact a Zipkin server.
After first version in #1348 and the discussion that followed I propose a second version that avoids exposing the used RestTemplate as a Bean.

Behavior is:
- by default the same as before
- if you provide a bean `OAuth2ProtectedResourceDetails` with name `ZipkinAutoConfiguration.OAUTH2_RESOURCE_BEAN_NAME` then use a new `ZipkinOAuth2RestTemplateWrapper` - similar to `ZipkinRestTemplateWrapper`
  New class will use this resource details to handle OAuth2 mechanism.

```java
		@Bean(name = ZipkinAutoConfiguration.OAUTH2_RESOURCE_BEAN_NAME)
		OAuth2ProtectedResourceDetails resourceDetails() {
			return new ClientCredentialsResourceDetails();
		}
```

This example comes from the test and is included in documentation.

This PR also contains:
- small refactoring in `ZipkinRestTemplateSenderConfiguration` to add new code and avoid duplication (or the zipkin URI resolution)
- add a `Condition`on `ActuatorSkipPatternProviderConfig`; this class triggered when adding `spring-security-oauth2-autoconfigure` dependency to zipkin module and caused errors
- exclude `ReactiveSecurityAutoConfiguration` in several _sleuth-zipkin_ tests (class triggered by adding `spring-security-oauth2-autoconfigure` dependency)