### PR TITLE
Add null check for sampler probability property

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSampler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSampler.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import brave.sampler.Sampler;
 
+import org.springframework.util.Assert;
+
 /**
  * This sampler is appropriate for low-traffic instrumentation (ex servers that each
  * receive <100K requests), or those who do not provision random trace ids. It not
@@ -52,6 +54,8 @@ public class ProbabilityBasedSampler extends Sampler {
 	private final SamplerProperties configuration;
 
 	public ProbabilityBasedSampler(SamplerProperties configuration) {
+		Assert.notNull(configuration.getProbability(),
+				"probability property is required for ProbabilityBasedSampler");
 		int outOf100 = (int) (configuration.getProbability() * 100.0f);
 		this.sampleDecisions = randomBitSet(100, outOf100, new Random());
 		this.configuration = configuration;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSamplerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSamplerTests.java
@@ -21,6 +21,7 @@ import java.util.Random;
 import brave.sampler.Sampler;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 
 /**
@@ -76,6 +77,13 @@ public class ProbabilityBasedSamplerTests {
 
 		int threshold = (int) (numberOfIterations * probability);
 		then(numberOfSampledElements).isEqualTo(threshold);
+	}
+
+	@Test
+	public void should_fail_given_no_probability() {
+		assertThatThrownBy(() -> new ProbabilityBasedSampler(this.samplerConfiguration))
+				.isInstanceOf(IllegalArgumentException.class).hasMessage(
+						"probability property is required for ProbabilityBasedSampler");
 	}
 
 	private int countNumberOfSampledElements(int numberOfIterations) {


### PR DESCRIPTION
When `spring.sleuth.sampler.probability` property is missing, instantiating `ProbabilityBasedSampler` throws an NPE during an attempt to autobox a null probability.

This PR adds an assertion with a user-readable error message.
