### PR TITLE
Automatically removes mdc

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/SpringAwareManagedChannelBuilder.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/SpringAwareManagedChannelBuilder.java
@@ -45,32 +45,29 @@ public class SpringAwareManagedChannelBuilder {
 	}
 
 	public ManagedChannelBuilder<?> forAddress(String name, int port) {
-
 		ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(name, port);
-
-		if (this.customizers != null) {
-			this.customizers.stream()
-					.forEach(customizer -> customizer.customize(builder));
-		}
+		customize(builder);
 		return builder;
 	}
 
 	public ManagedChannelBuilder<?> forTarget(String target) {
 		ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forTarget(target);
-		if (this.customizers != null) {
-			this.customizers.stream()
-					.forEach(customizer -> customizer.customize(builder));
-		}
+		customize(builder);
 		return builder;
 	}
 
 	public ManagedChannelBuilder<?> inProcessChannelBuilder(String serverName) {
 		ManagedChannelBuilder<?> builder = InProcessChannelBuilder.forName(serverName);
-		if (this.customizers != null) {
-			this.customizers.stream()
-					.forEach(customizer -> customizer.customize(builder));
-		}
+		customize(builder);
 		return builder;
+	}
+
+	private void customize(ManagedChannelBuilder<?> builder) {
+		if (this.customizers != null) {
+			for (GrpcManagedChannelBuilderCustomizer customizer : this.customizers) {
+				customizer.customize(builder);
+			}
+		}
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpClientParser.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpClientParser.java
@@ -59,12 +59,12 @@ class SleuthHttpClientParser extends HttpClientParser {
 		URI uri = URI.create(url);
 		addRequestTags(customizer, url, uri.getHost(), uri.getPath(),
 				adapter.method(req));
-		this.traceKeys.getHttp().getHeaders().forEach(((s) -> {
-			String headerValue = adapter.requestHeader(req, s);
+		for (String header : this.traceKeys.getHttp().getHeaders()) {
+			String headerValue = adapter.requestHeader(req, header);
 			if (headerValue != null) {
-				customizer.tag(key(s), headerValue);
+				customizer.tag(key(header), headerValue);
 			}
-		}));
+		}
 	}
 
 	private String key(String key) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
@@ -153,10 +153,11 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 
 		@Override
 		public void accept(HttpClientRequest req, Connection connection) {
-			if (propagation().keys().stream()
-					.anyMatch(key -> req.requestHeaders().contains(key))) {
-				// request already instrumented
-				return;
+			// request already instrumented
+			for (String key : propagation().keys()) {
+				if (req.requestHeaders().contains(key)) {
+					return;
+				}
 			}
 			AtomicReference reference = req.currentContext()
 					.getOrDefault(AtomicReference.class, new AtomicReference());

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRequestHttpHeadersFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRequestHttpHeadersFilter.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
+import java.util.List;
+import java.util.Map;
+
 import brave.Span;
 import brave.Tracer;
 import brave.http.HttpClientHandler;
@@ -58,8 +61,18 @@ final class TraceRequestHttpHeadersFilter extends AbstractHttpHeadersFilter {
 		exchange.getAttributes().put(SPAN_ATTRIBUTE, span);
 		HttpHeaders headersWithInput = new HttpHeaders();
 		headersWithInput.addAll(input);
-		builder.build().getHeaders().forEach(headersWithInput::put);
+		addHeadersWithInput(builder, headersWithInput);
 		return headersWithInput;
+	}
+
+	private void addHeadersWithInput(ServerHttpRequest.Builder builder,
+			HttpHeaders headersWithInput) {
+		for (Map.Entry<String, List<String>> entry : builder.build().getHeaders()
+				.entrySet()) {
+			String key = entry.getKey();
+			List<String> value = entry.getValue();
+			headersWithInput.put(key, value);
+		}
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java
@@ -100,11 +100,21 @@ final class TraceWebClientBeanPostProcessor implements BeanPostProcessor {
 
 	private Consumer<List<ExchangeFilterFunction>> addTraceExchangeFilterFunctionIfNotPresent() {
 		return functions -> {
-			if (functions.stream()
-					.noneMatch(f -> f instanceof TraceExchangeFilterFunction)) {
+			boolean noneMatch = noneMatchTraceExchangeFunction(functions);
+			if (noneMatch) {
 				functions.add(new TraceExchangeFilterFunction(this.beanFactory));
 			}
 		};
+	}
+
+	private boolean noneMatchTraceExchangeFunction(
+			List<ExchangeFilterFunction> functions) {
+		for (ExchangeFilterFunction function : functions) {
+			if (function instanceof TraceExchangeFilterFunction) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jScopeDecorator.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/Slf4jScopeDecorator.java
@@ -86,7 +86,8 @@ final class Slf4jScopeDecorator implements CurrentTraceContext.ScopeDecorator {
 		final String legacyPreviousParentId = MDC.get(LEGACY_PARENT_ID_NAME);
 		final String legacyPreviousSpanId = MDC.get(LEGACY_SPAN_ID_NAME);
 		final String legacySpanExportable = MDC.get(LEGACY_EXPORTABLE_NAME);
-		final List<AbstractMap.SimpleEntry<String, String>> previousMdc = Stream
+		final List<AbstractMap.SimpleEntry<String, String>> previousMdc =
+				Stream
 				.concat(whitelistedBaggageKeysWithValue(currentSpan),
 						whitelistedPropagationKeysWithValue(currentSpan))
 				.map((s) -> new AbstractMap.SimpleEntry<>(s, MDC.get(s)))
@@ -149,7 +150,9 @@ final class Slf4jScopeDecorator implements CurrentTraceContext.ScopeDecorator {
 				replace(LEGACY_PARENT_ID_NAME, legacyPreviousParentId);
 				replace(LEGACY_SPAN_ID_NAME, legacyPreviousSpanId);
 				replace(LEGACY_EXPORTABLE_NAME, legacySpanExportable);
-				previousMdc.forEach((e) -> replace(e.getKey(), e.getValue()));
+				for (AbstractMap.SimpleEntry<String, String> entry : previousMdc) {
+					replace(entry.getKey(), entry.getValue());
+				}
 			}
 
 		}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
@@ -130,4 +130,21 @@ public class Slf4JSpanLoggerTest {
 		assertThat(MDC.get("traceId")).isEqualTo("A");
 	}
 
+	@Test
+	public void should_clear_any_mdc_entries_when_their_keys_are_whitelisted() throws Exception {
+		MDC.put("my-baggage", "A");
+		MDC.put("my-propagation", "B");
+
+		Scope scope = this.slf4jScopeDecorator.decorateScope(this.span.context(), () -> {
+		});
+
+		assertThat(MDC.get("my-baggage")).isEqualTo("A");
+		assertThat(MDC.get("my-propagation")).isEqualTo("B");
+
+		scope.close();
+
+		assertThat(MDC.get("my-baggage")).isNullOrEmpty();
+		assertThat(MDC.get("my-propagation")).isNullOrEmpty();
+	}
+
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/log/Slf4JSpanLoggerTest.java
@@ -131,12 +131,14 @@ public class Slf4JSpanLoggerTest {
 	}
 
 	@Test
-	public void should_clear_any_mdc_entries_when_their_keys_are_whitelisted() throws Exception {
-		MDC.put("my-baggage", "A");
-		MDC.put("my-propagation", "B");
+	public void should_clear_any_mdc_entries_when_their_keys_are_whitelisted()
+			throws Exception {
 
 		Scope scope = this.slf4jScopeDecorator.decorateScope(this.span.context(), () -> {
 		});
+
+		MDC.put("my-baggage", "A");
+		MDC.put("my-propagation", "B");
 
 		assertThat(MDC.get("my-baggage")).isEqualTo("A");
 		assertThat(MDC.get("my-propagation")).isEqualTo("B");

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfigurationTests.java
@@ -32,10 +32,11 @@ public class SleuthTagPropagationAutoConfigurationTests {
 
 	@Test
 	public void shouldCreateHandlerByDefault() {
-		this.contextRunner
-				.withUserConfiguration(TraceAutoConfiguration.class).run((context) -> {
-			assertThat(context).hasSingleBean(TagPropagationFinishedSpanHandler.class);
-		});
+		this.contextRunner.withUserConfiguration(TraceAutoConfiguration.class)
+				.run((context) -> {
+					assertThat(context)
+							.hasSingleBean(TagPropagationFinishedSpanHandler.class);
+				});
 	}
 
 	@Test
@@ -63,12 +64,11 @@ public class SleuthTagPropagationAutoConfigurationTests {
 
 	@Test
 	public void shouldCreateHandlerWithYml() {
-		this.contextRunner
-				.withPropertyValues(
-						"spring.profiles.active=tag-propagation")
+		this.contextRunner.withPropertyValues("spring.profiles.active=tag-propagation")
 				.withUserConfiguration(TraceAutoConfiguration.class).run((context) -> {
 					assertThat(context)
 							.hasSingleBean(TagPropagationFinishedSpanHandler.class);
 				});
 	}
+
 }


### PR DESCRIPTION
cleares any MDC entries that match a whitelist entry for baggage or propagation key even if the `ExtraPropagation` API wasn't called.