### PR TITLE
Add passthrough mode to HystrixConcurrencyStrategy

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -1028,6 +1028,7 @@ That way, you ensure that a new span is created and closed for each execution.
 
 We register a custom https://github.com/Netflix/Hystrix/wiki/Plugins#concurrencystrategy[`HystrixConcurrencyStrategy`] called `TraceCallable` that wraps all `Callable` instances in their Sleuth representative.
 The strategy either starts or continues a span, depending on whether tracing was already going on before the Hystrix command was called.
+Optionally, you can set `spring.sleuth.hystrix.strategy.passthrough` to `true` to just propagate the trace context to the Hystrix execution thread if you don't wish to start a new span.
 To disable the custom Hystrix Concurrency Strategy, set the `spring.sleuth.hystrix.strategy.enabled` to `false`.
 
 ==== Manual Command setting

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
@@ -18,11 +18,11 @@ package org.springframework.cloud.sleuth.instrument.hystrix;
 
 import brave.Tracing;
 import com.netflix.hystrix.HystrixCommand;
-
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.SpanNamer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -34,21 +34,22 @@ import org.springframework.context.annotation.Configuration;
  * {@link com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy}.
  *
  * @author Marcin Grzejszczak
- * @since 1.0.0
  * @see SleuthHystrixConcurrencyStrategy
+ * @since 1.0.0
  */
 @Configuration
 @AutoConfigureAfter(TraceAutoConfiguration.class)
 @ConditionalOnClass(HystrixCommand.class)
 @ConditionalOnBean(Tracing.class)
-@ConditionalOnProperty(value = "spring.sleuth.hystrix.strategy.enabled",
-		matchIfMissing = true)
+@ConditionalOnProperty(value = "spring.sleuth.hystrix.strategy.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(SleuthHystrixConcurrencyStrategyProperties.class)
 public class SleuthHystrixAutoConfiguration {
 
 	@Bean
 	SleuthHystrixConcurrencyStrategy sleuthHystrixConcurrencyStrategy(Tracing tracing,
-			SpanNamer spanNamer) {
-		return new SleuthHystrixConcurrencyStrategy(tracing, spanNamer);
+																	  SpanNamer spanNamer,
+																	  SleuthHystrixConcurrencyStrategyProperties properties) {
+		return new SleuthHystrixConcurrencyStrategy(tracing, spanNamer, properties.isPassthrough());
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.instrument.hystrix;
 
 import brave.Tracing;
 import com.netflix.hystrix.HystrixCommand;
+
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
@@ -42,15 +42,16 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureAfter(TraceAutoConfiguration.class)
 @ConditionalOnClass(HystrixCommand.class)
 @ConditionalOnBean(Tracing.class)
-@ConditionalOnProperty(value = "spring.sleuth.hystrix.strategy.enabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "spring.sleuth.hystrix.strategy.enabled",
+		matchIfMissing = true)
 @EnableConfigurationProperties(SleuthHystrixConcurrencyStrategyProperties.class)
 public class SleuthHystrixAutoConfiguration {
 
 	@Bean
 	SleuthHystrixConcurrencyStrategy sleuthHystrixConcurrencyStrategy(Tracing tracing,
-																	  SpanNamer spanNamer,
-																	  SleuthHystrixConcurrencyStrategyProperties properties) {
-		return new SleuthHystrixConcurrencyStrategy(tracing, spanNamer, properties.isPassthrough());
+			SpanNamer spanNamer, SleuthHystrixConcurrencyStrategyProperties properties) {
+		return new SleuthHystrixConcurrencyStrategy(tracing, spanNamer,
+				properties.isPassthrough());
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategy.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategy.java
@@ -55,15 +55,19 @@ public class SleuthHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy
 			.getLog(SleuthHystrixConcurrencyStrategy.class);
 
 	private final Tracing tracing;
+
 	private final SpanNamer spanNamer;
+
 	private HystrixConcurrencyStrategy delegate;
+
 	private boolean passthrough;
 
 	public SleuthHystrixConcurrencyStrategy(Tracing tracing, SpanNamer spanNamer) {
-		 this(tracing, spanNamer, false);
+		this(tracing, spanNamer, false);
 	}
 
-	public SleuthHystrixConcurrencyStrategy(Tracing tracing, SpanNamer spanNamer, boolean passthrough) {
+	public SleuthHystrixConcurrencyStrategy(Tracing tracing, SpanNamer spanNamer,
+			boolean passthrough) {
 		this.tracing = tracing;
 		this.spanNamer = spanNamer;
 		this.passthrough = passthrough;
@@ -114,14 +118,17 @@ public class SleuthHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy
 			return callable;
 		}
 
-		Callable<T> wrappedCallable = this.delegate != null ? this.delegate.wrapCallable(callable) : callable;
+		Callable<T> wrappedCallable = this.delegate != null
+				? this.delegate.wrapCallable(callable) : callable;
+
 		if (wrappedCallable instanceof TraceCallable) {
 			return wrappedCallable;
 		}
 
 		if (passthrough) {
 			return this.tracing.currentTraceContext().wrap(callable);
-		} else {
+		}
+		else {
 			return new TraceCallable<>(this.tracing, this.spanNamer, wrappedCallable,
 					HYSTRIX_COMPONENT);
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
@@ -26,8 +26,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("spring.sleuth.hystrix.strategy")
 public class SleuthHystrixConcurrencyStrategyProperties {
 
+	/**
+	 * Enable custom HystrixConcurrencyStrategy that wraps all Callable instances into
+	 * their Sleuth representative - the TraceCallable.
+	 */
 	private boolean enabled = true;
 
+	/**
+	 * When enabled the tracing information is passed to the Hystrix execution threads but
+	 * spans are not created for each execution.
+	 */
 	private boolean passthrough = false;
 
 	public boolean isEnabled() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.hystrix;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Sleuth Hystrix settings.
+ *
+ * @author Daniel Albuquerque
+ */
+@ConfigurationProperties("spring.sleuth.hystrix.strategy")
+public class SleuthHystrixConcurrencyStrategyProperties {
+
+	private boolean enabled = true;
+	private boolean passthrough = true;
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public boolean isPassthrough() {
+		return passthrough;
+	}
+
+	public void setPassthrough(boolean passthrough) {
+		this.passthrough = passthrough;
+	}
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SleuthHystrixConcurrencyStrategyProperties {
 
 	private boolean enabled = true;
+
 	private boolean passthrough = false;
 
 	public boolean isEnabled() {
@@ -44,4 +45,5 @@ public class SleuthHystrixConcurrencyStrategyProperties {
 	public void setPassthrough(boolean passthrough) {
 		this.passthrough = passthrough;
 	}
+
 }

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
@@ -27,7 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SleuthHystrixConcurrencyStrategyProperties {
 
 	private boolean enabled = true;
-	private boolean passthrough = true;
+	private boolean passthrough = false;
 
 	public boolean isEnabled() {
 		return this.enabled;

--- a/spring-cloud-sleuth-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-sleuth-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -25,18 +25,6 @@
       "defaultValue": true
     },
     {
-      "name": "spring.sleuth.hystrix.strategy.enabled",
-      "type": "java.lang.Boolean",
-      "description": "Enable custom HystrixConcurrencyStrategy that wraps all Callable instances into their Sleuth representative - the TraceCallable.",
-      "defaultValue": true
-    },
-    {
-      "name": "spring.sleuth.hystrix.strategy.passthrough",
-      "type": "java.lang.Boolean",
-      "description": "When enabled the tracing information is passed to the Hystrix execution threads but spans are not created for each execution.",
-      "defaultValue": false
-    },
-    {
       "name": "spring.sleuth.feign.enabled",
       "type": "java.lang.Boolean",
       "description": "Enable span information propagation when using Feign.",

--- a/spring-cloud-sleuth-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-sleuth-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -31,6 +31,12 @@
       "defaultValue": true
     },
     {
+      "name": "spring.sleuth.hystrix.strategy.passthrough",
+      "type": "java.lang.Boolean",
+      "description": "When enabled the tracing information is passed to the Hystrix execution threads but spans are not created for each execution.",
+      "defaultValue": false
+    },
+    {
       "name": "spring.sleuth.feign.enabled",
       "type": "java.lang.Boolean",
       "description": "Enable span information propagation when using Feign.",

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
@@ -126,14 +126,18 @@ public class SleuthHystrixConcurrencyStrategyTest {
 	}
 
 	@Test
-	public void should_propagate_trace_context_when_passthrough_is_enabled() throws Exception {
+	public void should_propagate_trace_context_when_passthrough_is_enabled()
+			throws Exception {
 		SleuthHystrixConcurrencyStrategy strategy = new SleuthHystrixConcurrencyStrategy(
 				this.tracing, new DefaultSpanNamer(), true);
 
-		TraceContext traceContext = TraceContext.newBuilder().traceId(123L).spanId(456L).build();
-		CurrentTraceContext.Scope scope = tracing.currentTraceContext().newScope(traceContext);
+		TraceContext traceContext = TraceContext.newBuilder().traceId(123L).spanId(456L)
+				.build();
+		CurrentTraceContext.Scope scope = tracing.currentTraceContext()
+				.newScope(traceContext);
 
-		Callable<TraceContext> callable = strategy.wrapCallable(() -> tracing.currentTraceContext().get());
+		Callable<TraceContext> callable = strategy
+				.wrapCallable(() -> tracing.currentTraceContext().get());
 
 		then(callable).isNotInstanceOf(TraceCallable.class);
 		then(callable.call()).isEqualTo(traceContext);

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
 import brave.propagation.StrictScopeDecorator;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.propagation.TraceContext;
@@ -130,12 +131,13 @@ public class SleuthHystrixConcurrencyStrategyTest {
 				this.tracing, new DefaultSpanNamer(), true);
 
 		TraceContext traceContext = TraceContext.newBuilder().traceId(123L).spanId(456L).build();
-		tracing.currentTraceContext().newScope(traceContext);
+		CurrentTraceContext.Scope scope = tracing.currentTraceContext().newScope(traceContext);
 
 		Callable<TraceContext> callable = strategy.wrapCallable(() -> tracing.currentTraceContext().get());
 
 		then(callable).isNotInstanceOf(TraceCallable.class);
 		then(callable.call()).isEqualTo(traceContext);
+		scope.close();
 	}
 
 	@Test


### PR DESCRIPTION
Draft proposal for #1431.

Passthrough is disabled by default which means that the current behaviour will not change with this change.
When `spring.sleuth.hystrix.strategy.passthrough` is enabled, the HystrixConcurrencyStrategy will just pass the trace context to the Hystrix execution thread instead of using TraceCallables.
This way we propagate tracing information but don't create . spans for each execution.