### PR TITLE
Fix TraceableExecutorService

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
@@ -63,7 +63,7 @@ public class TraceableExecutorService implements ExecutorService {
 
 	@Override
 	public void execute(Runnable command) {
-		this.delegate.submit(ContextUtil.isContextInCreation(this.beanFactory) ? command
+		this.delegate.execute(ContextUtil.isContextInCreation(this.beanFactory) ? command
 				: new TraceRunnable(tracing(), spanNamer(), command, this.spanName));
 	}
 


### PR DESCRIPTION
TraceableExecutorService swallows Exception because `execute` submits a Runnable and ignores the Future's result. It should call the delegates `execute` method instead of the `submit`.