### PR TITLE
Added parametrization of RabbitMQ brokers

### DIFF
--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRabbitSenderConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRabbitSenderConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.cloud.sleuth.zipkin2.ZipkinAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
 @Configuration
 @ConditionalOnBean(CachingConnectionFactory.class)
@@ -40,12 +41,17 @@ class ZipkinRabbitSenderConfiguration {
 	@Value("${spring.zipkin.rabbitmq.queue:zipkin}")
 	private String queue;
 
+	@Value("${spring.zipkin.rabbitmq.addresses:}")
+	private String addresses;
+
 	@Bean(ZipkinAutoConfiguration.SENDER_BEAN_NAME)
 	Sender rabbitSender(CachingConnectionFactory connectionFactory,
 			RabbitProperties config) {
+		String addresses = StringUtils.hasText(this.addresses) ? this.addresses
+				: config.determineAddresses();
 		return RabbitMQSender.newBuilder()
 				.connectionFactory(connectionFactory.getRabbitConnectionFactory())
-				.queue(this.queue).addresses(config.determineAddresses()).build();
+				.queue(this.queue).addresses(addresses).build();
 	}
 
 }

--- a/spring-cloud-sleuth-zipkin/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-sleuth-zipkin/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -13,6 +13,11 @@
       "defaultValue": "zipkin"
     },
     {
+      "name": "spring.zipkin.rabbitmq.addresses",
+      "type": "java.lang.String",
+      "description": "Addresses of the RabbitMQ brokers used to send spans to Zipkin"
+    },
+    {
       "name": "spring.zipkin.activemq.queue",
       "type": "java.lang.String",
       "description": "Name of the ActiveMQ queue where spans should be sent to Zipkin.",


### PR DESCRIPTION
without this change we're reusing the same broker for application logic and sending spans to zipkin
with this change we're adding a property to allow providing a different set of addresses for brokers to send spans to Zipkin

fixes gh-1210