### PR TITLE
Prevent ignoring of ExtraFieldCustomizer

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -146,7 +146,8 @@ public class TraceAutoConfiguration {
 	@ConditionalOnMissingBean
 	Propagation.Factory sleuthPropagation(SleuthProperties sleuthProperties) {
 		if (sleuthProperties.getBaggageKeys().isEmpty()
-				&& sleuthProperties.getPropagationKeys().isEmpty()) {
+				&& sleuthProperties.getPropagationKeys().isEmpty()
+				&& extraFieldCustomizers.isEmpty()) {
 			return B3Propagation.FACTORY;
 		}
 		ExtraFieldPropagation.FactoryBuilder factoryBuilder;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationCustomizersTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationCustomizersTests.java
@@ -36,18 +36,26 @@ import static org.assertj.core.api.BDDAssertions.then;
 public class TraceAutoConfigurationCustomizersTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withPropertyValues("spring.sleuth.baggage-keys=my-baggage")
 			.withConfiguration(AutoConfigurations.of(TraceAutoConfiguration.class,
 					TraceWebAutoConfiguration.class, TraceHttpAutoConfiguration.class))
 			.withUserConfiguration(Customizers.class);
 
 	@Test
 	public void should_apply_customizers() {
-		this.contextRunner.run((context) -> {
+		this.contextRunner.withPropertyValues("spring.sleuth.baggage-keys=my-baggage").run((context) -> {
 			Customizers bean = context.getBean(Customizers.class);
 
 			shouldApplyCustomizations(bean);
 			shouldNotOverrideTheDefaults(context);
+		});
+	}
+
+	@Test
+	public void should_apply_extra_field_customizer_when_no_extra_properties_are_defined() {
+		this.contextRunner.run((context) -> {
+			Customizers bean = context.getBean(Customizers.class);
+
+			shouldApplyCustomizations(bean);
 		});
 	}
 


### PR DESCRIPTION
Changes verification in TraceAutoConfiguration.sleuthPropagation()
to not skip customization if at least one ExtraFieldCustomizer is
defined.

Without this fix the customizers are only applied when either
baggage-keys or propagation-keys property is defined.

Fixes gh-1454