### PR TITLE
Adds the possibility to opt-out of executor decoration

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.instrument.async;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.sleuth.instrument.scheduling.SleuthSchedulingProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,8 +30,8 @@ import org.springframework.context.annotation.Configuration;
  * @since 2.1.0
  */
 @Configuration
-@EnableConfigurationProperties(SleuthAsyncProperties.class)
-@ConditionalOnProperty(value = "spring.sleuth.async.enabled", matchIfMissing = true)
+@ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
+@EnableConfigurationProperties({SleuthAsyncProperties.class, SleuthSchedulingProperties.class})
 public class AsyncAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.sleuth.instrument.async;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableConfigurationProperties(SleuthAsyncProperties.class)
+@ConditionalOnProperty(value = "spring.sleuth.async.enabled", matchIfMissing = true)
 public class AsyncAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -31,7 +31,8 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
-@EnableConfigurationProperties({SleuthAsyncProperties.class, SleuthSchedulingProperties.class})
+@EnableConfigurationProperties({ SleuthAsyncProperties.class,
+		SleuthSchedulingProperties.class })
 public class AsyncAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
@@ -32,7 +32,9 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.SpanNamer;
+import org.springframework.cloud.sleuth.instrument.scheduling.SleuthSchedulingProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
@@ -52,11 +54,15 @@ import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
  * @see TraceAsyncAspect
  */
 @Configuration
+@EnableConfigurationProperties({ SleuthAsyncProperties.class,
+		SleuthSchedulingProperties.class })
 @ConditionalOnProperty(value = "spring.sleuth.async.enabled", matchIfMissing = true)
 @ConditionalOnBean(Tracing.class)
 public class AsyncDefaultAutoConfiguration {
 
 	@Bean
+	@ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled",
+			matchIfMissing = true)
 	public static ExecutorBeanPostProcessor executorBeanPostProcessor(
 			BeanFactory beanFactory) {
 		return new ExecutorBeanPostProcessor(beanFactory);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskScheduler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskScheduler.java
@@ -184,7 +184,7 @@ class LazyTraceThreadPoolTaskScheduler extends ThreadPoolTaskScheduler {
 
 	@Override
 	public void execute(Runnable task) {
-		this.delegate.execute(task);
+		this.delegate.execute(new TraceRunnable(tracing(), spanNamer(), task));
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
@@ -32,23 +32,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SleuthAsyncProperties {
 
 	/**
-	 * Enable tracing for {@link org.springframework.scheduling.annotation.Scheduled}.
-	 */
-	private boolean enabled = true;
-
-	/**
 	 * List of {@link java.util.concurrent.Executor} bean names that should be ignored and
 	 * not wrapped in a trace representation.
 	 */
 	private List<String> ignoredBeans = Collections.emptyList();
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
-	}
 
 	public List<String> getIgnoredBeans() {
 		return this.ignoredBeans;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
@@ -32,10 +32,23 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SleuthAsyncProperties {
 
 	/**
+	 * Enable tracing for {@link org.springframework.scheduling.annotation.Scheduled}.
+	 */
+	private boolean enabled = true;
+
+	/**
 	 * List of {@link java.util.concurrent.Executor} bean names that should be ignored and
 	 * not wrapped in a trace representation.
 	 */
 	private List<String> ignoredBeans = Collections.emptyList();
+
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
 
 	public List<String> getIgnoredBeans() {
 		return this.ignoredBeans;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDisabledTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDisabledTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.async;
+
+import java.util.concurrent.Executor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+		classes = { AsyncAutoConfiguration.class,
+				AsyncDisabledTests.ConfigureThreadPoolTaskScheduler.class },
+		webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = "spring.sleuth.async.enabled=false")
+public class AsyncDisabledTests {
+
+	@Autowired
+	@Qualifier("traceSenderThreadPool")
+	Executor executor;
+
+	@Test
+	public void should_not_wrap_scheduler() {
+		then(this.executor).isInstanceOf(ThreadPoolTaskScheduler.class);
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@EnableAsync
+	static class ConfigureThreadPoolTaskScheduler {
+
+		@Bean
+		@ConditionalOnMissingBean(name = "traceSenderThreadPool")
+		public ThreadPoolTaskScheduler traceSenderThreadPool() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDisabledTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/AsyncDisabledTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 		classes = { AsyncAutoConfiguration.class,
 				AsyncDisabledTests.ConfigureThreadPoolTaskScheduler.class },
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = "spring.sleuth.async.enabled=false")
+		properties = "spring.sleuth.scheduled.enabled=false")
 public class AsyncDisabledTests {
 
 	@Autowired
@@ -48,7 +48,7 @@ public class AsyncDisabledTests {
 
 	@Test
 	public void should_not_wrap_scheduler() {
-		then(this.executor).isInstanceOf(ThreadPoolTaskScheduler.class);
+		then(this.executor).isNotInstanceOf(LazyTraceThreadPoolTaskScheduler.class);
 	}
 
 	@Configuration

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskSchedulerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskSchedulerTests.java
@@ -128,7 +128,8 @@ public class LazyTraceThreadPoolTaskSchedulerTests {
 		};
 		this.executor.execute(r);
 
-		BDDMockito.then(this.delegate).should().execute(r);
+		BDDMockito.then(this.delegate).should()
+				.execute(BDDMockito.any(TraceRunnable.class));
 	}
 
 	@Test


### PR DESCRIPTION
Recently, `AsyncAutoConfiguration` auto-instruments executors. This
causes spans named 'async' with no tag or other metadata to help
understand what is happening. It was somewhat difficult troubleshooting
this because the control is by bean name, but for example the "async"
span doesn't include the bean name.

For starters, this allows people to opt-out of automatically spanning
executors via `spring.sleuth.async.enabled=false`

See https://github.com/spring-cloud/spring-cloud-gcp/issues/1978
cc @meltsufin @saturnism