### PR TITLE
Use Micrometer metrics instead of in memory one

### DIFF
--- a/spring-cloud-sleuth-core/pom.xml
+++ b/spring-cloud-sleuth-core/pom.xml
@@ -24,6 +24,9 @@
 	<packaging>jar</packaging>
 	<name>Spring Cloud Sleuth Core</name>
 	<description>Spring Cloud Sleuth Core</description>
+	<properties>
+		<spring-security-oauth2.version>2.2.0.RELEASE</spring-security-oauth2.version>
+	</properties>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -131,7 +134,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
-			<version>2.2.0.RELEASE</version>
+			<version>${spring-security-oauth2.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -286,20 +289,28 @@
 			<artifactId>brave-instrumentation-grpc</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>io.zipkin.reporter2</groupId>
+			<artifactId>zipkin-reporter-metrics-micrometer</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>io.micrometer</groupId>
+					<artifactId>micrometer-core</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 		<!-- Instrumentation of Lettuce -->
 		<dependency>
 			<groupId>io.lettuce</groupId>
 			<artifactId>lettuce-core</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<!-- For Instrumentation of Quartz -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-quartz</artifactId>
 			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.sleuth.autoconfig;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import brave.CurrentSpanCustomizer;
 import brave.ErrorParser;
@@ -34,6 +37,8 @@ import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import zipkin2.Span;
@@ -42,6 +47,7 @@ import zipkin2.reporter.Reporter;
 import zipkin2.reporter.ReporterMetrics;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -103,18 +109,14 @@ public class TraceAutoConfiguration {
 	@ConditionalOnMissingBean
 	// NOTE: stable bean name as might be used outside sleuth
 	Tracing tracing(@LocalServiceName String serviceName, Propagation.Factory factory,
-			CurrentTraceContext currentTraceContext, Sampler sampler,
-			ErrorParser errorParser, SleuthProperties sleuthProperties,
-			@Nullable List<Reporter<zipkin2.Span>> spanReporters) {
-		Tracing.Builder builder = Tracing.newBuilder().sampler(sampler)
-				.errorParser(errorParser)
-				.localServiceName(StringUtils.isEmpty(serviceName) ? DEFAULT_SERVICE_NAME
-						: serviceName)
+			CurrentTraceContext currentTraceContext, Sampler sampler, ErrorParser errorParser,
+			SleuthProperties sleuthProperties, @Nullable List<Reporter<zipkin2.Span>> spanReporters) {
+		Tracing.Builder builder = Tracing.newBuilder().sampler(sampler).errorParser(errorParser)
+				.localServiceName(StringUtils.isEmpty(serviceName) ? DEFAULT_SERVICE_NAME : serviceName)
 				.propagationFactory(factory).currentTraceContext(currentTraceContext)
 				.spanReporter(new CompositeReporter(this.spanAdjusters,
 						spanReporters != null ? spanReporters : Collections.emptyList()))
-				.traceId128Bit(sleuthProperties.isTraceId128())
-				.supportsJoin(sleuthProperties.isSupportsJoin());
+				.traceId128Bit(sleuthProperties.isTraceId128()).supportsJoin(sleuthProperties.isSupportsJoin());
 		for (FinishedSpanHandler finishedSpanHandlerFactory : this.finishedSpanHandlers) {
 			builder.addFinishedSpanHandler(finishedSpanHandlerFactory);
 		}
@@ -145,8 +147,7 @@ public class TraceAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	Propagation.Factory sleuthPropagation(SleuthProperties sleuthProperties) {
-		if (sleuthProperties.getBaggageKeys().isEmpty()
-				&& sleuthProperties.getPropagationKeys().isEmpty()
+		if (sleuthProperties.getBaggageKeys().isEmpty() && sleuthProperties.getPropagationKeys().isEmpty()
 				&& extraFieldCustomizers.isEmpty()) {
 			return B3Propagation.FACTORY;
 		}
@@ -155,8 +156,7 @@ public class TraceAutoConfiguration {
 			factoryBuilder = this.extraFieldPropagationFactoryBuilder;
 		}
 		else {
-			factoryBuilder = ExtraFieldPropagation
-					.newFactoryBuilder(B3Propagation.FACTORY);
+			factoryBuilder = ExtraFieldPropagation.newFactoryBuilder(B3Propagation.FACTORY);
 		}
 		if (!sleuthProperties.getBaggageKeys().isEmpty()) {
 			factoryBuilder = factoryBuilder
@@ -200,12 +200,6 @@ public class TraceAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	ReporterMetrics sleuthReporterMetrics() {
-		return new InMemoryReporterMetrics();
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
 	Reporter<zipkin2.Span> noOpSpanReporter() {
 		return Reporter.NOOP;
 	}
@@ -231,11 +225,9 @@ public class TraceAutoConfiguration {
 
 		private final Reporter<zipkin2.Span> spanReporter;
 
-		private CompositeReporter(List<SpanAdjuster> spanAdjusters,
-				List<Reporter<Span>> spanReporters) {
+		private CompositeReporter(List<SpanAdjuster> spanAdjusters, List<Reporter<Span>> spanReporters) {
 			this.spanAdjusters = spanAdjusters;
-			this.spanReporter = spanReporters.size() == 1 ? spanReporters.get(0)
-					: new ListReporter(spanReporters);
+			this.spanReporter = spanReporters.size() == 1 ? spanReporters.get(0) : new ListReporter(spanReporters);
 		}
 
 		@Override
@@ -249,8 +241,8 @@ public class TraceAutoConfiguration {
 
 		@Override
 		public String toString() {
-			return "CompositeReporter{" + "spanAdjusters=" + this.spanAdjusters
-					+ ", spanReporters=" + this.spanReporter + '}';
+			return "CompositeReporter{" + "spanAdjusters=" + this.spanAdjusters + ", spanReporters=" + this.spanReporter
+					+ '}';
 		}
 
 		private static final class ListReporter implements Reporter<zipkin2.Span> {
@@ -268,8 +260,7 @@ public class TraceAutoConfiguration {
 						spanReporter.report(span);
 					}
 					catch (Exception ex) {
-						log.warn("Exception occurred while trying to report the span "
-								+ span, ex);
+						log.warn("Exception occurred while trying to report the span " + span, ex);
 					}
 				}
 			}
@@ -277,6 +268,108 @@ public class TraceAutoConfiguration {
 			@Override
 			public String toString() {
 				return "ListReporter{" + "spanReporters=" + this.spanReporters + '}';
+			}
+
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnMissingBean(MeterRegistry.class)
+	static class TraceMetricsNoOpConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		ReporterMetrics sleuthReporterMetrics() {
+			return new InMemoryReporterMetrics();
+		}
+
+	}
+
+	@Configuration
+	@ConditionalOnBean(MeterRegistry.class)
+	static class TraceMicrometerMetricsConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		ReporterMetrics sleuthMicrometerReporterMetrics(MeterRegistry meterRegistry) {
+			return new MicrometerReporterMetrics(meterRegistry);
+		}
+
+		static final class MicrometerReporterMetrics implements ReporterMetrics {
+
+			private final Counter messages;
+
+			private final Counter messageBytes;
+
+			private final Counter spans;
+
+			private final Counter spanBytes;
+
+			private final Counter spansDropped;
+
+			private final AtomicLong spanPending;
+
+			private final AtomicLong spanBytesPending;
+
+			private final Map<Class<? extends Throwable>, Counter> messagesDropped = new ConcurrentHashMap<>();
+
+			private final MeterRegistry meterRegistry;
+
+			MicrometerReporterMetrics(MeterRegistry meterRegistry) {
+				this.messages = meterRegistry.counter("sleuth.messages");
+				this.messageBytes = meterRegistry.counter("sleuth.messageBytes");
+				this.spans = meterRegistry.counter("sleuth.spans");
+				this.spanBytes = meterRegistry.counter("sleuth.spanBytes");
+				this.spansDropped = meterRegistry.counter("sleuth.spansDropped");
+				this.spanPending = meterRegistry.gauge("sleuth.spanPending", new AtomicLong());
+				this.spanBytesPending = meterRegistry.gauge("sleuth.spanBytesPending", new AtomicLong());
+				this.meterRegistry = meterRegistry;
+			}
+
+			@Override
+			public void incrementMessages() {
+				this.messages.increment();
+			}
+
+			@Override
+			public void incrementMessagesDropped(Throwable cause) {
+				Counter counter = this.messagesDropped.get(cause.getClass());
+				if (counter == null) {
+					counter = this.meterRegistry.counter("sleuth.messagesDropped." + cause.getClass().getSimpleName());
+					this.messagesDropped.put(cause.getClass(), counter);
+				}
+				counter.increment();
+			}
+
+			@Override
+			public void incrementSpans(int quantity) {
+				this.spans.increment();
+			}
+
+			@Override
+			public void incrementSpanBytes(int quantity) {
+				this.spanBytes.increment(quantity);
+			}
+
+			@Override
+			public void incrementMessageBytes(int quantity) {
+				this.messageBytes.increment(quantity);
+			}
+
+			@Override
+			public void incrementSpansDropped(int quantity) {
+				this.spansDropped.increment(quantity);
+			}
+
+			@Override
+			public void updateQueuedSpans(int update) {
+				this.spanPending.set(update);
+			}
+
+			@Override
+			public void updateQueuedBytes(int update) {
+				this.spanBytesPending.set(update);
 			}
 
 		}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.autoconfig;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.BDDAssertions;
+import org.junit.Test;
+import zipkin2.reporter.InMemoryReporterMetrics;
+import zipkin2.reporter.ReporterMetrics;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class TraceAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(TraceAutoConfiguration.class));
+
+	@Test
+	public void should_apply_micrometer_reporter_metrics_when_meter_registry_bean_present() {
+		this.contextRunner.withUserConfiguration(WithMeterRegistry.class).run((context) -> {
+			ReporterMetrics bean = context.getBean(ReporterMetrics.class);
+
+			BDDAssertions.then(bean).isInstanceOf(
+					TraceAutoConfiguration.TraceMicrometerMetricsConfiguration.MicrometerReporterMetrics.class);
+		});
+	}
+
+	@Test
+	public void should_apply_in_memory_metrics_when_meter_registry_bean_missing() {
+		this.contextRunner.run((context) -> {
+			ReporterMetrics bean = context.getBean(ReporterMetrics.class);
+
+			BDDAssertions.then(bean).isInstanceOf(InMemoryReporterMetrics.class);
+		});
+	}
+
+	@Configuration
+	static class WithMeterRegistry {
+
+		@Bean
+		MeterRegistry meterRegistry() {
+			return new SimpleMeterRegistry();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Since I'm no metrics expert I need feedback from such as experts as @shakuzen @adriancole @msmsimondean and the rest of the experts interested in this topic ;)

I've added an initial implementation that uses `counter`s and `gauge`s from micrometer for metrics. I've passed some default values for metric names but I'm not sure if those are the best.

This would actually start defaulting to the Micrometer version of a metric reporter since it's pretty much always on the classpath. If someone doesn't have a `meterRegistry` bean, then the in memory option will be taken into account.

I don't think we can have an option that there is no micrometer on the classpath since it comes with boot.

UPDATE: As @spencergibb mentioned, micrometer comes as an dependency with an actuator, however actuator doesn't always have to be there. As @adriancole mentioned there already is a zipkin micrometer reporter that we can reuse.