### PR TITLE
Report HTTP pattern and handler function name for functional WebFlux routes.

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFilter.java
@@ -278,17 +278,13 @@ public final class TraceWebFilter implements WebFilter, Ordered {
 			}
 
 			private void terminateSpan(@Nullable Throwable t) {
-				String httpRoute = null;
 				Object attribute = this.exchange
 						.getAttribute(HandlerMapping.BEST_MATCHING_HANDLER_ATTRIBUTE);
-				if (attribute instanceof HandlerMethod) {
-					HandlerMethod handlerMethod = (HandlerMethod) attribute;
-					addClassMethodTag(handlerMethod, this.span);
-					addClassNameTag(handlerMethod, this.span);
-					Object pattern = this.exchange
-							.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-					httpRoute = pattern != null ? pattern.toString() : "";
-				}
+				addClassMethodTag(attribute, this.span);
+				addClassNameTag(attribute, this.span);
+				Object pattern = this.exchange
+						.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+				String httpRoute = pattern != null ? pattern.toString() : "";
 				addResponseTagsForSpanWithoutParent(this.exchange,
 						this.exchange.getResponse(), this.span);
 				DecoratedServerHttpResponse delegate = new DecoratedServerHttpResponse(


### PR DESCRIPTION
This pull request improves on the instrumentation of WebFlux requests when the routes are defined using `RouterFunction` rather than in a `@Controller`. In particular:
- Before this patch, the operation name used to be just the HTTP verb like `get`, but now it will include the pattern like: `get /api/books/{id}`. This brings parity with the `@Controller` case.
- The `mvc.controller` tag used to be unset but now it will be set to the name of the router function, such as `BooksRouterService$$Lambda$123/123456789`. While this is not perfect, at least it points you to the right file to look at.
