### PR TITLE
Configure OpentracingAutoConfiguration after TraceAutoConfiguration.

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/OpentracingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/OpentracingAutoConfiguration.java
@@ -20,11 +20,13 @@ import brave.Tracing;
 import brave.opentracing.BraveTracer;
 import io.opentracing.Tracer;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,6 +42,7 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(value = "spring.sleuth.opentracing.enabled", matchIfMissing = true)
 @ConditionalOnBean(Tracing.class)
 @ConditionalOnClass(Tracer.class)
+@AutoConfigureAfter(TraceAutoConfiguration.class)
 @EnableConfigurationProperties(SleuthOpentracingProperties.class)
 public class OpentracingAutoConfiguration {
 


### PR DESCRIPTION
`OpentracingAutoConfiguration` exposes an `io.opentracing.Tracer` bean. To create this bean a `brave.Tracing` bean is required. The presence of `@ConditionalOnBean(Tracing.class)` ensures that this configuration is only applied when the bean is available.

`TraceAutoConfiguration` exposes a `brave.Tracing` bean. To ensure this bean is always available when applying `OpentracingAutoConfiguration` it is necessary to express this dependency. I've done so here by adding an `@AutoConfigureAfter` to ensure this auto configuration is applied after `TraceAutoConfiguration`.

Without this in place the `io.opentracing.Tracer` is created only when the order happens to work out in our favor.