### PR TITLE
Use actual log timestamp as logstash timestamp

### DIFF
--- a/docs/src/main/asciidoc/intro.adoc
+++ b/docs/src/main/asciidoc/intro.adoc
@@ -158,19 +158,31 @@ If you want to use https://www.elastic.co/guide/en/logstash/current/index.html[L
 
 [source]
 filter {
-       # pattern matching logback pattern
-       grok {
-              match => { "message" => "%{TIMESTAMP_ISO8601:timestamp}\s+%{LOGLEVEL:severity}\s+\[%{DATA:service},%{DATA:trace},%{DATA:span},%{DATA:exportable}\]\s+%{DATA:pid}\s+---\s+\[%{DATA:thread}\]\s+%{DATA:class}\s+:\s+%{GREEDYDATA:rest}" }
-       }
+  # pattern matching logback pattern
+  grok {
+    match => { "message" => "%{TIMESTAMP_ISO8601:timestamp}\s+%{LOGLEVEL:severity}\s+\[%{DATA:service},%{DATA:trace},%{DATA:span},%{DATA:exportable}\]\s+%{DATA:pid}\s+---\s+\[%{DATA:thread}\]\s+%{DATA:class}\s+:\s+%{GREEDYDATA:rest}" }
+  }
+  date {
+    match => ["timestamp", "ISO8601"]
+  }
+  mutate {
+    remove_field => ["timestamp"]
+  }
 }
 
 NOTE: If you want to use Grok together with the logs from Cloud Foundry, you have to use the following pattern:
 [source]
 filter {
-       # pattern matching logback pattern
-       grok {
-              match => { "message" => "(?m)OUT\s+%{TIMESTAMP_ISO8601:timestamp}\s+%{LOGLEVEL:severity}\s+\[%{DATA:service},%{DATA:trace},%{DATA:span},%{DATA:exportable}\]\s+%{DATA:pid}\s+---\s+\[%{DATA:thread}\]\s+%{DATA:class}\s+:\s+%{GREEDYDATA:rest}" }
-       }
+  # pattern matching logback pattern
+  grok {
+    match => { "message" => "(?m)OUT\s+%{TIMESTAMP_ISO8601:timestamp}\s+%{LOGLEVEL:severity}\s+\[%{DATA:service},%{DATA:trace},%{DATA:span},%{DATA:exportable}\]\s+%{DATA:pid}\s+---\s+\[%{DATA:thread}\]\s+%{DATA:class}\s+:\s+%{GREEDYDATA:rest}" }
+  }
+  date {
+    match => ["timestamp", "ISO8601"]
+  }
+  mutate {
+    remove_field => ["timestamp"]
+  }
 }
 
 ===== JSON Logback with Logstash


### PR DESCRIPTION
Based on the grok example from the docs, a Filebeat + Logstash stack will produce the following:
- a `@timestamp` field based on the time that filebeat sends the log to logstash, as timestamp type.
- a `timestamp` field from the Spring Boot log, as string type.

In order to use the Spring Boot timestamp as the real Logstash `@timestamp` I use the following filters after the grok pattern:

```
  date {
    match => ["timestamp", "ISO8601"]
  }
  mutate {
    remove_field => ["timestamp"]
  }
```

Using these filters will result in `@timestamp` being the Spring Boot's timestamp, as a timestamp type, and will remove the now duplicated (string type) `timestamp`.