### PR TITLE
Reduces overhead when using reactor by avoiding redundant context syncs

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/AbstractSleuthMethodInvocationProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/AbstractSleuthMethodInvocationProcessor.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.annotation;
 
 import brave.Span;
 import brave.Tracer;
+import brave.propagation.CurrentTraceContext;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -46,6 +47,8 @@ abstract class AbstractSleuthMethodInvocationProcessor
 	private NewSpanParser newSpanParser;
 
 	private Tracer tracer;
+
+	private CurrentTraceContext currentTraceContext;
 
 	private SpanTagAnnotationHandler spanTagAnnotationHandler;
 
@@ -103,6 +106,14 @@ abstract class AbstractSleuthMethodInvocationProcessor
 			this.tracer = this.beanFactory.getBean(Tracer.class);
 		}
 		return this.tracer;
+	}
+
+	CurrentTraceContext currentTraceContext() {
+		if (this.currentTraceContext == null) {
+			this.currentTraceContext = this.beanFactory
+					.getBean(CurrentTraceContext.class);
+		}
+		return this.currentTraceContext;
 	}
 
 	NewSpanParser newSpanParser() {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java
@@ -268,8 +268,8 @@ final class TraceExchangeFilterFunction implements ExchangeFilterFunction {
 				this.tracing = parent.tracing;
 				this.scopePassingTransformer = parent.scopePassingTransformer;
 
-				if (!context.hasKey(Span.class)) {
-					context = context.put(Span.class, span);
+				if (!context.hasKey(TraceContext.class)) {
+					context = context.put(TraceContext.class, span.context());
 					if (log.isDebugEnabled()) {
 						log.debug("Reactor Context got injected with the client span "
 								+ span);

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import brave.Span;
 import brave.Tracer;
+import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import org.apache.commons.lang3.StringUtils;
 import org.awaitility.Awaitility;
@@ -75,8 +76,8 @@ public class SleuthSpanCreatorAspectFluxTests {
 	}
 
 	protected static Long id(Context context, Tracer tracer) {
-		if (context.hasKey(Span.class)) {
-			return context.get(Span.class).context().spanId();
+		if (context.hasKey(TraceContext.class)) {
+			return context.get(TraceContext.class).spanId();
 		}
 		return id(tracer);
 	}


### PR DESCRIPTION
This switches to pass around and use `TraceContext` instead of `Span` in
Reactor's context to take advantage of `maybeScope` which is far cheaper
than `withSpanInScope` when the span is already current. This also kills
some extra scope checks and any other accidental calls noticed.

The performance improvement here, I can't quantify as haven't done any
JMH on it.

cc @anuraaga