### PR TITLE
Cleanups of build including upgrade of Brave

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -888,7 +888,6 @@ Checkstyle rules are *disabled by default*. To add checkstyle to your project ju
                 <artifactId>spring-javaformat-maven-plugin</artifactId>
             </plugin>
             <plugin> <5>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
         </plugins>
@@ -896,7 +895,6 @@ Checkstyle rules are *disabled by default*. To add checkstyle to your project ju
     <reporting>
         <plugins>
             <plugin> <5>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
         </plugins>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -14,7 +14,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -27,15 +27,14 @@
 
 	<properties>
 		<main.basedir>${project.basedir}/..</main.basedir>
-		<jmh.version>1.16</jmh.version>
-		<maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>
-		<maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+		<jmh.version>1.22</jmh.version>
+		<maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
 		<sonar.skip>true</sonar.skip>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<spring-boot.version>2.3.0.BUILD-SNAPSHOT</spring-boot.version>
-		<brave.version>5.8.0</brave.version>
-		<okhttp.version>3.11.0</okhttp.version>
+		<brave.version>5.9.1</brave.version>
+		<okhttp.version>3.14.6</okhttp.version>
 	</properties>
 
 	<dependencyManagement>
@@ -92,7 +91,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.5.2</version>
+			<version>3.14.0</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -134,9 +133,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>${maven.compiler.source}</source>
 					<target>${maven.compiler.target}</target>
@@ -151,7 +149,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-install-plugin</artifactId>
-				<version>${maven-install-plugin.version}</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -369,9 +366,8 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-failsafe-plugin</artifactId>
-						<version>2.19.1</version>
+						<version>2.22.2</version>
 						<executions>
 							<execution>
 								<goals>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -56,11 +56,9 @@
 						<artifactId>git-commit-id-plugin</artifactId>
 					</plugin>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-dependency-plugin</artifactId>
 					</plugin>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-resources-plugin</artifactId>
 					</plugin>
 					<plugin>
@@ -72,7 +70,6 @@
 						<artifactId>asciidoctor-maven-plugin</artifactId>
 					</plugin>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-antrun-plugin</artifactId>
 					</plugin>
 				</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -59,9 +59,8 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.1</version>
+					<version>3.8.1</version>
 					<executions>
 						<execution>
 							<id>default-compile</id>
@@ -88,7 +87,6 @@
 					</executions>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
 					<version>1.3.1</version>
 					<executions>
@@ -108,7 +106,6 @@
 					</executions>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>2.8.2</version>
 				</plugin>
@@ -120,7 +117,6 @@
 				<artifactId>spring-javaformat-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
 		</plugins>
@@ -129,7 +125,6 @@
 	<reporting>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
 		</plugins>
@@ -244,7 +239,7 @@
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<version>3.8.0</version>
+				<version>3.14.0</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>
@@ -262,13 +257,12 @@
 		<spring-cloud-stream.version>Horsham.SR1</spring-cloud-stream.version>
 		<spring-cloud-netflix.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-openfeign.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-openfeign.version>
-		<brave.version>5.8.0</brave.version>
-		<spring-security-boot-autoconfigure.version>2.1.7.RELEASE
-		</spring-security-boot-autoconfigure.version>
+		<brave.version>5.9.1</brave.version>
+		<spring-security-boot-autoconfigure.version>2.1.7.RELEASE</spring-security-boot-autoconfigure.version>
 		<spring-cloud-aws.version>2.2.2.BUILD-SNAPSHOT</spring-cloud-aws.version>
 		<disable.nohttp.checks>false</disable.nohttp.checks>
-		<okhttp.version>3.10.0</okhttp.version>
-		<mockwebserver.version>3.10.0</mockwebserver.version>
+		<okhttp.version>3.14.6</okhttp.version>
+		<mockwebserver.version>3.14.6</mockwebserver.version>
 		<guava.version>20.0</guava.version>
 		<javax.resource-api.version>1.7.1</javax.resource-api.version>
 		<cglib-nodep.version>3.3.0</cglib-nodep.version>
@@ -357,9 +351,7 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.1</version>
 						<configuration>
 							<source>${maven.compiler.testSource}</source>
 							<target>${maven.compiler.testTarget}</target>
@@ -411,7 +403,6 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
 						<configuration>
 							<!-- Sets the VM argument line used when unit tests are run. -->

--- a/spring-cloud-sleuth-core/pom.xml
+++ b/spring-cloud-sleuth-core/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -378,7 +378,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
 						<configuration>
 							<forkCount>4</forkCount>

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClientTests.java
@@ -89,7 +89,7 @@ public class TracingFeignClientTests {
 		}
 
 		then(this.reporter.getSpans().get(0)).extracting("kind.ordinal")
-				.contains(Span.Kind.CLIENT.ordinal());
+				.isEqualTo(Span.Kind.CLIENT.ordinal());
 	}
 
 	@Test
@@ -113,7 +113,7 @@ public class TracingFeignClientTests {
 		}
 
 		then(this.reporter.getSpans().get(0)).extracting("kind.ordinal")
-				.contains(Span.Kind.CLIENT.ordinal());
+				.isEqualTo(Span.Kind.CLIENT.ordinal());
 		then(this.reporter.getSpans().get(0).tags()).containsEntry("error",
 				"exception has occurred");
 	}

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -31,7 +31,7 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<brave.version>5.9.0</brave.version>
+		<brave.version>5.9.1</brave.version>
 		<brave.opentracing.version>0.35.0</brave.opentracing.version>
 		<grpc.spring.boot.version>3.4.1</grpc.spring.boot.version>
 	</properties>

--- a/spring-cloud-sleuth-samples/pom.xml
+++ b/spring-cloud-sleuth-samples/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -73,7 +73,7 @@
 			<dependency>
 				<groupId>io.zipkin.zipkin2</groupId>
 				<artifactId>zipkin</artifactId>
-				<version>2.17.0</version>
+				<version>2.19.2</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-feign/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-feign/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-messaging/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -57,7 +57,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<source>1.8</source>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-ribbon/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -55,7 +55,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<version>1.16</version>
+				<version>1.18</version>
 				<configuration>
 					<skip>true</skip>
 					<signature>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-websocket/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-websocket/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -57,7 +57,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<source>1.8</source>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-zipkin/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -57,7 +57,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<source>1.8</source>
@@ -101,7 +100,6 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>3.9.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample/pom.xml
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -149,7 +149,6 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>3.10.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-starter-sleuth/pom.xml
+++ b/spring-cloud-starter-sleuth/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-starter-zipkin/pom.xml
+++ b/spring-cloud-starter-zipkin/pom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-async-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-async-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-grpc-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-grpc-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>20.0</version>
+			<version>${guava.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- GRPC Optional Dependencies -->

--- a/tests/spring-cloud-sleuth-instrumentation-hystrix-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-hystrix-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-lettuce-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-lettuce-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd
 https://www.w3.org/2001/XMLSchema-instance ">

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-rpc-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-rpc-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-rxjava-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-rxjava-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-scheduling-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-scheduling-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-webflux-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-webflux-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/tests/spring-cloud-sleuth-instrumentation-zuul-tests/pom.xml
+++ b/tests/spring-cloud-sleuth-instrumentation-zuul-tests/pom.xml
@@ -17,7 +17,7 @@
   ~
   -->
 
-<project xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://maven.apache.org/POM/4.0.0"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
In efforts to dig deep into benchmarks, I noticed we were a bit out of
date on Brave. Then, noticed some other artifacts could be bumped
safely. Finally, a find/replace on http/https was over zealous and
tripped up XML.

One change to test expectations and Brave is explained here:
https://github.com/openzipkin/brave/blob/master/instrumentation/RATIONALE.md#calling-spanfinish-while-the-context-is-in-scope