### PR TITLE
Corrects HookRegisteringBeanDefinitionRegistryPostProcessor.setupHooks

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
@@ -101,9 +101,8 @@ public class TraceReactorAutoConfiguration {
 		}
 
 		@Bean
-		// for tests
 		@ConditionalOnMissingBean
-		static HookRegisteringBeanDefinitionRegistryPostProcessor traceHookRegisteringBeanDefinitionRegistryPostProcessor(
+		HookRegisteringBeanDefinitionRegistryPostProcessor traceHookRegisteringBeanDefinitionRegistryPostProcessor(
 				ConfigurableApplicationContext context) {
 			if (log.isTraceEnabled()) {
 				log.trace(
@@ -190,7 +189,7 @@ class HookRegisteringBeanDefinitionRegistryPostProcessor
 		setupHooks(this.springContext);
 	}
 
-	void setupHooks(ConfigurableApplicationContext springContext) {
+	static void setupHooks(ConfigurableApplicationContext springContext) {
 		ConfigurableEnvironment environment = springContext.getEnvironment();
 		boolean decorateOnEach = environment.getProperty(
 				"spring.sleuth.reactor.decorate-on-each", Boolean.class, true);
@@ -199,14 +198,14 @@ class HookRegisteringBeanDefinitionRegistryPostProcessor
 				log.trace("Decorating onEach operator instrumentation");
 			}
 			Hooks.onEachOperator(SLEUTH_TRACE_REACTOR_KEY,
-					scopePassingSpanOperator(this.springContext));
+					scopePassingSpanOperator(springContext));
 		}
 		else {
 			if (log.isTraceEnabled()) {
 				log.trace("Decorating onLast operator instrumentation");
 			}
 			Hooks.onLastOperator(SLEUTH_TRACE_REACTOR_KEY,
-					scopePassingSpanOperator(this.springContext));
+					scopePassingSpanOperator(springContext));
 		}
 		Schedulers.setExecutorServiceDecorator(
 				TraceReactorAutoConfiguration.SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY,

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
@@ -51,9 +51,7 @@ public final class TraceReactorAutoConfigurationAccessorConfiguration {
 		if (log.isTraceEnabled()) {
 			log.trace("Setting up hooks");
 		}
-		TraceReactorAutoConfiguration.TraceReactorConfiguration
-				.traceHookRegisteringBeanDefinitionRegistryPostProcessor(context)
-				.setupHooks(context);
+		HookRegisteringBeanDefinitionRegistryPostProcessor.setupHooks(context);
 	}
 
 }

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
@@ -51,9 +51,7 @@ public final class TraceReactorAutoConfigurationAccessorConfiguration {
 		if (log.isTraceEnabled()) {
 			log.trace("Setting up hooks");
 		}
-		TraceReactorAutoConfiguration.TraceReactorConfiguration
-				.traceHookRegisteringBeanDefinitionRegistryPostProcessor(context)
-				.setupHooks(context);
+		HookRegisteringBeanDefinitionRegistryPostProcessor.setupHooks(context);
 	}
 
 }


### PR DESCRIPTION
Probably due to code drift, `HookRegisteringBeanDefinitionRegistryPostProcessor.setupHooks`
was used as an object method, which led to a confusing no-op chain in
tests.

This ensures it is used consistently as a static method, and also
corrects a bean accidentally marked static for testing.