### PR TITLE
Reduces the amount of wrapping in reactive commands

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
@@ -115,10 +115,19 @@ public abstract class ReactorSleuth {
 				return sub; // no need to scope a null parent
 			}
 
+			// Handle scenarios such as Mono.defer
+			if (sub instanceof ScopePassingSpanSubscriber) {
+				ScopePassingSpanSubscriber<?> scopePassing = (ScopePassingSpanSubscriber) sub;
+				if (scopePassing.parent.equals(parent)) {
+					return sub; // don't double-wrap
+				}
+			}
+
 			if (log.isTraceEnabled()) {
 				log.trace("Creating a scope passing span subscriber with Reactor Context "
 						+ "[" + context + "] and name [" + name(sub) + "]");
 			}
+
 			return new ScopePassingSpanSubscriber<>(sub, context, currentTraceContext,
 					parent);
 		});

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
@@ -37,17 +37,17 @@ import reactor.util.context.Context;
  */
 final class ScopePassingSpanSubscriber<T> implements SpanSubscription<T>, Scannable {
 
-	private static final Log log = LogFactory.getLog(ScopePassingSpanSubscriber.class);
+	static final Log log = LogFactory.getLog(ScopePassingSpanSubscriber.class);
 
-	private final Subscriber<? super T> subscriber;
+	final Subscriber<? super T> subscriber;
 
-	private final Context context;
+	final Context context;
 
-	private final CurrentTraceContext currentTraceContext;
+	final CurrentTraceContext currentTraceContext;
 
-	private final TraceContext parent;
+	final TraceContext parent;
 
-	private Subscription s;
+	Subscription s;
 
 	ScopePassingSpanSubscriber(Subscriber<? super T> subscriber, Context ctx,
 			CurrentTraceContext currentTraceContext, @Nullable TraceContext parent) {


### PR DESCRIPTION
This opts-out of wrapping when the reactor subscription is already
wrapped with the same trace context. I noticed this in some AspectJ
unit tests and webflux scenarios.

If I understand correctly, this should reduce the stack size, yet
keep the same propagation functionality as we have now.