### PR TITLE
Fixes WebClient which started a client span prior to a subscription

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
@@ -25,7 +25,6 @@ import brave.Span;
 import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.CurrentTraceContext.Scope;
 import brave.propagation.TraceContext;
 import io.netty.bootstrap.Bootstrap;
 import reactor.core.publisher.Mono;
@@ -155,12 +154,9 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 					null);
 			WrappedHttpClientRequest request = new WrappedHttpClientRequest(req);
 
-			// Simplify after openzipkin/brave#1082
-			try (Scope ws = currentTraceContext().maybeScope(parent)) {
-				clientSpan = handler().handleSend(request);
-				parseConnectionAddress(connection, clientSpan);
-				ref.set(clientSpan);
-			}
+			clientSpan = handler().handleSendWithParent(request, parent);
+			parseConnectionAddress(connection, clientSpan);
+			ref.set(clientSpan);
 		}
 
 		static void parseConnectionAddress(Connection connection, Span span) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientBeanPostProcessor.java
@@ -138,7 +138,7 @@ final class TraceExchangeFilterFunction implements ExchangeFilterFunction {
 
 	@Override
 	public Mono<ClientResponse> filter(ClientRequest request, ExchangeFunction next) {
-		return new MonoWebClientTrace(next, request, this, currentTraceContext.get());
+		return new MonoWebClientTrace(next, request, this);
 	}
 
 	CurrentTraceContext currentTraceContext() {
@@ -171,14 +171,13 @@ final class TraceExchangeFilterFunction implements ExchangeFilterFunction {
 		final TraceContext parent;
 
 		MonoWebClientTrace(ExchangeFunction next, ClientRequest request,
-				TraceExchangeFilterFunction filterFunction,
-				@Nullable TraceContext parent) {
+				TraceExchangeFilterFunction filterFunction) {
 			this.next = next;
 			this.request = request;
 			this.handler = filterFunction.handler();
 			this.currentTraceContext = filterFunction.currentTraceContext();
 			this.scopePassingTransformer = filterFunction.scopePassingTransformer;
-			this.parent = parent;
+			this.parent = currentTraceContext.get();
 		}
 
 		@Override


### PR DESCRIPTION
In looking at underlying HttpClient mechanics, I noticed the reactor
call doesn't happen until subscribe. Before this change, we started the
client span at the ExchangeFilterFunction, not at subscribe time.