### PR TITLE
Attempts to align feign code with master

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignAspect.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignAspect.java
@@ -53,6 +53,8 @@ class TraceFeignAspect {
 			log.debug("Executing feign client via TraceFeignAspect");
 		}
 		if (bean != wrappedBean) {
+			// NOTE: in master(3813cf9dd47f98db0e075412abbffbd9d6742974),
+			// this is executeTraceFeignClient(wrappedBean, pjp)
 			return executeTraceFeignClient(bean, pjp);
 		}
 		return pjp.proceed();

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignObjectWrapper.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignObjectWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.openfeign.loadbalancer.FeignBlockingLoadBalancerClient;
 import org.springframework.cloud.openfeign.ribbon.CachingSpringLoadBalancerFactory;
 import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
+import org.springframework.cloud.util.ProxyUtils;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -100,7 +101,7 @@ final class TraceFeignObjectWrapper {
 
 	private Object instrumentedFeignLoadBalancerClient(Object bean) {
 		if (AopUtils.getTargetClass(bean).equals(FeignBlockingLoadBalancerClient.class)) {
-			FeignBlockingLoadBalancerClient client = ((FeignBlockingLoadBalancerClient) bean);
+			FeignBlockingLoadBalancerClient client = ProxyUtils.getTargetObject(bean);
 			return new TraceFeignBlockingLoadBalancerClient(
 					(Client) new TraceFeignObjectWrapper(this.beanFactory)
 							.wrap(client.getDelegate()),

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClient.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import feign.Response;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.cloud.util.ProxyUtils;
 import org.springframework.lang.Nullable;
 
 /**
@@ -58,7 +59,9 @@ final class TracingFeignClient implements Client {
 	TracingFeignClient(HttpTracing httpTracing, Client delegate) {
 		this.currentTraceContext = httpTracing.tracing().currentTraceContext();
 		this.handler = HttpClientHandler.create(httpTracing);
-		this.delegate = delegate;
+		Client delegateTarget = ProxyUtils.getTargetObject(delegate);
+		this.delegate = delegateTarget instanceof TracingFeignClient
+				? ((TracingFeignClient) delegateTarget).delegate : delegateTarget;
 	}
 
 	static Client create(HttpTracing httpTracing, Client delegate) {


### PR DESCRIPTION
This tries to pick in the relevant changes made in 3813cf9dd47f98db0e075412abbffbd9d6742974

Notably, there's one glitch, `TraceFeignAspect` still passes bean, not
wrappedBean. The latter trips out `ManuallyCreatedLoadBalancerFeignClientTests`
as the nonexistenturl raises a hard error in Ribbon. I *think* this is a bug and
tests need to just adjust for that, but need a second opinion. Also, I'm not
entirely sure the intent of using the broken url then asserting against a
success result..