### PR TITLE
Adds base integration test for reactor clients and adds cancelation tests

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
@@ -17,14 +17,15 @@
 package org.springframework.cloud.sleuth.instrument.web.client;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 import brave.Span;
 import brave.http.HttpClientHandler;
 import brave.http.HttpTracing;
-import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import io.netty.bootstrap.Bootstrap;
 import reactor.core.publisher.Mono;
@@ -63,46 +64,58 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 					.doOnResponse(new TracingDoOnResponse(httpTracing))
 					.doOnRequestError(new TracingDoOnErrorRequest(httpTracing))
 					.doOnRequest(new TracingDoOnRequest(httpTracing))
-					.mapConnect(new TracingMapConnect(httpTracing));
+					.mapConnect(new TracingMapConnect(() -> {
+						HttpTracing ref = httpTracing.get();
+						return ref != null ? ref.tracing().currentTraceContext().get()
+								: null;
+					}));
 		}
 		return bean;
 	}
 
-	/** current client span, cleared on completion. */
-	private static final class CurrentClientSpan extends AtomicReference<Span> {
+	/** The current client span, cleared on completion for any reason. */
+	static final class PendingSpan extends AtomicReference<Span> {
 
 	}
 
-	private static class TracingMapConnect implements
+	static class TracingMapConnect implements
 			BiFunction<Mono<? extends Connection>, Bootstrap, Mono<? extends Connection>> {
 
-		final LazyBean<HttpTracing> httpTracing;
+		static final Exception CANCELLED_ERROR = new CancellationException("CANCELLED") {
+			@Override
+			public Throwable fillInStackTrace() {
+				return this; // stack trace doesn't add value here
+			}
+		};
 
-		CurrentTraceContext currentTraceContext;
+		final Supplier<TraceContext> currentTraceContext;
 
-		TracingMapConnect(LazyBean<HttpTracing> httpTracing) {
-			this.httpTracing = httpTracing;
+		TracingMapConnect(Supplier<TraceContext> currentTraceContext) {
+			this.currentTraceContext = currentTraceContext;
 		}
 
 		@Override
 		public Mono<? extends Connection> apply(Mono<? extends Connection> mono,
 				Bootstrap bootstrap) {
+			// This function is invoked once per-request. We keep a reference to the
+			// pending client span here, so that only one signal completes the span.
+			PendingSpan pendingSpan = new PendingSpan();
 			return mono.subscriberContext(context -> {
-				TraceContext invocationContext = currentTraceContext().get();
+				TraceContext invocationContext = currentTraceContext.get();
 				if (invocationContext != null) {
 					// Read in this processor and also in ScopePassingSpanSubscriber
 					context = context.put(TraceContext.class, invocationContext);
 				}
-				return context.put(CurrentClientSpan.class, new CurrentClientSpan());
+				return context.put(PendingSpan.class, pendingSpan);
+			}).doOnCancel(() -> {
+				// Check to see if Subscription.cancel() happened before another signal,
+				// like onComplete() completed the span (clearing the reference).
+				Span span = pendingSpan.getAndSet(null);
+				if (span != null) {
+					span.error(CANCELLED_ERROR);
+					span.finish();
+				}
 			});
-		}
-
-		CurrentTraceContext currentTraceContext() {
-			if (this.currentTraceContext == null) {
-				this.currentTraceContext = this.httpTracing.get().tracing()
-						.currentTraceContext();
-			}
-			return this.currentTraceContext;
 		}
 
 	}
@@ -127,22 +140,22 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 
 		@Override
 		public void accept(HttpClientRequest req, Connection connection) {
-			CurrentClientSpan ref = req.currentContext()
-					.getOrDefault(CurrentClientSpan.class, null);
-			if (ref == null) { // Somehow TracingMapConnect was not invoked.. skip out
-				return;
+			PendingSpan pendingSpan = req.currentContext().getOrDefault(PendingSpan.class,
+					null);
+			if (pendingSpan == null) {
+				return; // Somehow TracingMapConnect was not invoked.. skip out
 			}
 
 			// This might be re-entrant on auto-redirect or connection retry:
 			// See reactor/reactor-netty#1000 for follow-ups.
-			Span clientSpan = ref.getAndSet(null);
-			if (clientSpan != null) {
+			Span span = pendingSpan.getAndSet(null);
+			if (span != null) {
 				// Retry from a connect fail wouldn't have parsed the request, leading to
 				// an empty span with no data if we finished it. An auto-redirect would
 				// have parsed the request, but we have no idea which status code it
 				// finished with. Since we can't see the preceding request state, we
 				// abandon its span in favor of the next.
-				clientSpan.abandon();
+				span.abandon();
 			}
 
 			// Start a new client span with the appropriate parent
@@ -150,9 +163,9 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 					null);
 			HttpClientRequestWrapper request = new HttpClientRequestWrapper(req);
 
-			clientSpan = handler().handleSendWithParent(request, parent);
-			parseConnectionAddress(connection, clientSpan);
-			ref.set(clientSpan);
+			span = handler().handleSendWithParent(request, parent);
+			parseConnectionAddress(connection, span);
+			pendingSpan.set(span);
 		}
 
 		static void parseConnectionAddress(Connection connection, Span span) {
@@ -227,18 +240,18 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 
 		void handle(Context context, @Nullable HttpClientResponse resp,
 				@Nullable Throwable error) {
-			CurrentClientSpan ref = context.getOrDefault(CurrentClientSpan.class, null);
-			if (ref == null) { // Somehow TracingMapConnect was not invoked.. skip out
-				return;
+			PendingSpan pendingSpan = context.getOrDefault(PendingSpan.class, null);
+			if (pendingSpan == null) {
+				return; // Somehow TracingMapConnect was not invoked.. skip out
 			}
 
-			Span clientSpan = ref.getAndSet(null);
-			if (clientSpan == null) {
+			Span span = pendingSpan.getAndSet(null);
+			if (span == null) {
 				return; // Unexpected. In the handle method, without a span to finish!
 			}
 			HttpClientResponseWrapper response = resp != null
 					? new HttpClientResponseWrapper(resp) : null;
-			handler().handleReceive(response, error, clientSpan);
+			handler().handleReceive(response, error, span);
 		}
 
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/HttpClientBeanPostProcessor.java
@@ -125,10 +125,6 @@ class HttpClientBeanPostProcessor implements BeanPostProcessor {
 			return this.handler;
 		}
 
-		CurrentTraceContext currentTraceContext() {
-			return httpTracing.get().tracing().currentTraceContext();
-		}
-
 		@Override
 		public void accept(HttpClientRequest req, Connection connection) {
 			CurrentClientSpan ref = req.currentContext()

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/integration/WebClientTests.java
@@ -372,8 +372,12 @@ public class WebClientTests {
 				.contains("CLIENT");
 	}
 
+	/**
+	 * Cancel before {@link Subscription#request(long)} means a network request was never
+	 * sent
+	 */
 	@Test
-	public void shouldTagOnCancel() {
+	public void shouldNotTagOnCancel() {
 		this.webClient.get().uri("http://localhost:" + this.port + "/doNotSkip")
 				.retrieve().bodyToMono(String.class)
 				.subscribe(new BaseSubscriber<String>() {
@@ -383,8 +387,7 @@ public class WebClientTests {
 					}
 				});
 
-		then(this.reporter.getSpans()).isNotEmpty();
-		then(this.reporter.getSpans().get(0).tags()).containsEntry("error", "CANCELLED");
+		then(this.reporter.getSpans()).isEmpty();
 	}
 
 	@Test

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
@@ -17,17 +17,26 @@
 package org.springframework.cloud.sleuth.instrument.web.client;
 
 import java.net.URI;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import brave.http.HttpTracing;
 import brave.test.http.ITHttpAsyncClient;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Test;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import zipkin2.Callback;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This runs Brave's integration tests, ensuring common instrumentation bugs aren't
@@ -98,5 +107,54 @@ abstract class ITSpringConfiguredReactorClient
 	/** Returns a {@link Mono} of the HTTP status code. */
 	abstract Mono<Integer> getMono(AnnotationConfigApplicationContext context,
 			String pathIncludingQuery);
+
+	/**
+	 * This assumes that implementations do not issue an HTTP request until
+	 * {@link Subscription#request(long)} is called. Since a client span is only for
+	 * remote operations, we should not create one when we know a network request won't
+	 * happen. In this case, we ensure a canceled subscription doesn't end up traced.
+	 */
+	@Test
+	public void cancelledSubscription_doesntTrace() throws Exception {
+		CountDownLatch latch = new CountDownLatch(1);
+
+		BaseSubscriber<Integer> subscriber = new BaseSubscriber<Integer>() {
+			@Override protected void hookOnSubscribe(Subscription subscription) {
+				subscription.cancel();
+				latch.countDown();
+			}
+		};
+
+		getMono(client, "/foo").subscribe(subscriber);
+
+		latch.await();
+
+		assertThat(server.getRequestCount()).isZero();
+		// post-conditions will prove no span was created
+	}
+
+	@Test
+	public void cancelInFlight() throws Exception {
+		BaseSubscriber<Integer> subscriber = new BaseSubscriber<Integer>() {
+		};
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		server.setDispatcher(new Dispatcher() {
+			@Override
+			public MockResponse dispatch(RecordedRequest request) {
+				subscriber.cancel();
+				latch.countDown();
+				return new MockResponse();
+			}
+		});
+
+		getMono(client, "/foo").subscribe(subscriber);
+
+		latch.await();
+
+		assertThat(server.getRequestCount()).isOne();
+		assertThat(takeSpan().tags()).containsKey("error");
+	}
 
 }

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.web.client;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import brave.http.HttpTracing;
+import brave.test.http.ITHttpAsyncClient;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+import zipkin2.Callback;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ * This runs Brave's integration tests, ensuring common instrumentation bugs aren't
+ * present.
+ */
+// Function of spring context so that shutdown hooks happen!
+abstract class ITSpringConfiguredReactorClient
+		extends ITHttpAsyncClient<AnnotationConfigApplicationContext> {
+
+	final Class<?>[] componentClasses;
+
+	/**
+	 * @param componentClasses configure instrumentation given {@linkplain URI baseUrl},
+	 * {@link HttpClient} and {@link HttpTracing} bindings exist.
+	 */
+	ITSpringConfiguredReactorClient(Class<?>... componentClasses) {
+		this.componentClasses = componentClasses;
+	}
+
+	@Override
+	final protected AnnotationConfigApplicationContext newClient(int port) {
+		AnnotationConfigApplicationContext result = new AnnotationConfigApplicationContext();
+		URI baseUrl = URI.create("http://127.0.0.1:" + server.getPort());
+		result.registerBean(HttpTracing.class, () -> httpTracing);
+		result.registerBean(HttpClient.class, () -> testHttpClient(baseUrl));
+		result.registerBean(URI.class, () -> baseUrl);
+		result.register(componentClasses);
+		result.refresh();
+		return result;
+	}
+
+	static HttpClient testHttpClient(URI baseUrl) {
+		return HttpClient.create().baseUrl(baseUrl.toString())
+				.tcpConfiguration(tcpClient -> tcpClient
+						.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
+						.doOnConnected(conn -> conn
+								.addHandler(new ReadTimeoutHandler(1, TimeUnit.SECONDS))))
+				.followRedirect(true);
+	}
+
+	@Override
+	final protected void closeClient(AnnotationConfigApplicationContext context) {
+		context.close(); // ensures shutdown hooks fire
+	}
+
+	@Override
+	final protected void get(AnnotationConfigApplicationContext context,
+			String pathIncludingQuery) {
+		getMono(context, pathIncludingQuery).block();
+	}
+
+	@Override
+	final protected void post(AnnotationConfigApplicationContext context,
+			String pathIncludingQuery, String body) {
+		postMono(context, pathIncludingQuery, body).block();
+	}
+
+	@Override
+	final protected void getAsync(AnnotationConfigApplicationContext context, String path,
+			Callback<Integer> callback) {
+		TestHttpCallbackSubscriber.subscribe(getMono(context, path), callback);
+	}
+
+	/** Returns a {@link Mono} of the HTTP status code from the given "POST" request. */
+	abstract Mono<Integer> postMono(AnnotationConfigApplicationContext context,
+			String pathIncludingQuery, String body);
+
+	/** Returns a {@link Mono} of the HTTP status code. */
+	abstract Mono<Integer> getMono(AnnotationConfigApplicationContext context,
+			String pathIncludingQuery);
+
+}

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
@@ -119,7 +119,8 @@ abstract class ITSpringConfiguredReactorClient
 		CountDownLatch latch = new CountDownLatch(1);
 
 		BaseSubscriber<Integer> subscriber = new BaseSubscriber<Integer>() {
-			@Override protected void hookOnSubscribe(Subscription subscription) {
+			@Override
+			protected void hookOnSubscribe(Subscription subscription) {
 				subscription.cancel();
 				latch.countDown();
 			}

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ReactorNettyHttpClientBraveTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ReactorNettyHttpClientBraveTests.java
@@ -25,11 +25,6 @@ import reactor.netty.http.client.HttpClient;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-/**
- * This runs Brave's integration tests, ensuring common instrumentation bugs aren't
- * present.
- */
-// Function of spring context so that shutdown hooks happen!
 public class ReactorNettyHttpClientBraveTests extends ITSpringConfiguredReactorClient {
 
 	/**

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientBraveTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/WebClientBraveTests.java
@@ -16,71 +16,54 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client;
 
-import brave.http.HttpTracing;
-import brave.test.http.ITHttpAsyncClient;
+import java.net.URI;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
-import zipkin2.Callback;
 
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
+import org.springframework.boot.web.reactive.function.client.WebClientCustomizer;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
- * This runs Brave's integration tests without underlying instrumentation, which would
- * happen when a 3rd party client like Jetty is in use.
+ * This runs Brave's integration tests without underlying instrumentation, which is
+ * default in Spring Boot due to static instantiation in
+ * {@link org.springframework.boot.autoconfigure.web.reactive.function.client.ClientHttpConnectorConfiguration}.
  */
-// Function of spring context so that shutdown hooks happen!
-public class WebClientBraveTests
-		extends ITHttpAsyncClient<AnnotationConfigApplicationContext> {
+public class WebClientBraveTests extends ITSpringConfiguredReactorClient {
 
 	/**
 	 * This uses Spring to instrument the {@link WebClient} using a
 	 * {@link BeanPostProcessor}.
 	 */
-	@Override
-	protected AnnotationConfigApplicationContext newClient(int port) {
-		AnnotationConfigApplicationContext result = new AnnotationConfigApplicationContext();
-		result.registerBean(HttpTracing.class, () -> httpTracing);
-		result.register(WebClientBuilderConfiguration.class);
-		result.register(TraceWebClientBeanPostProcessor.class);
-		result.refresh();
-		return result;
+	public WebClientBraveTests() {
+		super(WebClientConfiguration.class, WebClientAutoConfiguration.class,
+				TraceWebClientBeanPostProcessor.class);
 	}
 
 	@Override
-	protected void closeClient(AnnotationConfigApplicationContext context) {
-		context.close(); // ensures shutdown hooks fire
-	}
-
-	@Override
-	protected void get(AnnotationConfigApplicationContext context,
-			String pathIncludingQuery) {
-		client(context).get().uri(pathIncludingQuery).exchange().block();
-	}
-
-	@Override
-	protected void post(AnnotationConfigApplicationContext context,
+	Mono<Integer> postMono(AnnotationConfigApplicationContext context,
 			String pathIncludingQuery, String body) {
-		client(context).post().uri(pathIncludingQuery).body(BodyInserters.fromValue(body))
-				.exchange().block();
+		return context.getBean(WebClient.Builder.class).build().post()
+				.uri(pathIncludingQuery).body(BodyInserters.fromValue(body)).exchange()
+				.map(ClientResponse::rawStatusCode);
 	}
 
 	@Override
-	protected void getAsync(AnnotationConfigApplicationContext context, String path,
-			Callback<Integer> callback) {
-		Mono<ClientResponse> request = client(context).get().uri(path).exchange();
-
-		TestHttpCallbackSubscriber.subscribe(request, ClientResponse::rawStatusCode,
-				callback);
+	Mono<Integer> getMono(AnnotationConfigApplicationContext context,
+			String pathIncludingQuery) {
+		return context.getBean(WebClient.Builder.class).build().get()
+				.uri(pathIncludingQuery).exchange().map(ClientResponse::rawStatusCode);
 	}
 
 	@Test
@@ -101,31 +84,19 @@ public class WebClientBraveTests
 	public void readsRequestAtResponseTime() {
 	}
 
-	WebClient client(AnnotationConfigApplicationContext context) {
-		return context.getBean(WebClient.Builder.class)
-				.baseUrl("http://127.0.0.1:" + server.getPort()).build();
-	}
-
-	/**
-	 * This fakes auto-configuration which wouldn't configure reactor's trace
-	 * instrumentation.
-	 */
 	@Configuration
-	static class WebClientBuilderConfiguration {
+	static class WebClientConfiguration {
 
+		/**
+		 * Normally, the HTTP connector would be statically initialized. This ensures the
+		 * {@link HttpClient} is configured for the mock endpoint.
+		 */
 		@Bean
-		HttpClient httpClient() {
-			return ReactorNettyHttpClientBraveTests.testHttpClient();
-		}
-
-		@Bean
-		ClientHttpConnector clientHttpConnector(HttpClient httpClient) {
-			return new ReactorClientHttpConnector(httpClient);
-		}
-
-		@Bean
-		WebClient.Builder webClientBuilder(ClientHttpConnector clientHttpConnector) {
-			return WebClient.builder().clientConnector(clientHttpConnector);
+		@Order(0)
+		public WebClientCustomizer clientConnectorCustomizer(HttpClient httpClient,
+				URI baseUrl) {
+			return (builder) -> builder.baseUrl(baseUrl.toString())
+					.clientConnector(new ReactorClientHttpConnector(httpClient));
 		}
 
 	}


### PR DESCRIPTION
in order to test typical concerns common to all reactor based clients, this makes a base type. Afterwards, we can do things like canceled subscriptions and make sure both WebClient and Reactor's HttpClient (both of which are pinned to reactor's types) get tested.