### PR TITLE
Updates to latest brave and removes all static thread local use

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -33,7 +33,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<spring-boot.version>2.2.5.RELEASE</spring-boot.version>
-		<brave.version>5.10.2</brave.version>
+		<brave.version>5.10.3-SNAPSHOT</brave.version>
 		<okhttp.version>3.14.6</okhttp.version>
 	</properties>
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -33,7 +33,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<spring-boot.version>2.2.5.RELEASE</spring-boot.version>
-		<brave.version>5.10.3-SNAPSHOT</brave.version>
+		<brave.version>5.11.0</brave.version>
 		<okhttp.version>3.14.6</okhttp.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
 		<spring-cloud-stream.version>Horsham.SR3</spring-cloud-stream.version>
 		<spring-cloud-netflix.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-openfeign.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-openfeign.version>
-		<brave.version>5.10.2</brave.version>
+		<brave.version>5.10.3-SNAPSHOT</brave.version>
 		<spring-security-boot-autoconfigure.version>2.1.7.RELEASE</spring-security-boot-autoconfigure.version>
 		<spring-cloud-aws.version>2.2.1.RELEASE</spring-cloud-aws.version>
 		<disable.nohttp.checks>false</disable.nohttp.checks>

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
 		<spring-cloud-stream.version>Horsham.SR3</spring-cloud-stream.version>
 		<spring-cloud-netflix.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 		<spring-cloud-openfeign.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-openfeign.version>
-		<brave.version>5.10.3-SNAPSHOT</brave.version>
+		<brave.version>5.11.0</brave.version>
 		<spring-security-boot-autoconfigure.version>2.1.7.RELEASE</spring-security-boot-autoconfigure.version>
 		<spring-cloud-aws.version>2.2.1.RELEASE</spring-cloud-aws.version>
 		<disable.nohttp.checks>false</disable.nohttp.checks>

--- a/spring-cloud-sleuth-core/pom.xml
+++ b/spring-cloud-sleuth-core/pom.xml
@@ -219,7 +219,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.zipkin.brave</groupId>
-			<artifactId>brave-context-log4j2</artifactId>
+			<artifactId>brave-context-slf4j</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.zipkin.brave</groupId>

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
@@ -49,7 +49,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 		this.contextRunner.withPropertyValues("spring.sleuth.baggage-keys=my-baggage")
 				.run((context) -> {
 					BDDAssertions.then(context.getBean(Propagation.Factory.class))
-							.hasFieldOrPropertyWithValue("delegate",
+							.hasFieldOrPropertyWithValue("delegate.delegate",
 									B3Propagation.FACTORY);
 				});
 	}
@@ -81,7 +81,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 				.withUserConfiguration(CustomPropagationFactoryBuilderConfig.class)
 				.run((context) -> {
 					BDDAssertions.then(context.getBean(Propagation.Factory.class))
-							.hasFieldOrPropertyWithValue("delegate",
+							.hasFieldOrPropertyWithValue("delegate.delegate",
 									B3SinglePropagation.FACTORY);
 				});
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/documentation/SpringCloudSleuthDocTests.java
@@ -27,10 +27,10 @@ import java.util.concurrent.Future;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.sampler.Sampler;
 import org.assertj.core.api.BDDAssertions;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -55,9 +55,9 @@ public class SpringCloudSleuthDocTests {
 
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.sampler(Sampler.ALWAYS_SAMPLE).spanReporter(this.reporter).build();
 
 	Tracer tracer = this.tracing.tracer();
@@ -65,6 +65,12 @@ public class SpringCloudSleuthDocTests {
 	@Before
 	public void setup() {
 		this.reporter.clear();
+	}
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskSchedulerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskSchedulerTests.java
@@ -24,8 +24,8 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,9 +43,9 @@ import org.springframework.util.ErrorHandler;
 @RunWith(MockitoJUnitRunner.class)
 public class LazyTraceThreadPoolTaskSchedulerTests {
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(currentTraceContext)
 			.build();
 
 	@Mock
@@ -60,6 +60,13 @@ public class LazyTraceThreadPoolTaskSchedulerTests {
 	public void setup() {
 		this.executor = new LazyTraceThreadPoolTaskScheduler(beanFactory(),
 				this.delegate);
+	}
+
+	@After
+	public void close() {
+		this.executor.shutdown();
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	BeanFactory beanFactory() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncAspectTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncAspectTest.java
@@ -17,11 +17,11 @@
 package org.springframework.cloud.sleuth.instrument.async;
 
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.assertj.core.api.BDDAssertions;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.BDDMockito;
@@ -35,11 +35,11 @@ import org.springframework.cloud.sleuth.util.ArrayListSpanReporter;
  */
 public class TraceAsyncAspectTest {
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	ProceedingJoinPoint point = Mockito.mock(ProceedingJoinPoint.class);
@@ -52,6 +52,12 @@ public class TraceAsyncAspectTest {
 				.willReturn(TraceAsyncAspectTest.class.getMethod("setup"));
 		BDDMockito.given(this.point.getSignature()).willReturn(signature);
 		BDDMockito.given(this.point.getTarget()).willReturn("");
+	}
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	// Issue#926

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncListenableTaskExecutorTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncListenableTaskExecutorTest.java
@@ -23,10 +23,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import org.assertj.core.api.BDDAssertions;
 import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Test;
 
 import org.springframework.core.task.AsyncListenableTaskExecutor;
@@ -39,15 +39,21 @@ public class TraceAsyncListenableTaskExecutorTest {
 
 	AsyncListenableTaskExecutor delegate = new SimpleAsyncTaskExecutor();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(currentTraceContext)
 			.build();
 
 	Tracer tracer = this.tracing.tracer();
 
 	TraceAsyncListenableTaskExecutor traceAsyncListenableTaskExecutor = new TraceAsyncListenableTaskExecutor(
 			this.delegate, this.tracing);
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
+	}
 
 	@Test
 	public void should_submit_listenable_trace_runnable() throws Exception {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceCallableTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceCallableTests.java
@@ -23,8 +23,7 @@ import java.util.concurrent.Executors;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,20 +40,21 @@ public class TraceCallableTests {
 
 	ExecutorService executor = Executors.newSingleThreadExecutor();
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	Tracer tracer = this.tracing.tracer();
 
 	@After
 	public void clean() {
+		this.executor.shutdown();
 		this.tracing.close();
 		this.reporter.clear();
-		this.executor.shutdown();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnableTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnableTests.java
@@ -23,8 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,20 +40,21 @@ public class TraceRunnableTests {
 
 	ExecutorService executor = Executors.newSingleThreadExecutor();
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	Tracer tracer = this.tracing.tracer();
 
 	@After
 	public void clean() {
+		this.executor.shutdown();
 		this.tracing.close();
 		this.reporter.clear();
-		this.executor.shutdown();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorServiceTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorServiceTests.java
@@ -29,11 +29,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import brave.ScopedSpan;
-import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.TraceContext;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.After;
 import org.junit.Before;
@@ -65,11 +64,11 @@ public class TraceableExecutorServiceTests {
 
 	ExecutorService traceManagerableExecutorService;
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	Tracer tracer = this.tracing.tracer();
@@ -85,12 +84,11 @@ public class TraceableExecutorServiceTests {
 	}
 
 	@After
-	public void tearDown() throws Exception {
+	public void close() {
 		this.traceManagerableExecutorService.shutdown();
 		this.executorService.shutdown();
-		if (Tracing.current() != null) {
-			Tracing.current().close();
-		}
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	@Test
@@ -244,9 +242,9 @@ public class TraceableExecutorServiceTests {
 
 		@Override
 		public void run() {
-			Span span = Tracing.currentTracer().currentSpan();
-			this.traceIds.add(span.context().traceId());
-			this.spanIds.add(span.context().spanId());
+			TraceContext context = currentTraceContext.get();
+			this.traceIds.add(context.traceId());
+			this.spanIds.add(context.spanId());
 		}
 
 		void clear() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorServiceTest.java
@@ -22,8 +22,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,9 +48,9 @@ import static org.mockito.Mockito.never;
 @RunWith(MockitoJUnitRunner.class)
 public class TraceableScheduledExecutorServiceTest {
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.build();
 
 	@Mock
@@ -65,6 +65,12 @@ public class TraceableScheduledExecutorServiceTest {
 	@Before
 	public void setup() {
 		beanFactory();
+	}
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/CircuitBreakerTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/CircuitBreakerTests.java
@@ -22,10 +22,10 @@ import brave.ScopedSpan;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.sampler.Sampler;
 import org.assertj.core.api.BDDAssertions;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,11 +36,11 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 public class CircuitBreakerTests {
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).sampler(Sampler.ALWAYS_SAMPLE).build();
 
 	Tracer tracer = this.tracing.tracer();
@@ -48,6 +48,12 @@ public class CircuitBreakerTests {
 	@Before
 	public void setup() {
 		this.reporter.clear();
+	}
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyTest.java
@@ -22,8 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import brave.Tracing;
 import brave.propagation.CurrentTraceContext;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import com.netflix.hystrix.HystrixThreadPoolKey;
 import com.netflix.hystrix.HystrixThreadPoolProperties;
@@ -54,9 +53,9 @@ public class SleuthHystrixConcurrencyStrategyTest {
 
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	@Before
@@ -64,6 +63,7 @@ public class SleuthHystrixConcurrencyStrategyTest {
 	public void setup() {
 		HystrixPlugins.reset();
 		this.reporter.clear();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpClientParserTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpClientParserTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import brave.SpanCustomizer;
 import brave.http.HttpClientRequest;
 import brave.http.HttpRequest;
+import brave.propagation.TraceContext;
 import org.junit.Test;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -38,6 +39,8 @@ import static org.mockito.Mockito.when;
 @Deprecated
 public class SleuthHttpClientParserTests {
 
+	private TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).build();
+
 	private TraceKeys traceKeys = new TraceKeys();
 
 	private TestSpan span = new TestSpan();
@@ -50,7 +53,7 @@ public class SleuthHttpClientParserTests {
 		when(request.method()).thenReturn("GET");
 		when(request.url()).thenReturn("https://foo/" + bigName());
 
-		parser.parse(request, null, span);
+		parser.parse(request, context, span);
 
 		then(this.span.name).hasSize(50);
 	}
@@ -70,7 +73,7 @@ public class SleuthHttpClientParserTests {
 		when(request.url()).thenReturn("http://localhost/?foo=bar");
 		when(request.header("host")).thenReturn("localhost");
 
-		parser.parse(request, null, span);
+		parser.parse(request, context, span);
 
 		then(this.span.tags).containsEntry("http.url", "http://localhost/?foo=bar")
 				.containsEntry("http.host", "localhost").containsEntry("http.path", "/")
@@ -84,7 +87,7 @@ public class SleuthHttpClientParserTests {
 		HttpRequest request = mock(HttpRequest.class);
 		when(request.header("x-foo")).thenReturn("bar");
 
-		parser.parse(request, null, span);
+		parser.parse(request, context, span);
 
 		then(this.span.tags).containsEntry("http.x-foo", "bar");
 	}
@@ -131,7 +134,7 @@ public class SleuthHttpClientParserTests {
 			@Override
 			public void header(String name, String value) {
 			}
-		}, null, this.span);
+		}, context, this.span);
 
 		then(this.span.tags).containsEntry("http.user-agent", "Test")
 				.containsEntry("http.accept", "'text/plain','text/xml'")

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceResponseHttpHeadersFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceResponseHttpHeadersFilterTests.java
@@ -18,9 +18,9 @@ package org.springframework.cloud.sleuth.instrument.web.client;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import org.assertj.core.api.BDDAssertions;
+import org.junit.After;
 import org.junit.Test;
 
 import org.springframework.cloud.gateway.filter.headers.HttpHeadersFilter;
@@ -31,14 +31,20 @@ import org.springframework.mock.web.server.MockServerWebExchange;
 
 public class TraceResponseHttpHeadersFilterTests {
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	HttpTracing httpTracing = HttpTracing.newBuilder(this.tracing).build();
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
+	}
 
 	@Test
 	public void should_not_report_span_when_no_span_was_present_in_attribute() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignRetriesTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/FeignRetriesTests.java
@@ -23,8 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import feign.Client;
 import feign.Feign;
 import feign.FeignException;
@@ -61,11 +60,11 @@ public class FeignRetriesTests {
 	@Mock
 	BeanFactory beanFactory;
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	HttpTracing httpTracing = HttpTracing.newBuilder(this.tracing).build();
@@ -75,6 +74,12 @@ public class FeignRetriesTests {
 	public void setup() {
 		BDDMockito.given(this.beanFactory.getBean(HttpTracing.class))
 				.willReturn(this.httpTracing);
+	}
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignAspectTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignAspectTests.java
@@ -16,14 +16,12 @@
 
 package org.springframework.cloud.sleuth.instrument.web.client.feign;
 
-import java.io.IOException;
-
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import feign.Client;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,9 +52,9 @@ public class TraceFeignAspectTests {
 	@Mock
 	TraceLoadBalancerFeignClient traceLoadBalancerFeignClient;
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(currentTraceContext)
 			.build();
 
 	HttpTracing httpTracing = HttpTracing.newBuilder(this.tracing).build();
@@ -67,11 +65,16 @@ public class TraceFeignAspectTests {
 	public void setup() {
 		this.traceFeignAspect = new TraceFeignAspect(this.beanFactory) {
 			@Override
-			Object executeTraceFeignClient(Object bean, ProceedingJoinPoint pjp)
-					throws IOException {
+			Object executeTraceFeignClient(Object bean, ProceedingJoinPoint pjp) {
 				return null;
 			}
 		};
+	}
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClientTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClientTests.java
@@ -25,11 +25,11 @@ import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import feign.Client;
 import feign.Request;
 import org.assertj.core.api.BDDAssertions;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,11 +49,11 @@ public class TracingFeignClientTests {
 
 	Request.Options options = new Request.Options();
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	List<zipkin2.Span> spans = new ArrayList<>();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(currentTraceContext)
 			.spanReporter(spans::add).build();
 
 	Tracer tracer = this.tracing.tracer();
@@ -68,6 +68,12 @@ public class TracingFeignClientTests {
 	@Before
 	public void setup() {
 		this.traceFeignClient = TracingFeignClient.create(this.httpTracing, this.client);
+	}
+
+	@After
+	public void close() {
+		this.tracing.close();
+		this.currentTraceContext.close();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/zuul/TracePostZuulFilterTests.java
@@ -25,8 +25,7 @@ import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
 import brave.http.HttpTracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import com.netflix.zuul.context.RequestContext;
 import com.netflix.zuul.monitoring.TracerFactory;
 import org.junit.After;
@@ -55,11 +54,11 @@ public class TracePostZuulFilterTests {
 	@Mock
 	HttpServletResponse httpServletResponse;
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	HttpTracing httpTracing = HttpTracing.newBuilder(this.tracing).build();
@@ -71,7 +70,8 @@ public class TracePostZuulFilterTests {
 	@After
 	public void clean() {
 		RequestContext.getCurrentContext().unset();
-		this.httpTracing.tracing().close();
+		this.tracing.close();
+		this.currentTraceContext.close();
 		RequestContext.testSetCurrentContext(null);
 	}
 

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -31,8 +31,8 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<brave.version>5.10.3-SNAPSHOT</brave.version>
-		<brave.opentracing.version>0.35.2-SNAPSHOT</brave.opentracing.version>
+		<brave.version>5.11.0</brave.version>
+		<brave.opentracing.version>0.36.0</brave.opentracing.version>
 		<grpc.spring.boot.version>3.4.1</grpc.spring.boot.version>
 	</properties>
 	<dependencyManagement>

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -31,8 +31,8 @@
 	<name>spring-cloud-sleuth-dependencies</name>
 	<description>Spring Cloud Sleuth Dependencies</description>
 	<properties>
-		<brave.version>5.10.2</brave.version>
-		<brave.opentracing.version>0.35.1</brave.opentracing.version>
+		<brave.version>5.10.3-SNAPSHOT</brave.version>
+		<brave.opentracing.version>0.35.2-SNAPSHOT</brave.opentracing.version>
 		<grpc.spring.boot.version>3.4.1</grpc.spring.boot.version>
 	</properties>
 	<dependencyManagement>

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 
-import brave.Tracing;
 import brave.sampler.Sampler;
 import feign.Client;
 import feign.Request;
@@ -67,9 +66,6 @@ public class ManuallyCreatedLoadBalancerFeignClientTests {
 
 	@Autowired
 	ArrayListSpanReporter reporter;
-
-	@Autowired
-	Tracing tracer;
 
 	@Before
 	public void open() {

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
@@ -20,7 +20,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 
-import brave.Tracing;
 import brave.sampler.Sampler;
 import feign.Client;
 import feign.Request;
@@ -71,9 +70,6 @@ public class Issue502Tests {
 
 	@Autowired
 	ArrayListSpanReporter reporter;
-
-	@Autowired
-	Tracing tracer;
 
 	@Before
 	public void open() {

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/ITTracingChannelInterceptorTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/ITTracingChannelInterceptorTests.java
@@ -26,8 +26,7 @@ import javax.annotation.PreDestroy;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,10 +154,13 @@ public class ITTracingChannelInterceptorTests implements MessageHandler {
 		}
 
 		@Bean
+		StrictCurrentTraceContext currentTraceContext() {
+			return StrictCurrentTraceContext.create();
+		}
+
+		@Bean
 		Tracing tracing() {
-			return Tracing.newBuilder()
-					.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-							.addScopeDecorator(StrictScopeDecorator.create()).build())
+			return Tracing.newBuilder().currentTraceContext(currentTraceContext())
 					.spanReporter(spans()::add).build();
 		}
 

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
@@ -22,9 +22,9 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import brave.Tracing;
 import brave.http.HttpRequest;
 import brave.http.HttpRequestParser;
+import brave.propagation.CurrentTraceContext;
 import brave.sampler.Sampler;
 import brave.sampler.SamplerFunction;
 import org.assertj.core.api.BDDAssertions;
@@ -65,6 +65,9 @@ import static org.assertj.core.api.BDDAssertions.then;
 public class TraceFilterWebIntegrationTests {
 
 	@Autowired
+	CurrentTraceContext currentTraceContext;
+
+	@Autowired
 	BlockingQueueSpanReporter reporter;
 
 	@Autowired
@@ -84,7 +87,7 @@ public class TraceFilterWebIntegrationTests {
 		new RestTemplate().getForObject("http://localhost:" + port() + "/good",
 				String.class);
 
-		then(Tracing.current().tracer().currentSpan()).isNull();
+		then(this.currentTraceContext.get()).isNull();
 		then(this.reporter.takeSpan().tags()).containsKey("http.url");
 	}
 
@@ -98,7 +101,7 @@ public class TraceFilterWebIntegrationTests {
 		catch (Exception e) {
 		}
 
-		then(Tracing.current().tracer().currentSpan()).isNull();
+		then(this.currentTraceContext.get()).isNull();
 		Span fromFirstTraceFilterFlow = this.reporter.takeSpan();
 		then(fromFirstTraceFilterFlow.tags()).containsEntry("http.method", "GET")
 				.containsEntry("mvc.controller.class", "ExceptionThrowingController")
@@ -124,7 +127,7 @@ public class TraceFilterWebIntegrationTests {
 		catch (HttpClientErrorException e) {
 		}
 
-		then(Tracing.current().tracer().currentSpan()).isNull();
+		then(this.currentTraceContext.get()).isNull();
 		Span span = this.reporter.takeSpan();
 		then(span.kind().ordinal()).isEqualTo(Span.Kind.SERVER.ordinal());
 		then(span.tags()).containsEntry("http.status_code", "400");

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/RestTemplateTraceAspectIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/RestTemplateTraceAspectIntegrationTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
 import brave.sampler.Sampler;
 import brave.spring.web.TracingAsyncClientHttpRequestInterceptor;
 import org.awaitility.Awaitility;
@@ -75,6 +76,9 @@ public class RestTemplateTraceAspectIntegrationTests {
 
 	@Autowired
 	AspectTestingController controller;
+
+	@Autowired
+	CurrentTraceContext currentTraceContext;
 
 	@Autowired
 	Tracing tracer;
@@ -142,7 +146,7 @@ public class RestTemplateTraceAspectIntegrationTests {
 			throws Exception {
 		whenARequestIsSentToASyncEndpointThatShouldBeFilteredOut();
 
-		then(Tracing.current().tracer().currentSpan()).isNull();
+		then(this.currentTraceContext.get()).isNull();
 		then(this.reporter.getSpans()).isEmpty();
 	}
 

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exceptionresolver/Issue585Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exceptionresolver/Issue585Tests.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import brave.Span;
 import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
 import brave.sampler.Sampler;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.junit.Test;
@@ -57,6 +58,9 @@ public class Issue585Tests {
 	TestRestTemplate testRestTemplate = new TestRestTemplate();
 
 	@Autowired
+	CurrentTraceContext currentTraceContext;
+
+	@Autowired
 	ArrayListSpanReporter reporter;
 
 	@LocalServerPort
@@ -68,7 +72,7 @@ public class Issue585Tests {
 				"http://localhost:" + this.port + "/sleuthtest?greeting=foo",
 				String.class);
 
-		then(Tracing.current().tracer().currentSpan()).isNull();
+		then(this.currentTraceContext.get()).isNull();
 		then(entity.getStatusCode().value()).isEqualTo(500);
 		then(this.reporter.getSpans().get(0).tags()).containsEntry("custom", "tag")
 				.containsKeys("error");

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.CurrentTraceContext.Scope;
-import brave.propagation.StrictScopeDecorator;
+import brave.propagation.StrictCurrentTraceContext;
 import brave.propagation.TraceContext;
 import org.assertj.core.presentation.StandardRepresentation;
 import org.junit.After;
@@ -59,8 +59,7 @@ public class ScopePassingSpanSubscriberTests {
 				Objects::toString);
 	}
 
-	final CurrentTraceContext currentTraceContext = CurrentTraceContext.Default
-			.newBuilder().addScopeDecorator(StrictScopeDecorator.create()).build();
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
 
 	TraceContext context = TraceContext.newBuilder().traceId(1).spanId(1).sampled(true)
 			.build();
@@ -128,6 +127,7 @@ public class ScopePassingSpanSubscriberTests {
 	@After
 	public void close() {
 		springContext.close();
+		currentTraceContext.close();
 	}
 
 	@Test

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/ITSpringConfiguredReactorClient.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.sleuth.instrument.web.client;
 import java.net.URI;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
 import brave.http.HttpTracing;
 import brave.propagation.CurrentTraceContext;
@@ -33,7 +34,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.publisher.BaseSubscriber;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
-import zipkin2.Callback;
+import zipkin2.Span;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -99,8 +100,8 @@ abstract class ITSpringConfiguredReactorClient
 	}
 
 	@Override
-	final protected void getAsync(AnnotationConfigApplicationContext context, String path,
-			Callback<Integer> callback) {
+	final protected void get(AnnotationConfigApplicationContext context, String path,
+			BiConsumer<Integer, Throwable> callback) {
 		TestHttpCallbackSubscriber.subscribe(getMono(context, path), callback);
 	}
 
@@ -160,7 +161,7 @@ abstract class ITSpringConfiguredReactorClient
 
 		assertThat(server.getRequestCount()).isOne();
 
-		takeClientSpanWithError("CANCELLED");
+		reporter.takeRemoteSpanWithError(Span.Kind.CLIENT, "CANCELLED");
 	}
 
 }

--- a/tests/spring-cloud-sleuth-instrumentation-rxjava-tests/src/test/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersHookTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-rxjava-tests/src/test/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersHookTests.java
@@ -28,8 +28,7 @@ import java.util.concurrent.ThreadFactory;
 
 import brave.Tracer;
 import brave.Tracing;
-import brave.propagation.StrictScopeDecorator;
-import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,11 +51,11 @@ public class SleuthRxJavaSchedulersHookTests {
 
 	List<String> threadsToIgnore = new ArrayList<>();
 
+	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();
+
 	ArrayListSpanReporter reporter = new ArrayListSpanReporter();
 
-	Tracing tracing = Tracing.newBuilder()
-			.currentTraceContext(ThreadLocalCurrentTraceContext.newBuilder()
-					.addScopeDecorator(StrictScopeDecorator.create()).build())
+	Tracing tracing = Tracing.newBuilder().currentTraceContext(this.currentTraceContext)
 			.spanReporter(this.reporter).build();
 
 	Tracer tracer = this.tracing.tracer();
@@ -65,6 +64,7 @@ public class SleuthRxJavaSchedulersHookTests {
 	public void clean() {
 		this.tracing.close();
 		this.reporter.clear();
+		this.currentTraceContext.close();
 	}
 
 	@Before


### PR DESCRIPTION
This moves to the pending brave release. This passes the same tests
locally as before this commit.

feign has some problems on 2.2.x so I skipped like so:

```
./mvnw clean install -pl -:spring-cloud-sleuth-instrumentation-feign-tests
```