### PR TITLE
Fixes bugs in skip pattern code and Feign tests

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternSampler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternSampler.java
@@ -27,18 +27,12 @@ import brave.sampler.SamplerFunction;
  * @author Marcin Grzejszczak
  * @since 2.0.0
  */
-class SkipPatternHttpServerSampler implements SamplerFunction<HttpRequest> {
-
-	private final SkipPatternProvider provider;
+abstract class SkipPatternSampler implements SamplerFunction<HttpRequest> {
 
 	private Pattern pattern;
 
-	SkipPatternHttpServerSampler(SkipPatternProvider provider) {
-		this.provider = provider;
-	}
-
 	@Override
-	public Boolean trySample(HttpRequest request) {
+	public final Boolean trySample(HttpRequest request) {
 		String url = request.path();
 		boolean shouldSkip = pattern().matcher(url).matches();
 		if (shouldSkip) {
@@ -47,9 +41,11 @@ class SkipPatternHttpServerSampler implements SamplerFunction<HttpRequest> {
 		return null;
 	}
 
+	abstract Pattern getPattern();
+
 	private Pattern pattern() {
 		if (this.pattern == null) {
-			this.pattern = this.provider.skipPattern();
+			this.pattern = getPattern();
 		}
 		return this.pattern;
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
@@ -96,7 +96,7 @@ public class SleuthWebProperties {
 	}
 
 	public void setSkipPattern(String skipPattern) {
-		this.skipPattern = skipPattern;
+		this.skipPattern = emptyToNull(skipPattern);
 	}
 
 	public String getAdditionalSkipPattern() {
@@ -104,7 +104,7 @@ public class SleuthWebProperties {
 	}
 
 	public void setAdditionalSkipPattern(String additionalSkipPattern) {
-		this.additionalSkipPattern = additionalSkipPattern;
+		this.additionalSkipPattern = emptyToNull(additionalSkipPattern);
 	}
 
 	public int getFilterOrder() {
@@ -149,6 +149,13 @@ public class SleuthWebProperties {
 		this.client = client;
 	}
 
+	static String emptyToNull(String skipPattern) {
+		if (skipPattern != null && skipPattern.isEmpty()) {
+			skipPattern = null; // otherwise this would skip paths named ""!
+		}
+		return skipPattern;
+	}
+
 	/**
 	 * Web client properties.
 	 *
@@ -159,7 +166,7 @@ public class SleuthWebProperties {
 		/**
 		 * Pattern for URLs that should be skipped in client side tracing.
 		 */
-		private String skipPattern = "";
+		private String skipPattern;
 
 		/**
 		 * Enable interceptor injecting into
@@ -180,7 +187,7 @@ public class SleuthWebProperties {
 		}
 
 		public void setSkipPattern(String skipPattern) {
-			this.skipPattern = skipPattern;
+			this.skipPattern = emptyToNull(skipPattern);
 		}
 
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignAspect.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignAspect.java
@@ -53,9 +53,7 @@ class TraceFeignAspect {
 			log.debug("Executing feign client via TraceFeignAspect");
 		}
 		if (bean != wrappedBean) {
-			// NOTE: in master(3813cf9dd47f98db0e075412abbffbd9d6742974),
-			// this is executeTraceFeignClient(wrappedBean, pjp)
-			return executeTraceFeignClient(bean, pjp);
+			return executeTraceFeignClient(wrappedBean, pjp);
 		}
 		return pjp.proceed();
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignContext.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignContext.java
@@ -44,7 +44,10 @@ class TraceFeignContext extends FeignContext {
 	@SuppressWarnings("unchecked")
 	public <T> T getInstance(String name, Class<T> type) {
 		T object = this.delegate.getInstance(name, type);
-		return (T) this.traceFeignObjectWrapper.wrap(object);
+		if (object != null) {
+			return (T) this.traceFeignObjectWrapper.wrap(object);
+		}
+		return null;
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
@@ -60,6 +60,13 @@ public class SkipPatternProviderConfigTest {
 					TraceAutoConfiguration.class, TraceWebAutoConfiguration.class));
 
 	@Test
+	public void should_return_null_when_cleared() throws Exception {
+		contextRunner.withPropertyValues("spring.sleuth.web.skip-pattern")
+				.run(context -> then(context.getBean("sleuthSkipPatternProvider"))
+						.hasToString("null"));
+	}
+
+	@Test
 	public void should_pick_skip_pattern_from_sleuth_properties() throws Exception {
 		contextRunner.withPropertyValues("spring.sleuth.web.skip-pattern=foo.*|bar.*")
 				.run(context -> {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfigurationTests.java
@@ -25,6 +25,7 @@ import brave.http.HttpSampler;
 import brave.http.HttpServerParser;
 import brave.http.HttpTracing;
 import brave.sampler.SamplerFunction;
+import brave.sampler.SamplerFunctions;
 import org.junit.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -40,13 +41,25 @@ import static org.assertj.core.api.BDDAssertions.then;
 public class TraceHttpAutoConfigurationTests {
 
 	@Test
-	public void defaultsToSkipPatternHttpClientSampler() {
+	public void defaultsClientSamplerToDefer() {
 		contextRunner().run((context) -> {
 			SamplerFunction<HttpRequest> clientSampler = context
 					.getBean(HttpTracing.class).clientRequestSampler();
 
-			then(clientSampler).isInstanceOf(SkipPatternHttpClientSampler.class);
+			then(clientSampler).isSameAs(SamplerFunctions.deferDecision());
 		});
+	}
+
+	@Test
+	public void configuresClientSkipPattern() throws Exception {
+		contextRunner()
+				.withPropertyValues("spring.sleuth.web.client.skip-pattern=foo.*|bar.*")
+				.run((context) -> {
+					SamplerFunction<HttpRequest> clientSampler = context
+							.getBean(HttpTracing.class).clientRequestSampler();
+
+					then(clientSampler).isInstanceOf(SkipPatternHttpClientSampler.class);
+				});
 	}
 
 	@Test
@@ -83,13 +96,24 @@ public class TraceHttpAutoConfigurationTests {
 	}
 
 	@Test
-	public void defaultsToSkipPatternHttpServerSampler() {
+	public void defaultsServerSamplerToSkipPattern() {
 		contextRunner().run((context) -> {
 			SamplerFunction<HttpRequest> serverSampler = context
 					.getBean(HttpTracing.class).serverRequestSampler();
 
 			then(serverSampler).isInstanceOf(SkipPatternHttpServerSampler.class);
 		});
+	}
+
+	@Test
+	public void defaultsServerSamplerToDeferWhenSkipPatternCleared() {
+		contextRunner().withPropertyValues("spring.sleuth.web.skip-pattern")
+				.run((context) -> {
+					SamplerFunction<HttpRequest> clientSampler = context
+							.getBean(HttpTracing.class).serverRequestSampler();
+
+					then(clientSampler).isSameAs(SamplerFunctions.deferDecision());
+				});
 	}
 
 	@Test

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
@@ -54,8 +54,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class,
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "feign.hystrix.enabled=false",
-				"foo.ribbon.listOfServers=non.existing.url" })
+		properties = { "feign.hystrix.enabled=false" })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ManuallyCreatedLoadBalancerFeignClientTests {
 

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
@@ -53,8 +53,8 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class,
-		webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "feign.hystrix.enabled=false" })
+		webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+				"feign.hystrix.enabled=false", "ribbon.listOfServers=non.existing.url" })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ManuallyCreatedLoadBalancerFeignClientTests {
 
@@ -160,7 +160,7 @@ class MyDelegateClient implements Client {
 
 }
 
-@FeignClient(name = "foo", url = "https://non.existing.url")
+@FeignClient(name = "foo", url = "http://fooloadbalancer")
 interface MyNameRemote {
 
 	@RequestMapping(value = "/", method = RequestMethod.GET)

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125/ManuallyCreatedLoadBalancerFeignClientTests.java
@@ -53,8 +53,9 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class,
-		webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
-				"feign.hystrix.enabled=false", "ribbon.listOfServers=non.existing.url" })
+		webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "feign.hystrix.enabled=false",
+				"foo.ribbon.listOfServers=non.existing.url" })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ManuallyCreatedLoadBalancerFeignClientTests {
 
@@ -160,7 +161,7 @@ class MyDelegateClient implements Client {
 
 }
 
-@FeignClient(name = "foo", url = "http://fooloadbalancer")
+@FeignClient(name = "foo", url = "http://foo")
 interface MyNameRemote {
 
 	@RequestMapping(value = "/", method = RequestMethod.GET)

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
@@ -60,8 +60,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class,
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "feign.hystrix.enabled=false",
-				"foo.ribbon.listOfServers=non.existing.url" })
+		properties = { "feign.hystrix.enabled=false" })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ManuallyCreatedDelegateLoadBalancerFeignClientTests {
 

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 
-import brave.Tracing;
 import brave.sampler.Sampler;
 import feign.Client;
 import feign.Contract;
@@ -60,8 +59,8 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class,
-		webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		properties = { "feign.hystrix.enabled=false" })
+		webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+				"feign.hystrix.enabled=false", "ribbon.listOfServers=non.existing.url" })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ManuallyCreatedDelegateLoadBalancerFeignClientTests {
 
@@ -77,9 +76,6 @@ public class ManuallyCreatedDelegateLoadBalancerFeignClientTests {
 	@Autowired
 	ArrayListSpanReporter reporter;
 
-	@Autowired
-	Tracing tracer;
-
 	@Before
 	public void open() {
 		this.reporter.clear();
@@ -92,7 +88,6 @@ public class ManuallyCreatedDelegateLoadBalancerFeignClientTests {
 		then(this.myClient.wasCalled()).isTrue();
 		then(this.myDelegateClient.wasCalled()).isTrue();
 		then(response).isEqualTo("foo");
-		System.out.println("this.myclient.wascalled: " + this.myClient.wasCalled());
 		List<Span> spans = this.reporter.getSpans();
 		// retries
 		then(spans).hasSize(1);
@@ -194,7 +189,7 @@ class MyDelegateClient implements Client {
 
 }
 
-@FeignClient(name = "foo", url = "https://non.existing.url")
+@FeignClient(name = "foo", url = "http://fooloadbalancer")
 interface MyNameRemote {
 
 	@RequestMapping(value = "/", method = RequestMethod.GET)

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue1125delegates/ManuallyCreatedDelegateLoadBalancerFeignClientTests.java
@@ -59,8 +59,9 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class,
-		webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
-				"feign.hystrix.enabled=false", "ribbon.listOfServers=non.existing.url" })
+		webEnvironment = SpringBootTest.WebEnvironment.NONE,
+		properties = { "feign.hystrix.enabled=false",
+				"foo.ribbon.listOfServers=non.existing.url" })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class ManuallyCreatedDelegateLoadBalancerFeignClientTests {
 
@@ -133,8 +134,8 @@ class Application {
 	public MyNameRemote myNameRemote(Client client, Decoder decoder, Encoder encoder,
 			Contract contract) {
 		return Feign.builder().client(client).encoder(encoder).decoder(decoder)
-				.contract(contract).target(new HardCodedTarget<>(MyNameRemote.class,
-						"foo", "https://non.existing.url"));
+				.contract(contract)
+				.target(new HardCodedTarget<>(MyNameRemote.class, "foo", "http://foo"));
 	}
 
 	@Bean
@@ -189,7 +190,7 @@ class MyDelegateClient implements Client {
 
 }
 
-@FeignClient(name = "foo", url = "http://fooloadbalancer")
+@FeignClient(name = "foo", url = "http://foo")
 interface MyNameRemote {
 
 	@RequestMapping(value = "/", method = RequestMethod.GET)

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
@@ -85,7 +85,7 @@ public class Issue502Tests {
 		List<Span> spans = this.reporter.getSpans();
 		// retries
 		then(spans).hasSize(1);
-		then(spans.get(0).tags().get("http.path")).isEqualTo("/");
+		then(spans.get(0).tags().get("http.path")).isEqualTo("");
 	}
 
 }

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/java/org/springframework/cloud/sleuth/instrument/feign/issues/issue502/Issue502Tests.java
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-@FeignClient(name = "foo", url = "https://non.existing.url")
+@FeignClient(name = "foo", url = "http://foo")
 interface MyNameRemote {
 
 	@RequestMapping(value = "/", method = RequestMethod.GET)

--- a/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/resources/application.yml
+++ b/tests/spring-cloud-sleuth-instrumentation-feign-tests/src/test/resources/application.yml
@@ -2,6 +2,12 @@ hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds: 5000
 ribbon:
   ConnectTimeout: 3000
   ReadTimeout: 5000
+  eager-load:
+    enabled: true
+    clients: foo
+foo:
+  ribbon:
+    listOfServers: non.existing.url
 
 exceptionService.ribbon:
   MaxAutoRetries: 3


### PR DESCRIPTION
Before, the client sampler would only skip the path named ""! This was
the path used in one of the failing Feign tests, which made
troubleshooting like a murder mystery.


The "" is a regression in spring-cloud-openfeign noted below:
https://github.com/spring-cloud/spring-cloud-openfeign/pull/245/files#r403424379