### PR TITLE
Stops propagating Sleuth 1.x spring-messaging headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,13 +132,6 @@
 
 	<dependencyManagement>
 		<dependencies>
-			<!-- force latest reactor-netty -->
-			<dependency>
-				<groupId>io.projectreactor.netty</groupId>
-				<artifactId>reactor-netty</artifactId>
-				<version>0.9.6.RELEASE</version>
-				<optional>true</optional>
-			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-sleuth-dependencies</artifactId>

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/baggage/TraceBaggageAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/baggage/TraceBaggageAutoConfiguration.java
@@ -72,11 +72,16 @@ public class TraceBaggageAutoConfiguration {
 	 * To override the underlying context format, override this bean and set the delegate
 	 * to what you need. {@link BaggagePropagation.FactoryBuilder} will unwrap itself if
 	 * no fields are configured.
+	 *
+	 * <p>
+	 * This will use {@link B3Propagation.Format#SINGLE_NO_PARENT} for non-remote spans,
+	 * such as for messaging. Note: it will still parse incoming multi-header spans.
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	BaggagePropagation.FactoryBuilder baggagePropagationFactoryBuilder() {
-		return BaggagePropagation.newFactoryBuilder(B3Propagation.FACTORY);
+		return BaggagePropagation.newFactoryBuilder(B3Propagation.newFactoryBuilder()
+				.injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build());
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessageHeaders.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessageHeaders.java
@@ -23,7 +23,9 @@ package org.springframework.cloud.sleuth.instrument.messaging;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.4
+ * @deprecated Since 3.0 these headers should not be used anymore as "b3" is sent instead
  */
+@Deprecated
 public final class TraceMessageHeaders {
 
 	/**

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.sleuth.autoconfig;
 
+import brave.Tracing;
 import brave.baggage.BaggagePropagation;
 import brave.propagation.B3Propagation;
 import brave.propagation.B3SinglePropagation;
@@ -41,8 +42,8 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 	@Test
 	public void stillCreatesDefault() {
 		this.contextRunner.run((context) -> {
-			BDDAssertions.then(context.getBean(Propagation.Factory.class))
-					.isEqualTo(B3Propagation.FACTORY);
+			BDDAssertions.then(context.getBean(Tracing.class).propagation())
+					.isInstanceOf(B3Propagation.class);
 		});
 	}
 
@@ -52,8 +53,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 				.withPropertyValues("spring.sleuth.baggage.remote-fields=country-code")
 				.run((context) -> {
 					BDDAssertions.then(context.getBean(Propagation.Factory.class))
-							.hasFieldOrPropertyWithValue("delegate",
-									B3Propagation.FACTORY);
+							.extracting("delegate").isNotNull();
 				});
 	}
 
@@ -61,8 +61,8 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 	public void defaultValueUsedWhenApplicationNameNotSet() {
 		this.contextRunner.withPropertyValues("spring.application.name=")
 				.run((context) -> {
-					BDDAssertions.then(context.getBean(Propagation.Factory.class))
-							.isEqualTo(B3Propagation.FACTORY);
+					BDDAssertions.then(context.getBean(Tracing.class).propagation())
+							.isInstanceOf(B3Propagation.class);
 				});
 	}
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/MessageHeaderPropagationTest.java
@@ -56,26 +56,26 @@ public class MessageHeaderPropagationTest
 	@Test
 	public void testGetByteArrayValue() {
 		MessageHeaderAccessor carrier = carrier();
-		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124".getBytes());
-		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124000000".getBytes());
-		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "X-B3-TraceId");
-		assertThat(value).isEqualTo("48485a3953bb6124000000");
+		carrier.setHeader("b3", "48485a3953bb6124-1234".getBytes());
+		carrier.setHeader("b3", "48485a3953bb6124000000-1234".getBytes());
+		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "b3");
+		assertThat(value).isEqualTo("48485a3953bb6124000000-1234");
 	}
 
 	@Test
 	public void testGetStringValue() {
 		MessageHeaderAccessor carrier = carrier();
-		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124");
-		carrier.setHeader("X-B3-TraceId", "48485a3953bb61240000000");
-		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "X-B3-TraceId");
-		assertThat(value).isEqualTo("48485a3953bb61240000000");
+		carrier.setHeader("B3", "48485a3953bb6124-1234");
+		carrier.setHeader("B3", "48485a3953bb61240000000-1234");
+		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "B3");
+		assertThat(value).isEqualTo("48485a3953bb61240000000-1234");
 	}
 
 	@Test
 	public void testGetNullValue() {
 		MessageHeaderAccessor carrier = carrier();
-		carrier.setHeader("X-B3-TraceId", "48485a3953bb6124");
-		carrier.setHeader("X-B3-TraceId", "48485a3953bb61240000000");
+		carrier.setHeader("B3", "48485a3953bb6124-1234");
+		carrier.setHeader("B3", "48485a3953bb61240000000-1234");
 		String value = MessageHeaderPropagation.INSTANCE.get(carrier, "non existent key");
 		assertThat(value).isNull();
 	}
@@ -85,7 +85,7 @@ public class MessageHeaderPropagationTest
 		MessageHeaderAccessor carrier = carrier();
 		carrier.setHeader(NativeMessageHeaderAccessor.NATIVE_HEADERS,
 				"{spanTraceId=[123], spanId=[456], spanSampled=[0]}");
-		MessageHeaderPropagation.INSTANCE.get(carrier, "X-B3-SpanId");
+		MessageHeaderPropagation.INSTANCE.get(carrier, "b3");
 	}
 
 	@Test
@@ -94,7 +94,7 @@ public class MessageHeaderPropagationTest
 		carrier.setHeader(NativeMessageHeaderAccessor.NATIVE_HEADERS,
 				"{spanTraceId=[123], spanId=[456], spanSampled=[0]}");
 		MessageHeaderPropagation.removeAnyTraceHeaders(carrier,
-				Collections.singletonList("X-B3-SpanId"));
+				Collections.singletonList("b3"));
 	}
 
 	@Test
@@ -102,7 +102,7 @@ public class MessageHeaderPropagationTest
 		MessageHeaderAccessor carrier = carrier();
 		carrier.setHeader(NativeMessageHeaderAccessor.NATIVE_HEADERS,
 				"{spanTraceId=[123], spanId=[456], spanSampled=[0]}");
-		MessageHeaderPropagation.INSTANCE.put(carrier, "X-B3-SpanId", "1234");
+		MessageHeaderPropagation.INSTANCE.put(carrier, "b3", "1234");
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/PropagationSetterTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/PropagationSetterTest.java
@@ -40,40 +40,38 @@ public abstract class PropagationSetterTest<C, K> {
 
 	@Test
 	public void set() throws Exception {
-		K key = keyFactory().create("X-B3-TraceId");
-		setter().put(carrier(), key, "48485a3953bb6124");
+		K key = keyFactory().create("b3");
+		setter().put(carrier(), key, "1");
 
-		assertThat(read(carrier(), key)).containsExactly("48485a3953bb6124");
+		assertThat(read(carrier(), key)).containsExactly("1");
 	}
 
 	@Test
 	public void set128() throws Exception {
-		K key = keyFactory().create("X-B3-TraceId");
-		setter().put(carrier(), key, "463ac35c9f6413ad48485a3953bb6124");
+		K key = keyFactory().create("b3");
+		setter().put(carrier(), key, "1");
 
-		assertThat(read(carrier(), key))
-				.containsExactly("463ac35c9f6413ad48485a3953bb6124");
+		assertThat(read(carrier(), key)).containsExactly("1");
 	}
 
 	@Test
 	public void setTwoKeys() throws Exception {
-		K key1 = keyFactory().create("X-B3-TraceId");
-		K key2 = keyFactory().create("X-B3-SpanId");
-		setter().put(carrier(), key1, "463ac35c9f6413ad48485a3953bb6124");
-		setter().put(carrier(), key2, "48485a3953bb6124");
+		K key1 = keyFactory().create("b3");
+		K key2 = keyFactory().create("baggage");
+		setter().put(carrier(), key1, "1");
+		setter().put(carrier(), key2, "country-code=FO");
 
-		assertThat(read(carrier(), key1))
-				.containsExactly("463ac35c9f6413ad48485a3953bb6124");
-		assertThat(read(carrier(), key2)).containsExactly("48485a3953bb6124");
+		assertThat(read(carrier(), key1)).containsExactly("1");
+		assertThat(read(carrier(), key2)).containsExactly("country-code=FO");
 	}
 
 	@Test
 	public void reset() throws Exception {
-		K key = keyFactory().create("X-B3-TraceId");
-		setter().put(carrier(), key, "48485a3953bb6124");
-		setter().put(carrier(), key, "463ac35c9f6413ad");
+		K key = keyFactory().create("b3");
+		setter().put(carrier(), key, "0");
+		setter().put(carrier(), key, "1");
 
-		assertThat(read(carrier(), key)).containsExactly("463ac35c9f6413ad");
+		assertThat(read(carrier(), key)).containsExactly("1");
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/opentracing/BraveTracerTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/opentracing/BraveTracerTest.java
@@ -41,6 +41,7 @@ import org.springframework.cloud.sleuth.util.ArrayListSpanReporter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
@@ -82,10 +83,8 @@ public class BraveTracerTest {
 
 	@Test
 	public void extractTraceContext() {
-		Map<String, String> map = new LinkedHashMap<>();
-		map.put("X-B3-TraceId", "0000000000000001");
-		map.put("X-B3-SpanId", "0000000000000002");
-		map.put("X-B3-Sampled", "1");
+		Map<String, String> map = singletonMap("b3",
+				"0000000000000001-0000000000000002-1");
 
 		BraveSpanContext openTracingContext = this.opentracing
 				.extract(Format.Builtin.HTTP_HEADERS, new TextMapAdapter(map));
@@ -97,9 +96,7 @@ public class BraveTracerTest {
 	@Test
 	public void extractBaggage() {
 		Map<String, String> map = new LinkedHashMap<>();
-		map.put("X-B3-TraceId", "0000000000000001");
-		map.put("X-B3-SpanId", "0000000000000002");
-		map.put("X-B3-Sampled", "1");
+		map.put("b3", "0000000000000001-0000000000000002-1");
 		map.put("country-code", "FO");
 
 		BraveSpanContext openTracingContext = this.opentracing
@@ -111,10 +108,8 @@ public class BraveTracerTest {
 
 	@Test
 	public void extractTraceContextTextMap() {
-		Map<String, String> map = new LinkedHashMap<>();
-		map.put("X-B3-TraceId", "0000000000000001");
-		map.put("X-B3-SpanId", "0000000000000002");
-		map.put("X-B3-Sampled", "1");
+		Map<String, String> map = singletonMap("b3",
+				"0000000000000001-0000000000000002-1");
 
 		BraveSpanContext openTracingContext = this.opentracing
 				.extract(Format.Builtin.TEXT_MAP, new TextMapAdapter(map));
@@ -126,9 +121,7 @@ public class BraveTracerTest {
 	@Test
 	public void extractTraceContextCaseInsensitive() {
 		Map<String, String> map = new LinkedHashMap<>();
-		map.put("X-B3-TraceId", "0000000000000001");
-		map.put("x-b3-spanid", "0000000000000002");
-		map.put("x-b3-SaMpLeD", "1");
+		map.put("B3", "0000000000000001-0000000000000002-1");
 		map.put("other", "1");
 
 		BraveSpanContext openTracingContext = this.opentracing

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceRestTemplateInterceptorTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceRestTemplateInterceptorTests.java
@@ -93,6 +93,7 @@ public class TraceRestTemplateInterceptorTests {
 		Map<String, String> headers = this.template.getForEntity("/", Map.class)
 				.getBody();
 
+		// Default inject format for client spans is B3 multi
 		then(headers.get("X-B3-TraceId")).isNotNull();
 		then(headers.get("X-B3-SpanId")).isNotNull();
 	}
@@ -109,6 +110,7 @@ public class TraceRestTemplateInterceptorTests {
 			span.finish();
 		}
 
+		// Default inject format for client spans is B3 multi
 		then(headers.get("X-B3-TraceId"))
 				.isEqualTo(SpanUtil.idToHex(span.context().traceId()));
 		then(headers.get("X-B3-SpanId"))
@@ -205,7 +207,8 @@ public class TraceRestTemplateInterceptorTests {
 		@RequestMapping("/")
 		public Map<String, String> home(@RequestHeader HttpHeaders headers) {
 			this.span = TraceRestTemplateInterceptorTests.this.tracer.currentSpan();
-			Map<String, String> map = new HashMap<String, String>();
+			Map<String, String> map = new HashMap<>();
+			// Default inject format for client spans is B3 multi
 			addHeaders(map, headers, "X-B3-SpanId", "X-B3-TraceId", "X-B3-ParentSpanId");
 			return map;
 		}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRequestHttpHeadersFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceRequestHttpHeadersFilterTests.java
@@ -32,6 +32,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 
+// This test uses B3 multi format as it is the default for client propagation
 public class TraceRequestHttpHeadersFilterTests {
 
 	StrictCurrentTraceContext currentTraceContext = StrictCurrentTraceContext.create();

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceResponseHttpHeadersFilterTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceResponseHttpHeadersFilterTests.java
@@ -51,8 +51,7 @@ public class TraceResponseHttpHeadersFilterTests {
 		HttpHeadersFilter filter = TraceResponseHttpHeadersFilter
 				.create(this.httpTracing);
 		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.set("X-B3-TraceId", "52f112af7472aff0");
-		httpHeaders.set("X-B3-SpanId", "53e6ab6fc5dfee58");
+		httpHeaders.set("b3", "52f112af7472aff0-53e6ab6fc5dfee58");
 		MockServerHttpRequest request = MockServerHttpRequest.post("foo/bar")
 				.headers(httpHeaders).build();
 		MockServerWebExchange exchange = MockServerWebExchange.builder(request).build();
@@ -67,8 +66,7 @@ public class TraceResponseHttpHeadersFilterTests {
 		HttpHeadersFilter filter = TraceResponseHttpHeadersFilter
 				.create(this.httpTracing);
 		HttpHeaders httpHeaders = new HttpHeaders();
-		httpHeaders.set("X-B3-TraceId", "52f112af7472aff0");
-		httpHeaders.set("X-B3-SpanId", "53e6ab6fc5dfee58");
+		httpHeaders.set("b3", "52f112af7472aff0-53e6ab6fc5dfee58");
 		MockServerHttpRequest request = MockServerHttpRequest.post("foo/bar")
 				.headers(httpHeaders).build();
 		MockServerWebExchange exchange = MockServerWebExchange.builder(request).build();

--- a/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/RequestSendingRunnable.java
+++ b/spring-cloud-sleuth-samples/spring-cloud-sleuth-sample-test-core/src/main/java/tools/RequestSendingRunnable.java
@@ -30,6 +30,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static tools.SpanUtil.idToHex;
 
 /**
  * Runnable that will send a request via the provide rest template to the given url. It
@@ -38,9 +39,6 @@ import static org.assertj.core.api.BDDAssertions.then;
  * @author Marcin Grzejszczak
  */
 public class RequestSendingRunnable implements Runnable {
-
-	static final String TRACE_ID_NAME = "X-B3-TraceId";
-	static final String SPAN_ID_NAME = "X-B3-SpanId";
 
 	private static final Log log = LogFactory.getLog(RequestSendingRunnable.class);
 
@@ -75,8 +73,7 @@ public class RequestSendingRunnable implements Runnable {
 
 	private RequestEntity<Void> requestWithTraceId() {
 		HttpHeaders headers = new HttpHeaders();
-		headers.add(TRACE_ID_NAME, SpanUtil.idToHex(this.traceId));
-		headers.add(SPAN_ID_NAME, SpanUtil.idToHex(this.spanId));
+		headers.add("b3", idToHex(this.traceId) + "-" + idToHex(this.spanId));
 		URI uri = URI.create(this.url);
 		RequestEntity<Void> requestEntity = new RequestEntity<>(headers, HttpMethod.GET,
 				uri);

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/ITTracingChannelInterceptorTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/ITTracingChannelInterceptorTests.java
@@ -100,10 +100,10 @@ public class ITTracingChannelInterceptorTests implements MessageHandler {
 	// formerly known as TraceChannelInterceptorTest.executableSpanCreation
 	@Test
 	public void propagatesNoopSpan() {
-		this.directChannel.send(
-				MessageBuilder.withPayload("hi").setHeader("X-B3-Sampled", "0").build());
+		this.directChannel
+				.send(MessageBuilder.withPayload("hi").setHeader("b3", "0").build());
 
-		assertThat(this.message.getHeaders()).containsEntry("X-B3-Sampled", "0");
+		assertThat(this.message.getHeaders()).containsEntry("b3", "0");
 
 		assertThat(this.currentSpan.isNoop()).isTrue();
 	}

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceContextPropagationChannelInterceptorTests.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.sleuth.instrument.messaging;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
+import brave.propagation.B3SingleFormat;
+import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -80,19 +82,12 @@ public class TraceContextPropagationChannelInterceptorTests {
 		Message<?> message = this.channel.receive(0);
 		assertThat(message).as("message was null").isNotNull();
 
-		String spanId = message.getHeaders().get(TraceMessageHeaders.SPAN_ID_NAME,
-				String.class);
-		assertThat(spanId).as("spanId was equal to parent's id")
+		String b3 = message.getHeaders().get("b3", String.class);
+		// Trace and Span IDs are implicitly checked
+		TraceContext extracted = B3SingleFormat.parseB3SingleFormat(b3).context();
+
+		assertThat(extracted.spanIdString()).as("spanId was equal to parent's id")
 				.isNotEqualTo(expectedSpanId);
-
-		String traceId = message.getHeaders().get(TraceMessageHeaders.TRACE_ID_NAME,
-				String.class);
-		assertThat(traceId).as("traceId was null").isNotNull();
-
-		String parentId = message.getHeaders().get(TraceMessageHeaders.PARENT_ID_NAME,
-				String.class);
-		assertThat(parentId).as("parentId was not equal to parent's id")
-				.isEqualTo(this.reporter.getSpans().get(0).id());
 	}
 
 	@Configuration

--- a/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceStreamChannelInterceptorTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-messaging-tests/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/TraceStreamChannelInterceptorTests.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.sleuth.instrument.messaging;
 import brave.Span;
 import brave.Tracer;
 import brave.Tracing;
+import brave.propagation.B3SingleFormat;
+import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -83,21 +85,12 @@ public class TraceStreamChannelInterceptorTests {
 		Message<?> message = this.channel.receive(0);
 		assertThat(message).as("message was null").isNotNull();
 
-		String spanId = message.getHeaders().get(TraceMessageHeaders.SPAN_ID_NAME,
-				String.class);
-		assertThat(spanId).as("spanId was equal to parent's id")
+		String b3 = message.getHeaders().get("b3", String.class);
+		// Trace and Span IDs are implicitly checked
+		TraceContext extracted = B3SingleFormat.parseB3SingleFormat(b3).context();
+
+		assertThat(extracted.spanIdString()).as("spanId was equal to parent's id")
 				.isNotEqualTo(expectedSpanId);
-
-		String traceId = message.getHeaders().get(TraceMessageHeaders.TRACE_ID_NAME,
-				String.class);
-		assertThat(traceId).as("traceId was null").isNotNull();
-
-		String parentId = message.getHeaders().get(TraceMessageHeaders.PARENT_ID_NAME,
-				String.class);
-		// [0] - producer
-		// [1] - http:testsendmessage
-		assertThat(parentId).as("parentId was not equal to parent's id")
-				.isEqualTo(this.reporter.getSpans().get(1).id());
 	}
 
 	@Configuration

--- a/tests/spring-cloud-sleuth-instrumentation-webflux-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/GH1102Tests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-webflux-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/GH1102Tests.java
@@ -52,9 +52,6 @@ public class GH1102Tests {
 	@Autowired
 	TestRetry testRetry;
 
-	@Autowired
-	ArrayListSpanReporter reporter;
-
 	@LocalServerPort
 	int port;
 
@@ -73,6 +70,7 @@ public class GH1102Tests {
 			foo.finish();
 		}
 
+		// Default inject format for client spans is B3 multi
 		BDDAssertions.then(this.testRetry.getHttpHeaders().get("x-b3-traceid"))
 				.hasSize(1);
 	}

--- a/tests/spring-cloud-sleuth-instrumentation-webflux-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-webflux-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxTests.java
@@ -155,8 +155,7 @@ public class TraceWebFluxTests {
 	private ClientResponse whenNonSampledRequestIsSent(int port) {
 		Mono<ClientResponse> exchange = WebClient.create().get()
 				.uri("http://localhost:" + port + "/api/c2/10")
-				.header("X-B3-SpanId", EXPECTED_TRACE_ID)
-				.header("X-B3-TraceId", EXPECTED_TRACE_ID).header("X-B3-Sampled", "0")
+				.header("b3", EXPECTED_TRACE_ID + "-" + EXPECTED_TRACE_ID + "-0")
 				.exchange();
 		return exchange.block();
 	}


### PR DESCRIPTION
To reduce confusion and overhead, the following custom spring-messaging headers added in Sleuth 1.0 are no longer sent, and a log warning is issued once if they are by outside code.

* spanId
* spanSampled
* spanParentSpanId
* spanTraceId
* spanFlags

Sending the above headers actually increases the headers by up to 10 because they are duplicated in the "native" part of messages. This overhead is extreme especially if messages never leave the process.

The solution is to only send [b3 single format](https://github.com/openzipkin/b3-propagation#single-header), which has been in sleuth since 2.0 and is compatible with JMS. The B3 single format is always parsed and takes precedence, even if multiple headers are sent, so this is a safe change.

Note: Unlike RPC, messaging spans never join with their parent. Better performance is achieved by not propagating the producer's parentId downstream.

Note: Deprecated spring-messaging headers such "spanTraceId" as are still read in Sleuth 3.x. However, they will not be at some point in the future. Please pay attention to the log messages and update your code if you are accidentally using them.