### PR TITLE
replace method for deprecation and keep reference of requestTemplate

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClient.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TracingFeignClient.java
@@ -173,11 +173,10 @@ final class TracingFeignClient implements Client {
 			if (headers == null) {
 				return delegate;
 			}
-			String method = delegate.method();
 			String url = delegate.url();
 			byte[] body = delegate.body();
 			Charset charset = delegate.charset();
-			return Request.create(method, url, headers, body, charset);
+			return Request.create(delegate.httpMethod(), url, headers, body, charset, delegate.requestTemplate());
 		}
 
 	}


### PR DESCRIPTION
there are some integration codes in out project making use of the requestTemplate, but after enable sleuth the reference is null. We found the reason here and the method of building the request is depracated