### PR TITLE
Get KafkaStreamsTracing via BeanFactory to prevent eager initialization

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.streams.KafkaStreams;
 
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -66,8 +67,8 @@ public class SleuthKafkaStreamsConfiguration {
 
 	@Bean
 	static KafkaStreamsBuilderFactoryBeanPostProcessor kafkaStreamsBuilderFactoryBeanPostProcessor(
-			KafkaStreamsTracing kafkaStreamsTracing) {
-		return new KafkaStreamsBuilderFactoryBeanPostProcessor(kafkaStreamsTracing);
+			BeanFactory beanFactory) {
+		return new KafkaStreamsBuilderFactoryBeanPostProcessor(beanFactory);
 	}
 
 }
@@ -86,10 +87,10 @@ class KafkaStreamsBuilderFactoryBeanPostProcessor implements BeanPostProcessor {
 	private static final Log log = LogFactory
 			.getLog(KafkaStreamsBuilderFactoryBeanPostProcessor.class);
 
-	private final KafkaStreamsTracing kafkaStreamsTracing;
+	private final BeanFactory beanFactory;
 
-	KafkaStreamsBuilderFactoryBeanPostProcessor(KafkaStreamsTracing kafkaStreamsTracing) {
-		this.kafkaStreamsTracing = kafkaStreamsTracing;
+	KafkaStreamsBuilderFactoryBeanPostProcessor(BeanFactory beanFactory) {
+		this.beanFactory = beanFactory;
 	}
 
 	@Override
@@ -101,7 +102,8 @@ class KafkaStreamsBuilderFactoryBeanPostProcessor implements BeanPostProcessor {
 				log.debug(
 						"StreamsBuilderFactoryBean bean is auto-configured to enable tracing.");
 			}
-			sbfb.setClientSupplier(kafkaStreamsTracing.kafkaClientSupplier());
+			sbfb.setClientSupplier(this.beanFactory.getBean(KafkaStreamsTracing.class)
+					.kafkaClientSupplier());
 		}
 		return bean;
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.sleuth.instrument.messaging;
 
 import brave.kafka.streams.KafkaStreamsTracing;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
@@ -16,14 +16,22 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
+import javax.annotation.PostConstruct;
+
+import brave.Tracing;
 import brave.kafka.streams.KafkaStreamsTracing;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +42,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(OutputCaptureExtension.class)
 class SleuthKafkaStreamsConfigurationIntegrationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -72,16 +81,51 @@ class SleuthKafkaStreamsConfigurationIntegrationTests {
 	@Test
 	void should_set_KafkaClientSupplier_on_StreamsBuilderFactoryBean() {
 		this.contextRunner
-				.run(context -> verify(streamsBuilderFactoryBean).setClientSupplier(any(KafkaClientSupplier.class)));
+				.run(context -> verify(UserConfig.streamsBuilderFactoryBean)
+						.setClientSupplier(any(KafkaClientSupplier.class)));
 	}
 
-	private static final StreamsBuilderFactoryBean streamsBuilderFactoryBean = mock(StreamsBuilderFactoryBean.class);
+	@Test
+	void should_not_complain_about_eager_initialization() {
+		this.contextRunner
+				.withUserConfiguration(EagerInitializationConfig.class)
+				.run(context -> verify(UserConfig.streamsBuilderFactoryBean)
+						.setClientSupplier(any(KafkaClientSupplier.class)));
+	}
+
+	@AfterEach
+	void afterEach(CapturedOutput output) {
+		assertThat(output).doesNotContain("is not eligible for getting processed by all BeanPostProcessors");
+	}
 
 	@Configuration
 	static class UserConfig {
+		static StreamsBuilderFactoryBean streamsBuilderFactoryBean;
+
 		@Bean
 		StreamsBuilderFactoryBean streamsBuilderFactoryBean() {
-			return streamsBuilderFactoryBean;
+			streamsBuilderFactoryBean = mock(StreamsBuilderFactoryBean.class);
+			return UserConfig.streamsBuilderFactoryBean;
+		}
+	}
+
+	@Configuration
+	static class EagerInitializationConfig {
+		@Bean
+		EagerInitializationComponent eagerInitializationComponent() {
+			return new EagerInitializationComponent();
+		}
+	}
+
+	static class EagerInitializationComponent {
+
+		@Autowired
+		private Tracing tracing;
+		private KafkaStreamsTracing kafkaStreamsTracing;
+
+		@PostConstruct
+		void init() {
+			kafkaStreamsTracing = KafkaStreamsTracing.create(tracing);
 		}
 	}
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
@@ -70,7 +70,7 @@ class SleuthKafkaStreamsConfigurationIntegrationTests {
 	}
 
 	@Test
-	void testKafkaStreamsBuilderFactoryBeanPostProcessor() {
+	void should_set_KafkaClientSupplier_on_StreamsBuilderFactoryBean() {
 		this.contextRunner
 				.run(context -> verify(streamsBuilderFactoryBean).setClientSupplier(any(KafkaClientSupplier.class)));
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfigurationIntegrationTests.java
@@ -1,0 +1,70 @@
+package org.springframework.cloud.sleuth.instrument.messaging;
+
+import brave.kafka.streams.KafkaStreamsTracing;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.KafkaStreams;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class SleuthKafkaStreamsConfigurationIntegrationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+					TraceAutoConfiguration.class,
+					SleuthKafkaStreamsConfiguration.class))
+			.withUserConfiguration(UserConfig.class);
+
+	@Test
+	void should_create_KafkaStreamsTracing() {
+		this.contextRunner
+				.run(context -> assertThat(context).hasSingleBean(KafkaStreamsTracing.class));
+	}
+
+	@Test
+	void should_not_create_KafkaStreamsTracing_when_KafkaStreams_not_present() {
+		this.contextRunner
+				.withClassLoader(new FilteredClassLoader(KafkaStreams.class))
+				.run(context -> assertThat(context).doesNotHaveBean(KafkaStreamsTracing.class));
+	}
+
+	@Test
+	void should_not_create_KafkaStreamsTracing_when_kafkastreams_disabled() {
+		this.contextRunner
+				.withPropertyValues("spring.sleuth.messaging.kafka.streams.enabled=false")
+				.run(context -> assertThat(context).doesNotHaveBean(KafkaStreamsTracing.class));
+	}
+
+	@Test
+	void should_not_create_KafkaStreamsTracing_when_messaging_disabled() {
+		this.contextRunner
+				.withPropertyValues("spring.sleuth.messaging.enabled=false")
+				.run(context -> assertThat(context).doesNotHaveBean(KafkaStreamsTracing.class));
+	}
+
+	@Test
+	void testKafkaStreamsBuilderFactoryBeanPostProcessor() {
+		this.contextRunner
+				.run(context -> verify(streamsBuilderFactoryBean).setClientSupplier(any(KafkaClientSupplier.class)));
+	}
+
+	private static final StreamsBuilderFactoryBean streamsBuilderFactoryBean = mock(StreamsBuilderFactoryBean.class);
+
+	@Configuration
+	static class UserConfig {
+		@Bean
+		StreamsBuilderFactoryBean streamsBuilderFactoryBean() {
+			return streamsBuilderFactoryBean;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1599 

Had to wrestle a bit with the [sample project added by @jorgheymans](https://github.com/jorgheymans/sleuth-bug) by using `spring-cloud-dependencies:Hoxton.SR4` as parent adding the following two properties:
```
<brave.version>5.11.2</brave.version>
<spring-cloud-sleuth.version>2.2.3.BUILD-SNAPSHOT</spring-cloud-sleuth.version>
```
But after that, and with the changes on this PR cherry-picked into the Sleuth `2.2.x`  branch, I no longer see the message when starting that application. @jorgheymans can you confirm?

Not entirely sure if/how I could add a unit test to prove this works otherwise.