### PR TITLE
Move TraceSchedulingAutoConfiguration @Conditional for optional AspectJ

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
@@ -40,7 +40,6 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
  * @see TraceSchedulingAspect
  */
 @Configuration(proxyBeanMethods = false)
-@EnableAspectJAutoProxy
 @ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
 @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
 @ConditionalOnBean(Tracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableAspectJAutoProxy
+@ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
 @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
 @ConditionalOnBean(Tracing.class)
 @AutoConfigureAfter(TraceAutoConfiguration.class)
@@ -48,7 +49,6 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 public class TraceSchedulingAutoConfiguration {
 
 	@Bean
-	@ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
 	public TraceSchedulingAspect traceSchedulingAspect(Tracer tracer,
 			SleuthSchedulingProperties sleuthSchedulingProperties) {
 		String skipPatternString = sleuthSchedulingProperties.getSkipPattern();

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
@@ -38,8 +38,7 @@ class TraceSchedulingAutoConfigurationTest {
 	void shoud_create_TraceSchedulingAspect() {
 		this.contextRunner
 				.run(context -> assertThat(context)
-						.hasSingleBean(TraceSchedulingAspect.class)
-						.hasSingleBean(AnnotationAwareAspectJAutoProxyCreator.class));
+						.hasSingleBean(TraceSchedulingAspect.class));
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.sleuth.instrument.scheduling;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
@@ -46,8 +46,7 @@ class TraceSchedulingAutoConfigurationTest {
 		this.contextRunner
 				.withClassLoader(new FilteredClassLoader(ProceedingJoinPoint.class))
 				.run(context -> assertThat(context)
-						.doesNotHaveBean(TraceSchedulingAspect.class)
-						.doesNotHaveBean(AnnotationAwareAspectJAutoProxyCreator.class));
+						.hasSingleBean(TraceSchedulingAspect.class));
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfigurationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.scheduling;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TraceSchedulingAutoConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(
+					TraceAutoConfiguration.class,
+					TraceSchedulingAutoConfiguration.class));
+
+	@Test
+	void shoud_create_TraceSchedulingAspect() {
+		this.contextRunner
+				.run(context -> assertThat(context)
+						.hasSingleBean(TraceSchedulingAspect.class)
+						.hasSingleBean(AnnotationAwareAspectJAutoProxyCreator.class));
+	}
+
+	@Test
+	void shoud_not_create_TraceSchedulingAspect_without_aspectJ() {
+		this.contextRunner
+				.withClassLoader(new FilteredClassLoader(ProceedingJoinPoint.class))
+				.run(context -> assertThat(context)
+						.doesNotHaveBean(TraceSchedulingAspect.class)
+						.doesNotHaveBean(AnnotationAwareAspectJAutoProxyCreator.class));
+	}
+
+}


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-sleuth#1621

With the conditional in the original location the tests fail;
With the conditional in the new location the tests pass.