### PR TITLE
Deprecates ExceptionLoggingFilter and disables it by default

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/ExceptionLoggingFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/ExceptionLoggingFilter.java
@@ -29,11 +29,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * Filter running after {@link brave.servlet.TracingFilter} that logs uncaught exceptions.
- *
- * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @deprecated Since 2.2.3 this is disabled by default and will be removed in 3.0
  */
+@Deprecated
 class ExceptionLoggingFilter implements Filter {
 
 	private static final Log log = LogFactory.getLog(ExceptionLoggingFilter.class);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.java
@@ -83,10 +83,8 @@ public class TraceWebServletAutoConfiguration {
 		return filterRegistrationBean;
 	}
 
-	// TODO: Rename to exception-logging-filter for 3.0
 	@Bean
-	@ConditionalOnProperty(value = "spring.sleuth.web.exception-logging-filter-enabled",
-			matchIfMissing = true)
+	@ConditionalOnProperty("spring.sleuth.web.exception-logging-filter-enabled")
 	public FilterRegistrationBean exceptionThrowingFilter(
 			SleuthWebProperties webProperties) {
 		FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean(

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
@@ -19,12 +19,10 @@ package org.springframework.cloud.sleuth.log;
 import brave.propagation.CurrentTraceContext;
 import org.slf4j.MDC;
 
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.autoconfig.SleuthProperties;
-import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -36,12 +34,14 @@ import org.springframework.context.annotation.Configuration;
  * @author Spencer Gibb
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated Do not use this type directly as it was removed in 3.x
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.enabled", matchIfMissing = true)
 // This is not auto-configuration, but it was in the past. Leaving the name as
 // SleuthLogAutoConfiguration because some may have imported this directly.
 // A less precise name is better than rev-locking code.
+@Deprecated
 public class SleuthLogAutoConfiguration {
 
 	/**
@@ -50,8 +50,7 @@ public class SleuthLogAutoConfiguration {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(MDC.class)
 	@EnableConfigurationProperties(SleuthSlf4jProperties.class)
-	@AutoConfigureBefore(TraceAutoConfiguration.class)
-	protected static class Slf4jConfiguration {
+	public static class Slf4jConfiguration {
 
 		@Bean
 		@ConditionalOnProperty(value = "spring.sleuth.log.slf4j.enabled",

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthLogAutoConfiguration.java
@@ -29,9 +29,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration
- * Auto-configuration} adds a {@link Slf4jScopeDecorator} that prints tracing information
- * in the logs.
+ * {@link Configuration} that adds a {@link Slf4jScopeDecorator} that prints tracing
+ * information in the logs.
  * <p>
  *
  * @author Spencer Gibb
@@ -40,7 +39,9 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.enabled", matchIfMissing = true)
-@AutoConfigureBefore(TraceAutoConfiguration.class)
+// This is not auto-configuration, but it was in the past. Leaving the name as
+// SleuthLogAutoConfiguration because some may have imported this directly.
+// A less precise name is better than rev-locking code.
 public class SleuthLogAutoConfiguration {
 
 	/**
@@ -49,6 +50,7 @@ public class SleuthLogAutoConfiguration {
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(MDC.class)
 	@EnableConfigurationProperties(SleuthSlf4jProperties.class)
+	@AutoConfigureBefore(TraceAutoConfiguration.class)
 	protected static class Slf4jConfiguration {
 
 		@Bean

--- a/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
@@ -2,7 +2,6 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.sleuth.annotation.SleuthAnnotationAutoConfiguration,\
 org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration,\
-org.springframework.cloud.sleuth.log.SleuthLogAutoConfiguration,\
 org.springframework.cloud.sleuth.propagation.SleuthTagPropagationAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceHttpAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceWebAutoConfiguration,\

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
@@ -61,7 +61,8 @@ import static org.assertj.core.api.BDDAssertions.then;
 @ExtendWith({ SpringExtension.class, OutputCaptureExtension.class })
 @SpringBootTest(classes = TraceFilterWebIntegrationTests.Config.class,
 		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-		properties = "spring.sleuth.http.legacy.enabled=true")
+		properties = { "spring.sleuth.http.legacy.enabled=true",
+				"spring.sleuth.web.exception-logging-filter-enabled=true" })
 public class TraceFilterWebIntegrationTests {
 
 	@Autowired
@@ -92,7 +93,8 @@ public class TraceFilterWebIntegrationTests {
 	}
 
 	@Test
-	public void should_not_create_a_span_for_error_controller(CapturedOutput capture) {
+	public void exception_logging_filter_logs_synchronous_exceptions(
+			CapturedOutput capture) {
 		try {
 			new RestTemplate().getForObject("http://localhost:" + port() + "/",
 					String.class);
@@ -107,7 +109,7 @@ public class TraceFilterWebIntegrationTests {
 				.containsEntry("mvc.controller.class", "ExceptionThrowingController")
 				.containsEntry("error",
 						"Request processing failed; nested exception is java.lang.RuntimeException: Throwing exception");
-		// issue#714
+		// Trace IDs in logs: issue#714
 		String hex = fromFirstTraceFilterFlow.traceId();
 		String[] split = capture.toString().split("\n");
 		List<String> list = Arrays.stream(split)

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfigurationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfigurationTests.java
@@ -37,9 +37,9 @@ public class TraceWebServletAutoConfigurationTests {
 					TraceWebServletAutoConfiguration.class));
 
 	@Test
-	public void shouldCreateExceptionLoggingFilterBeanByDefault() {
+	public void shouldNotCreateExceptionLoggingFilterBeanByDefault() {
 		this.contextRunner.run((context) -> {
-			assertThat(context).hasBean(EXCEPTION_LOGGING_FILTER_BEAN_NAME);
+			assertThat(context).doesNotHaveBean(EXCEPTION_LOGGING_FILTER_BEAN_NAME);
 		});
 	}
 


### PR DESCRIPTION
`ExceptionLoggingFilter` logs "Uncaught exception thrown" to error level
when there is a synchronous exception not otherwise swallowed. This is a
cure worse than the disease. This issue disables by default and the 3.x
should remove this, ending the years of problems it caused.

Fixes #1347

This was done IIUC to help @jfuerth who had log messages with trace IDs,
except the uncaught one, in #714 (Sept 2017). They were formerly told to
use `ExceptionHandler` and noted that didn't work in practice as it
subverted their status code logic.

Concretely, 4203566d87434e2cb65fbbb9b90fd92bac447f2e "solved" the issue
by having sleuth log all uncaught exceptions with the message
"Uncaught exception thrown". This code was initially embedded in
sleuth's and later pulled out to `ExceptionLoggingFilter` in 2.0.

A few months later @brenuart noticed this "solution" had problems. For
example, it caused the same exception to be logged twice. Bertrand also
mentioned some faults in the implementation including edge cases like
`ClientAbortException` not addressed by this. (In fact, there are even
more problems: the implementation assumes async isn't in use!)
Bertands concerns about this having surprising logging effects were
dismissed as a non-issue. Bertrand raised #859 about glitches this
caused, the status_code related ones being if statemented around, and
it went quiet a while.

A month later @oburgosm opened #902 (currently 5 thumbs up) asking to
remove the "Uncaught exception thrown" or at least set it to debug.
The response was if they don't like it, control their own tracing
filter and the issue was closed.

A month later, @nickcodefresh opened #966 confused about "Uncaught
exception thrown" messages raised by sleuth, incidentally the
`ClientAbortException` mentioned by @brenuart before. Because the
logging came from Sleuth, it appeared they were zipkin errors, and was
explained they weren't.

A year later, @T3rm1 opened #1347 to remove the filter, or at least
disable it by default. The response was first to set the Logger to OFF.
A few days later the issue was closed as the submitter was told they
were the first person to complain about this. 5 months later, another
user rallied for support.

In April 2020, #902 was re-touched by @kosciej who asked to please
reconsider, mentioning it was not typical even in Spring to do this,
for example 'org.springframework.web.filter' package. The impact of
needing to specifically change apps to OFF the sleuth logger seemed
harsh. The suggestion was instead of setting log config, to set a
property instead `spring.sleuth.web.exception-logging-filter-enabled`,
to `false` as that could also accomplish the goal of stopping
"Uncaught exception thrown".

A month later (yesterday) @MrHurniak commented again on #1347 with the
usual complaint that it is redundant and confusing.