### PR TITLE
Deprecates unnecessarily public types to ease burden

### DIFF
--- a/spring-cloud-sleuth-core/pom.xml
+++ b/spring-cloud-sleuth-core/pom.xml
@@ -330,6 +330,7 @@
 			<artifactId>spring-boot-autoconfigure-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/DefaultSpanNamer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/DefaultSpanNamer.java
@@ -42,7 +42,10 @@ import org.springframework.core.annotation.AnnotationUtils;
  * @author Marcin Grzejszczak
  * @since 1.0.0
  * @see SpanName
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class DefaultSpanNamer implements SpanNamer {
 
 	private static boolean isDefaultToString(Object delegate, String spanName) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
@@ -26,7 +26,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.11
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth")
 public class SleuthProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -70,7 +70,10 @@ import org.springframework.util.StringUtils;
  * @author Marcin Grzejszczak
  * @author Tim Ysewyn
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(SleuthProperties.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
@@ -35,7 +35,10 @@ import org.springframework.core.env.PropertySource;
  * @author Dave Syer
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceEnvironmentPostProcessor implements EnvironmentPostProcessor {
 
 	private static final String PROPERTY_SOURCE_NAME = "defaultProperties";

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncAutoConfiguration.java
@@ -28,7 +28,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Jesus Alonso
  * @since 2.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)
 @EnableConfigurationProperties({ SleuthAsyncProperties.class,

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncCustomAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncCustomAutoConfiguration.java
@@ -35,7 +35,10 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
  *
  * @author Dave Syer
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean(AsyncConfigurer.class)
 @AutoConfigureBefore(AsyncDefaultAutoConfiguration.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/AsyncDefaultAutoConfiguration.java
@@ -52,7 +52,10 @@ import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
  * @since 1.0.0
  * @see LazyTraceExecutor
  * @see TraceAsyncAspect
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties({ SleuthAsyncProperties.class,
 		SleuthSchedulingProperties.class })

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizer.java
@@ -29,7 +29,10 @@ import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
  *
  * @author Dave Syer
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class LazyTraceAsyncCustomizer extends AsyncConfigurerSupport {
 
 	private final BeanFactory beanFactory;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncTaskExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncTaskExecutor.java
@@ -35,7 +35,10 @@ import org.springframework.core.task.AsyncTaskExecutor;
  *
  * @author Marcin Grzejszczak
  * @since 2.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class LazyTraceAsyncTaskExecutor implements AsyncTaskExecutor {
 
 	private static final Log log = LogFactory.getLog(LazyTraceAsyncTaskExecutor.class);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceExecutor.java
@@ -32,7 +32,10 @@ import org.springframework.cloud.sleuth.SpanNamer;
  *
  * @author Dave Syer
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class LazyTraceExecutor implements Executor {
 
 	private static final Log log = LogFactory.getLog(LazyTraceExecutor.class);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
@@ -39,7 +39,10 @@ import org.springframework.util.concurrent.ListenableFuture;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.10
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @SuppressWarnings("serial")
 public class LazyTraceThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
@@ -26,8 +26,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jesus Alonso
  * @since 2.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
-
+@Deprecated
 @ConfigurationProperties(prefix = "spring.sleuth.async")
 public class SleuthAsyncProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncAspect.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncAspect.java
@@ -36,7 +36,10 @@ import org.springframework.util.ReflectionUtils;
  * @author Marcin Grzejszczak
  * @since 1.0.0
  * @see Tracer
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Aspect
 public class TraceAsyncAspect {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncListenableTaskExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceAsyncListenableTaskExecutor.java
@@ -32,7 +32,10 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @since 1.0.0
  * @see brave.propagation.CurrentTraceContext#wrap(Runnable)
  * @see brave.propagation.CurrentTraceContext#wrap(Callable)
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceAsyncListenableTaskExecutor implements AsyncListenableTaskExecutor {
 
 	private final AsyncListenableTaskExecutor delegate;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceCallable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceCallable.java
@@ -33,7 +33,10 @@ import org.springframework.cloud.sleuth.SpanNamer;
  * @author Spencer Gibb
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceCallable<V> implements Callable<V> {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnable.java
@@ -30,7 +30,10 @@ import org.springframework.cloud.sleuth.SpanNamer;
  * @author Spencer Gibb
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceRunnable implements Runnable {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
@@ -36,7 +36,10 @@ import org.springframework.cloud.sleuth.SpanNamer;
  *
  * @author Gaurav Rai Mazra
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceableExecutorService implements ExecutorService {
 
 	final ExecutorService delegate;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
@@ -29,7 +29,10 @@ import org.springframework.beans.factory.BeanFactory;
  *
  * @author Gaurav Rai Mazra
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceableScheduledExecutorService extends TraceableExecutorService
 		implements ScheduledExecutorService {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/SleuthCircuitBreakerAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/SleuthCircuitBreakerAutoConfiguration.java
@@ -42,7 +42,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Marcin Grzejszczak
  * @since 2.2.1
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(TraceAutoConfiguration.class)
 @ConditionalOnClass(CircuitBreaker.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/SleuthCircuitBreakerProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/SleuthCircuitBreakerProperties.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.2.1
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.circuitbreaker")
 public class SleuthCircuitBreakerProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/TraceFunction.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/TraceFunction.java
@@ -27,7 +27,10 @@ import brave.Tracer;
  *
  * @param <T> type returned by the fallback
  * @since 2.2.1
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceFunction<T> implements Function<Throwable, T> {
 
 	private final Tracer tracer;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/TraceSupplier.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/TraceSupplier.java
@@ -27,7 +27,10 @@ import brave.Tracer;
  *
  * @param <T> type returned by the supplier
  * @since 2.2.1
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceSupplier<T> implements Supplier<T> {
 
 	private final Tracer tracer;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/SpringAwareManagedChannelBuilder.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/SpringAwareManagedChannelBuilder.java
@@ -35,6 +35,7 @@ import io.grpc.inprocess.InProcessChannelBuilder;
  *
  * @author Tyler Van Gorder
  */
+// TODO: research why we need to continue to maintain this given current libraries
 public class SpringAwareManagedChannelBuilder {
 
 	private List<GrpcManagedChannelBuilderCustomizer> customizers;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/TraceGrpcAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/grpc/TraceGrpcAutoConfiguration.java
@@ -40,7 +40,10 @@ import org.springframework.context.annotation.Bean;
  * brave-instrumentation-grpc are on the classpath.
  *
  * @author Tyler Van Gorder
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConditionalOnClass({ GrpcTracing.class, GRpcGlobalInterceptor.class })
 @ConditionalOnProperty(value = "spring.sleuth.grpc.enabled", matchIfMissing = true)
 @ConditionalOnBean(RpcTracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixAutoConfiguration.java
@@ -37,7 +37,10 @@ import org.springframework.context.annotation.Configuration;
  * @author Marcin Grzejszczak
  * @see SleuthHystrixConcurrencyStrategy
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(TraceAutoConfiguration.class)
 @ConditionalOnClass(HystrixCommand.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategy.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategy.java
@@ -46,7 +46,10 @@ import org.springframework.cloud.sleuth.instrument.async.TraceCallable;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class SleuthHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
 
 	private static final String HYSTRIX_COMPONENT = "hystrix";

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
@@ -22,7 +22,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Sleuth Hystrix settings.
  *
  * @author Daniel Albuquerque
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.hystrix.strategy")
 public class SleuthHystrixConcurrencyStrategyProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthKafkaStreamsConfiguration.java
@@ -40,7 +40,10 @@ import org.springframework.kafka.config.StreamsBuilderFactoryBean;
  * Auto-configuration} enables Kafka Streams span creation and reporting.
  *
  * @author Tim te Beek
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean(Tracing.class)
 @AutoConfigureAfter({ TraceAutoConfiguration.class })

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthMessagingProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthMessagingProperties.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth")
 public class SleuthMessagingProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessageHeaders.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessageHeaders.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.sleuth.instrument.messaging;
 
+import brave.propagation.B3Propagation;
+
 /**
  * Contains trace related messaging headers. The deprecated headers contained `-` which
  * for example in the JMS specs is invalid. That's why the public constants in this class
@@ -23,7 +25,9 @@ package org.springframework.cloud.sleuth.instrument.messaging;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.4
+ * @deprecated These names are obviated by {@link B3Propagation.Format#SINGLE}.
  */
+@Deprecated
 public final class TraceMessageHeaders {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessagingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessagingAutoConfiguration.java
@@ -86,7 +86,10 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean(Tracing.class)
 @ConditionalOnClass(MessagingTracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceSpringIntegrationAutoConfiguration.java
@@ -39,7 +39,10 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
  * @author Spencer Gibb
  * @since 1.0.0
  * @see TracingChannelInterceptor
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(GlobalChannelInterceptor.class)
 @ConditionalOnBean(Tracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TracingChannelInterceptor.java
@@ -58,7 +58,10 @@ import org.springframework.util.ClassUtils;
  * which is less sensitive to message manipulation by other interceptors.
  *
  * @author Marcin Grzejszczak
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public final class TracingChannelInterceptor extends ChannelInterceptorAdapter
 		implements ExecutorChannelInterceptor {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/websocket/TraceWebSocketAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/websocket/TraceWebSocketAutoConfiguration.java
@@ -37,7 +37,10 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
  * @author Dave Syer
  * @since 1.0.0
  * @see AbstractWebSocketMessageBrokerConfigurer
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(DelegatingWebSocketMessageBrokerConfiguration.class)
 @ConditionalOnBean(Tracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/OpentracingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/OpentracingAutoConfiguration.java
@@ -37,7 +37,10 @@ import org.springframework.context.annotation.Configuration;
  * @author Spencer Gibb
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.opentracing.enabled", matchIfMissing = true)
 @ConditionalOnBean(Tracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/SleuthOpentracingProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/SleuthOpentracingProperties.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.opentracing")
 public class SleuthOpentracingProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/quartz/TraceQuartzAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/quartz/TraceQuartzAutoConfiguration.java
@@ -36,7 +36,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Branden Cash
  * @since 2.2.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean({ Tracing.class, Scheduler.class })
 @AutoConfigureAfter({ TraceAutoConfiguration.class, QuartzAutoConfiguration.class })

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorSleuth.java
@@ -39,6 +39,8 @@ import org.springframework.context.ConfigurableApplicationContext;
  * @author Stephane Maldini
  * @since 2.0.0
  */
+// TODO: this is public as it is used out of package, but unlikely intended to be
+// non-internal
 public abstract class ReactorSleuth {
 
 	private static final Log log = LogFactory.getLog(ReactorSleuth.class);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SleuthReactorProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SleuthReactorProperties.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.2
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.reactor")
 public class SleuthReactorProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
@@ -55,7 +55,10 @@ import static org.springframework.cloud.sleuth.instrument.reactor.TraceReactorAu
  * @author Stephane Maldini
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.reactor.enabled", matchIfMissing = true)
 @ConditionalOnClass(Mono.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceRedisAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceRedisAutoConfiguration.java
@@ -39,7 +39,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Chao Chang
  * @since 2.2.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.redis.enabled", matchIfMissing = true)
 @ConditionalOnBean({ Tracing.class, ClientResources.class })

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceRedisProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceRedisProperties.java
@@ -22,7 +22,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Sleuth Redis properties.
  *
  * @author Daniel Albuquerque
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.redis")
 public class TraceRedisProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rpc/TraceRpcAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rpc/TraceRpcAutoConfiguration.java
@@ -41,7 +41,10 @@ import org.springframework.lang.Nullable;
  * Auto-configuration} related to RPC based communication.
  *
  * @since 2.2.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "spring.sleuth.rpc.enabled", havingValue = "true",
 		matchIfMissing = true)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/RxJavaAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/RxJavaAutoConfiguration.java
@@ -37,7 +37,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Shivang Shah
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @AutoConfigureAfter(TraceAutoConfiguration.class)
 @ConditionalOnBean(Tracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersProperties.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.rxjava.schedulers")
 public class SleuthRxJavaSchedulersProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/SleuthSchedulingProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/SleuthSchedulingProperties.java
@@ -24,7 +24,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.scheduled")
 public class SleuthSchedulingProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAspect.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAspect.java
@@ -40,7 +40,10 @@ import org.springframework.cloud.sleuth.util.SpanNameUtil;
  * @author Spencer Gibb
  * @since 1.0.0
  * @see Tracing
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Aspect
 public class TraceSchedulingAspect {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/TraceSchedulingAutoConfiguration.java
@@ -37,7 +37,10 @@ import org.springframework.context.annotation.Configuration;
  * @author Spencer Gibb
  * @since 1.0.0
  * @see TraceSchedulingAspect
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
 @ConditionalOnProperty(value = "spring.sleuth.scheduled.enabled", matchIfMissing = true)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpLegacyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpLegacyProperties.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.http.legacy")
 public class SleuthHttpLegacyProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
@@ -24,7 +24,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.web")
 public class SleuthWebProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.java
@@ -47,7 +47,10 @@ import org.springframework.lang.Nullable;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean(TraceWebAutoConfiguration.class)
 @ConditionalOnProperty(name = "spring.sleuth.http.enabled", havingValue = "true",

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAspect.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAspect.java
@@ -56,7 +56,10 @@ import org.springframework.web.context.request.async.WebAsyncTask;
  * @since 1.0.0
  * @see org.springframework.stereotype.Controller
  * @see org.springframework.web.client.RestOperations
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @SuppressWarnings("ArgNamesWarningsInspection")
 @Aspect
 public class TraceWebAspect {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -53,7 +53,10 @@ import org.springframework.util.StringUtils;
  * @author Marcin Grzejszczak
  * @author Tim Ysewyn
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.web.enabled", matchIfMissing = true)
 @ConditionalOnBean(Tracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFilter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFilter.java
@@ -51,7 +51,10 @@ import org.springframework.web.server.WebFilterChain;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public final class TraceWebFilter implements WebFilter, Ordered {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebFluxAutoConfiguration.java
@@ -32,7 +32,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.web.enabled", matchIfMissing = true)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebServletAutoConfiguration.java
@@ -52,7 +52,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * @author Marcin Grzejszczak
  * @author Spencer Gibb
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.web.enabled", matchIfMissing = true)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
@@ -44,7 +44,10 @@ import org.springframework.web.client.AsyncRestTemplate;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @SleuthWebClientEnabled
 @ConditionalOnProperty(value = "spring.sleuth.web.async.client.enabled",

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -62,7 +62,10 @@ import org.springframework.web.reactive.function.client.WebClient;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @SleuthWebClientEnabled
 @ConditionalOnBean(HttpTracing.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/NeverRetry.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/NeverRetry.java
@@ -24,7 +24,9 @@ import feign.Retryer;
  * Feign. For the 1.0.x stream we add it here.
  *
  * @author Ryan Baxter
+ * @deprecated This type will be removed in 3.0
  */
+@Deprecated
 public class NeverRetry implements Retryer {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignProperties.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.2
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.feign")
 public class SleuthFeignProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignBlockingLoadBalancerClient.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignBlockingLoadBalancerClient.java
@@ -41,7 +41,10 @@ import org.springframework.cloud.openfeign.loadbalancer.FeignBlockingLoadBalance
  * @since 2.2.0
  * @see TraceLoadBalancerFeignClient
  * @see FeignBlockingLoadBalancerClient
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceFeignBlockingLoadBalancerClient
 		extends FeignBlockingLoadBalancerClient {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceFeignClientAutoConfiguration.java
@@ -42,7 +42,10 @@ import org.springframework.context.annotation.Scope;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.feign.enabled", matchIfMissing = true)
 @ConditionalOnClass({ Client.class, FeignContext.class })

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceLoadBalancerFeignClient.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/TraceLoadBalancerFeignClient.java
@@ -40,7 +40,10 @@ import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.7
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TraceLoadBalancerFeignClient extends LoadBalancerFeignClient {
 
 	private static final Log log = LogFactory.getLog(TraceLoadBalancerFeignClient.class);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/zuul/TraceZuulAutoConfiguration.java
@@ -35,7 +35,10 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Dave Syer
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.zuul.enabled", matchIfMissing = true)
 @ConditionalOnWebApplication

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
@@ -26,7 +26,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.log.slf4j")
 public class SleuthSlf4jProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationAutoConfiguration.java
@@ -29,7 +29,10 @@ import org.springframework.context.annotation.Configuration;
 /**
  * @author Taras Danylchuk
  * @since 2.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(value = "spring.sleuth.enabled", matchIfMissing = true)
 @AutoConfigureBefore(TraceAutoConfiguration.class)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
@@ -26,7 +26,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Taras Danylchuk
  * @since 2.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.propagation.tag")
 public class SleuthTagPropagationProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/TagPropagationFinishedSpanHandler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/TagPropagationFinishedSpanHandler.java
@@ -35,7 +35,10 @@ import static java.util.Objects.nonNull;
  *
  * @author Taras Danylchuk
  * @since 2.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class TagPropagationFinishedSpanHandler extends FinishedSpanHandler {
 
 	private final SleuthProperties sleuthProperties;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSampler.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/ProbabilityBasedSampler.java
@@ -44,7 +44,10 @@ import org.springframework.util.Assert;
  * @author Marcin Grzejszczak
  * @author Adrian Cole
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class ProbabilityBasedSampler extends Sampler {
 
 	private final AtomicInteger counter = new AtomicInteger(0);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfiguration.java
@@ -33,7 +33,10 @@ import org.springframework.context.annotation.Configuration;
  * @author Marcin Grzejszczak
  * @see SamplerCondition
  * @since 2.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(SamplerProperties.class)
 // This is not auto-configuration, but it was in the past. Leaving the name as

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerProperties.java
@@ -24,7 +24,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Marcin Grzejszczak
  * @author Adrian Cole
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.sleuth.sampler")
 public class SamplerProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/util/ArrayListSpanReporter.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/util/ArrayListSpanReporter.java
@@ -27,7 +27,9 @@ import zipkin2.reporter.Reporter;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
+ * @deprecated This type will be removed in 3.0. Use io.zipkin.brave:brave-tests instead
  */
+@Deprecated
 public class ArrayListSpanReporter implements Reporter<Span> {
 
 	private final List<Span> spans = new ArrayList<>();

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/util/SpanNameUtil.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/util/SpanNameUtil.java
@@ -23,7 +23,9 @@ import org.springframework.util.StringUtils;
  *
  * @author Adrian Cole
  * @since 1.0.2
+ * @deprecated This type should have been internal. It will be hidden or removed in 3.0
  */
+@Deprecated
 public final class SpanNameUtil {
 
 	static final int MAX_NAME_LENGTH = 50;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/jms/config/TracingJmsListenerEndpointRegistry.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/jms/config/TracingJmsListenerEndpointRegistry.java
@@ -46,7 +46,10 @@ import org.springframework.lang.Nullable;
  *
  * @author Marcin Grzejszczak
  * @since 2.1.1
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public final class TracingJmsListenerEndpointRegistry
 		extends JmsListenerEndpointRegistry {
 

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocator.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/DefaultEndpointLocator.java
@@ -44,7 +44,10 @@ import org.springframework.util.StringUtils;
  *
  * @author Dave Syer
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class DefaultEndpointLocator implements EndpointLocator,
 		ApplicationListener<ServletWebServerInitializedEvent> {
 

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/DefaultZipkinRestTemplateCustomizer.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/DefaultZipkinRestTemplateCustomizer.java
@@ -32,7 +32,10 @@ import org.springframework.web.client.RestTemplate;
  *
  * @author Marcin Grzejszczak
  * @since 1.1.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 public class DefaultZipkinRestTemplateCustomizer implements ZipkinRestTemplateCustomizer {
 
 	private final ZipkinProperties zipkinProperties;

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
@@ -60,7 +60,10 @@ import org.springframework.web.client.RestTemplate;
  * @since 1.0.0
  * @see ZipkinRestTemplateCustomizer
  * @see DefaultZipkinRestTemplateCustomizer
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(ZipkinProperties.class)
 @ConditionalOnProperty(value = { "spring.sleuth.enabled", "spring.zipkin.enabled" },

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
@@ -25,7 +25,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Spencer Gibb
  * @since 1.0.0
+ * @deprecated This type should have never been public and will be hidden or removed in
+ * 3.0
  */
+@Deprecated
 @ConfigurationProperties("spring.zipkin")
 public class ZipkinProperties {
 


### PR DESCRIPTION
Types like Properties and AutoConfiguration and internal utilities are
routinely marked public when they needn't be. This causes toil as we
have to preserve signatures even if they were made public by accident.

This deprecates the mass of types marked public to give some hope of
less undifferentiated toil in the future. Ideally, future change will
consider greatly if a type should be public or not as doing so haunts
maintainers.