### PR TITLE
Replaces deprecated note on Properties with TODO to hide them in 3.x

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAnnotationProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/SleuthAnnotationProperties.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @since 1.2.0
  */
 @ConfigurationProperties("spring.sleuth.annotation")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthAnnotationProperties {
 
 	private boolean enabled = true;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/SleuthProperties.java
@@ -26,11 +26,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.11
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthProperties {
 
 	private boolean enabled = true;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/SleuthAsyncProperties.java
@@ -26,11 +26,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jesus Alonso
  * @since 2.1.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties(prefix = "spring.sleuth.async")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthAsyncProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/SleuthCircuitBreakerProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/circuitbreaker/SleuthCircuitBreakerProperties.java
@@ -23,10 +23,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.2.1
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// TODO: Hide in 3.x, if it isn't already deleted
 @ConfigurationProperties("spring.sleuth.circuitbreaker")
 public class SleuthCircuitBreakerProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/hystrix/SleuthHystrixConcurrencyStrategyProperties.java
@@ -22,10 +22,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Sleuth Hystrix settings.
  *
  * @author Daniel Albuquerque
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// TODO: Hide in 3.x, if it isn't already deleted
 @ConfigurationProperties("spring.sleuth.hystrix.strategy")
 public class SleuthHystrixConcurrencyStrategyProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthMessagingProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/SleuthMessagingProperties.java
@@ -23,10 +23,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// TODO: Hide in 3.x, if it isn't already deleted
 @ConfigurationProperties("spring.sleuth")
 public class SleuthMessagingProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/SleuthOpentracingProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/opentracing/SleuthOpentracingProperties.java
@@ -23,10 +23,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// TODO: Hide in 3.x, if it isn't already deleted
 @ConfigurationProperties("spring.sleuth.opentracing")
 public class SleuthOpentracingProperties {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SleuthReactorProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SleuthReactorProperties.java
@@ -23,11 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.2
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.reactor")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthReactorProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceRedisProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceRedisProperties.java
@@ -22,11 +22,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Sleuth Redis properties.
  *
  * @author Daniel Albuquerque
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.redis")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class TraceRedisProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/rxjava/SleuthRxJavaSchedulersProperties.java
@@ -23,11 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.rxjava.schedulers")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthRxJavaSchedulersProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/SleuthSchedulingProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/scheduling/SleuthSchedulingProperties.java
@@ -24,11 +24,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.scheduled")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthSchedulingProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpLegacyProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpLegacyProperties.java
@@ -23,11 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.http.legacy")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthHttpLegacyProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthHttpProperties.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @since 2.0.0
  */
 @ConfigurationProperties("spring.sleuth.http")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthHttpProperties {
 
 	private boolean enabled = true;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/SleuthWebProperties.java
@@ -24,11 +24,9 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.web")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthWebProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/feign/SleuthFeignProperties.java
@@ -23,11 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.2
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.feign")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthFeignProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
@@ -26,11 +26,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Arthur Gavlyukovskiy
  * @since 1.0.12
- * @deprecated This type should have never been public and will be hidden or removed in
  * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.log.slf4j")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthSlf4jProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
@@ -26,11 +26,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Taras Danylchuk
  * @since 2.1.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.propagation.tag")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SleuthTagPropagationProperties {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerProperties.java
@@ -24,11 +24,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Marcin Grzejszczak
  * @author Adrian Cole
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.sleuth.sampler")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class SamplerProperties {
 
 	/**

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
@@ -25,11 +25,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Spencer Gibb
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @ConfigurationProperties("spring.zipkin")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class ZipkinProperties {
 
 	/**

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinSenderProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinSenderProperties.java
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @since 1.3.1
  */
 @ConfigurationProperties("spring.zipkin.sender")
+// TODO: Hide in 3.x, if it isn't already deleted
 public class ZipkinSenderProperties {
 
 	/**


### PR DESCRIPTION
I noticed we deleted many things without deprecation in 3.x and figured
deprecation was the right way. However, this doesn't work for auto-config
properties. This replaces deprecation with a TODO note to hide all the
types so that 4.x won't require guessing if someone externally is using
them directly or not.