### PR TITLE
Pares back some deprecation after analyzing each file

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizer.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizer.java
@@ -29,10 +29,8 @@ import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
  *
  * @author Dave Syer
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// public as most types in this package were documented for use
 public class LazyTraceAsyncCustomizer extends AsyncConfigurerSupport {
 
 	private final BeanFactory beanFactory;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncTaskExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncTaskExecutor.java
@@ -35,10 +35,8 @@ import org.springframework.core.task.AsyncTaskExecutor;
  *
  * @author Marcin Grzejszczak
  * @since 2.1.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// public as most types in this package were documented for use
 public class LazyTraceAsyncTaskExecutor implements AsyncTaskExecutor {
 
 	private static final Log log = LogFactory.getLog(LazyTraceAsyncTaskExecutor.class);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceExecutor.java
@@ -32,10 +32,8 @@ import org.springframework.cloud.sleuth.SpanNamer;
  *
  * @author Dave Syer
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// public as most types in this package were documented for use
 public class LazyTraceExecutor implements Executor {
 
 	private static final Log log = LogFactory.getLog(LazyTraceExecutor.class);

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
@@ -39,11 +39,9 @@ import org.springframework.util.concurrent.ListenableFuture;
  *
  * @author Marcin Grzejszczak
  * @since 1.0.10
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @SuppressWarnings("serial")
+// public as most types in this package were documented for use
 public class LazyTraceThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 
 	private static final Log log = LogFactory

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceCallable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceCallable.java
@@ -33,10 +33,8 @@ import org.springframework.cloud.sleuth.SpanNamer;
  * @author Spencer Gibb
  * @author Marcin Grzejszczak
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// public as most types in this package were documented for use
 public class TraceCallable<V> implements Callable<V> {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnable.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceRunnable.java
@@ -30,10 +30,8 @@ import org.springframework.cloud.sleuth.SpanNamer;
  * @author Spencer Gibb
  * @author Marcin Grzejszczak
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// public as most types in this package were documented for use
 public class TraceRunnable implements Runnable {
 
 	/**

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableExecutorService.java
@@ -36,10 +36,8 @@ import org.springframework.cloud.sleuth.SpanNamer;
  *
  * @author Gaurav Rai Mazra
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// public as most types in this package were documented for use
 public class TraceableExecutorService implements ExecutorService {
 
 	final ExecutorService delegate;

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/async/TraceableScheduledExecutorService.java
@@ -29,10 +29,8 @@ import org.springframework.beans.factory.BeanFactory;
  *
  * @author Gaurav Rai Mazra
  * @since 1.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
+// public as most types in this package were documented for use
 public class TraceableScheduledExecutorService extends TraceableExecutorService
 		implements ScheduledExecutorService {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessagingAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessagingAutoConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.sleuth.instrument.messaging;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,7 +48,6 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -86,10 +84,7 @@ import org.springframework.util.ReflectionUtils;
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean(Tracing.class)
 @ConditionalOnClass(MessagingTracing.class)
@@ -97,17 +92,17 @@ import org.springframework.util.ReflectionUtils;
 		TraceSpringMessagingAutoConfiguration.class })
 @OnMessagingEnabled
 @EnableConfigurationProperties(SleuthMessagingProperties.class)
+// public allows @AutoConfigureAfter(TraceMessagingAutoConfiguration)
+// for components needing MessagingTracing
 public class TraceMessagingAutoConfiguration {
-
-	@Autowired(required = false)
-	List<MessagingTracingCustomizer> messagingTracingCustomizers = new ArrayList<>();
 
 	@Bean
 	@ConditionalOnMissingBean
 	// NOTE: stable bean name as might be used outside sleuth
 	MessagingTracing messagingTracing(Tracing tracing,
 			@Nullable @ProducerSampler SamplerFunction<MessagingRequest> producerSampler,
-			@Nullable @ConsumerSampler SamplerFunction<MessagingRequest> consumerSampler) {
+			@Nullable @ConsumerSampler SamplerFunction<MessagingRequest> consumerSampler,
+			@Nullable List<MessagingTracingCustomizer> messagingTracingCustomizers) {
 
 		MessagingTracing.Builder builder = MessagingTracing.newBuilder(tracing);
 		if (producerSampler != null) {
@@ -116,8 +111,10 @@ public class TraceMessagingAutoConfiguration {
 		if (consumerSampler != null) {
 			builder.consumerSampler(consumerSampler);
 		}
-		for (MessagingTracingCustomizer customizer : this.messagingTracingCustomizers) {
-			customizer.customize(builder);
+		if (messagingTracingCustomizers != null) {
+			for (MessagingTracingCustomizer customizer : messagingTracingCustomizers) {
+				customizer.customize(builder);
+			}
 		}
 		return builder.build();
 	}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceHttpAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,12 +50,18 @@ import org.springframework.lang.Nullable;
  * @since 2.0.0
  */
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnProperty(name = "spring.sleuth.http.enabled", havingValue = "true",
-		matchIfMissing = true)
+// This was formerly conditional on TraceWebAutoConfiguration, which was
+// conditional on "spring.sleuth.web.enabled". As this is conditional on
+// "spring.sleuth.http.enabled", to be compatible with old behavior we have
+// to be conditional on two properties.
+@ConditionalOnProperty(
+		name = { "spring.sleuth.http.enabled", "spring.sleuth.web.enabled" },
+		havingValue = "true", matchIfMissing = true)
 @ConditionalOnBean(Tracing.class)
 @ConditionalOnClass(HttpTracing.class)
 @AutoConfigureAfter(TraceAutoConfiguration.class)
 @Import(TraceWebAutoConfiguration.class)
+@EnableConfigurationProperties(TraceKeys.class)
 // public allows @AutoConfigureAfter(TraceHttpAutoConfiguration)
 // for components needing HttpTracing
 public class TraceHttpAutoConfiguration {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebAsyncClientAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.sleuth.instrument.web.TraceWebServletAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.TraceHttpAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.AsyncClientHttpRequestFactory;
@@ -54,7 +54,7 @@ import org.springframework.web.client.AsyncRestTemplate;
 		matchIfMissing = true)
 @ConditionalOnClass(AsyncRestTemplate.class)
 @ConditionalOnBean(HttpTracing.class)
-@AutoConfigureAfter(TraceWebServletAutoConfiguration.class)
+@AutoConfigureAfter(TraceHttpAutoConfiguration.class)
 public class TraceWebAsyncClientAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -42,7 +42,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoR
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
 import org.springframework.cloud.gateway.filter.headers.HttpHeadersFilter;
-import org.springframework.cloud.sleuth.instrument.web.TraceWebServletAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.TraceHttpAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -69,7 +69,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration(proxyBeanMethods = false)
 @SleuthWebClientEnabled
 @ConditionalOnBean(HttpTracing.class)
-@AutoConfigureAfter(TraceWebServletAutoConfiguration.class)
+@AutoConfigureAfter(TraceHttpAutoConfiguration.class)
 @AutoConfigureBefore(HttpClientConfiguration.class)
 public class TraceWebClientAutoConfiguration {
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
@@ -25,7 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for slf4j.
  *
  * @author Arthur Gavlyukovskiy
- * @since 1.0.12 3.0
+ * @since 1.0.12
  */
 @ConfigurationProperties("spring.sleuth.log.slf4j")
 // TODO: Hide in 3.x, if it isn't already deleted

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/log/SleuthSlf4jProperties.java
@@ -25,8 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Configuration properties for slf4j.
  *
  * @author Arthur Gavlyukovskiy
- * @since 1.0.12
- * 3.0
+ * @since 1.0.12 3.0
  */
 @ConfigurationProperties("spring.sleuth.log.slf4j")
 // TODO: Hide in 3.x, if it isn't already deleted

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfiguration.java
@@ -33,10 +33,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Marcin Grzejszczak
  * @see SamplerCondition
  * @since 2.1.0
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(SamplerProperties.class)
 // This is not auto-configuration, but it was in the past. Leaving the name as

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/jms/config/TracingJmsListenerEndpointRegistry.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/jms/config/TracingJmsListenerEndpointRegistry.java
@@ -46,10 +46,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Marcin Grzejszczak
  * @since 2.1.1
- * @deprecated This type should have never been public and will be hidden or removed in
- * 3.0
  */
-@Deprecated
 public final class TracingJmsListenerEndpointRegistry
 		extends JmsListenerEndpointRegistry {
 

--- a/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-sleuth-core/src/main/resources/META-INF/spring.factories
@@ -4,7 +4,6 @@ org.springframework.cloud.sleuth.annotation.SleuthAnnotationAutoConfiguration,\
 org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration,\
 org.springframework.cloud.sleuth.propagation.SleuthTagPropagationAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceHttpAutoConfiguration,\
-org.springframework.cloud.sleuth.instrument.web.TraceWebAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.TraceWebServletAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.client.TraceWebClientAutoConfiguration,\
 org.springframework.cloud.sleuth.instrument.web.client.TraceWebAsyncClientAutoConfiguration,\


### PR DESCRIPTION
This puts specific comments in as to why certain files that seem like they
shouldn't be public are. Notably, this includes entrypoint autoconfiguration,
which are sometimes order sensitive. In other cases there are types that were
documented (notably the async package).

This also untangles a few configuration.