### PR TITLE
Backports BaggagePropagation to 2.2.x

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfiguration.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.autoconfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import brave.baggage.BaggageField;
+import brave.baggage.BaggagePropagation;
+import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
+import brave.baggage.BaggagePropagationCustomizer;
+import brave.propagation.B3Propagation;
+import brave.propagation.ExtraFieldCustomizer;
+import brave.propagation.ExtraFieldPropagation;
+import brave.propagation.Propagation;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.Nullable;
+
+/**
+ * {@link Configuration} for {@link BaggagePropagation}.
+ * <p>
+ *
+ * @author Spencer Gibb
+ * @author Marcin Grzejszczak
+ * @since 2.0.0
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(SleuthProperties.class)
+class TraceBaggageConfiguration {
+
+	static final Log logger = LogFactory.getLog(TraceBaggageConfiguration.class);
+
+	static final String LOCAL_KEYS = "spring.sleuth.local-keys";
+	static final String BAGGAGE_KEYS = "spring.sleuth.baggage-keys";
+	static final String PROPAGATION_KEYS = "spring.sleuth.propagation-keys";
+
+	// These List<String> beans allow us to get deprecated property values, regardless of
+	// if they were comma or yaml encoded. This keeps them out of SleuthBaggageProperties
+
+	@Bean(BAGGAGE_KEYS)
+	@ConfigurationProperties(BAGGAGE_KEYS)
+	List<String> baggageKeys() {
+		return new ArrayList<>();
+	}
+
+	@Bean(LOCAL_KEYS)
+	@ConfigurationProperties(LOCAL_KEYS)
+	List<String> localKeys() {
+		return new ArrayList<>();
+	}
+
+	@Bean(PROPAGATION_KEYS)
+	@ConfigurationProperties(PROPAGATION_KEYS)
+	List<String> propagationKeys() {
+		return new ArrayList<>();
+	}
+
+	/**
+	 * To override the underlying context format, override this bean and set the delegate
+	 * to what you need. {@link BaggagePropagation.FactoryBuilder} will unwrap itself if
+	 * no fields are configured.
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	BaggagePropagation.FactoryBuilder baggagePropagationFactoryBuilder() {
+		// Default for spring-messaging is on 2.2.x is MULTI, though 3.x it is
+		// SINGLE_NO_PARENT spring-cloud/spring-cloud-sleuth#1607
+		return BaggagePropagation.newFactoryBuilder(B3Propagation.newFactoryBuilder()
+				.injectFormat(B3Propagation.Format.MULTI).build());
+	}
+
+	Propagation.Factory sleuthPropagation(
+			ExtraFieldPropagation.FactoryBuilder extraFieldPropagationFactoryBuilder,
+			List<String> baggageKeys, List<String> localKeys,
+			List<String> propagationKeys,
+			@Nullable List<ExtraFieldCustomizer> extraFieldCustomizers) {
+		if (extraFieldCustomizers == null) {
+			extraFieldCustomizers = Collections.emptyList();
+		}
+		ExtraFieldPropagation.FactoryBuilder factoryBuilder;
+		if (extraFieldPropagationFactoryBuilder != null) {
+			factoryBuilder = extraFieldPropagationFactoryBuilder;
+		}
+		else {
+			factoryBuilder = ExtraFieldPropagation
+					.newFactoryBuilder(B3Propagation.FACTORY);
+		}
+		if (!baggageKeys.isEmpty()) {
+			factoryBuilder
+					// for HTTP
+					.addPrefixedFields("baggage-", baggageKeys)
+					// for messaging
+					.addPrefixedFields("baggage_", baggageKeys);
+		}
+		for (String key : propagationKeys) {
+			factoryBuilder.addField(key);
+		}
+		for (String key : localKeys) {
+			factoryBuilder.addRedactedField(key);
+		}
+		for (ExtraFieldCustomizer customizer : extraFieldCustomizers) {
+			customizer.customize(factoryBuilder);
+		}
+		return factoryBuilder.build();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	Propagation.Factory sleuthPropagation(
+			@Nullable ExtraFieldPropagation.FactoryBuilder extraFieldPropagationFactoryBuilder,
+			@Nullable List<ExtraFieldCustomizer> extraFieldCustomizers,
+			BaggagePropagation.FactoryBuilder factoryBuilder,
+			@Qualifier(BAGGAGE_KEYS) List<String> baggageKeys,
+			@Qualifier(LOCAL_KEYS) List<String> localKeys,
+			@Qualifier(PROPAGATION_KEYS) List<String> propagationKeys,
+			@Nullable List<BaggagePropagationCustomizer> baggagePropagationCustomizers) {
+
+		boolean useDeprecated = false;
+		if (extraFieldPropagationFactoryBuilder != null) {
+			logger.warn("ExtraFieldPropagation.FactoryBuilder is deprecated. "
+					+ "Please switch to BaggagePropagation.FactoryBuilder");
+			useDeprecated = true;
+		}
+		if (extraFieldCustomizers != null) {
+			logger.warn("ExtraFieldCustomizer is deprecated. "
+					+ "Please switch to BaggagePropagationCustomizer");
+			useDeprecated = true;
+		}
+		if (useDeprecated) {
+			return sleuthPropagation(extraFieldPropagationFactoryBuilder, localKeys,
+					propagationKeys, baggageKeys, extraFieldCustomizers);
+		}
+
+		for (String fieldName : localKeys) {
+			factoryBuilder.add(SingleBaggageField.local(BaggageField.create(fieldName)));
+		}
+
+		for (String fieldName : propagationKeys) {
+			factoryBuilder.add(SingleBaggageField.remote(BaggageField.create(fieldName)));
+		}
+
+		for (String key : baggageKeys) {
+			factoryBuilder.add(SingleBaggageField.newBuilder(BaggageField.create(key))
+					.addKeyName("baggage-" + key) // for HTTP
+					.addKeyName("baggage_" + key) // for messaging
+					.build());
+		}
+
+		if (baggagePropagationCustomizers != null) {
+			for (BaggagePropagationCustomizer customizer : baggagePropagationCustomizers) {
+				customizer.customize(factoryBuilder);
+			}
+		}
+		return factoryBuilder.build();
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/propagation/SleuthTagPropagationProperties.java
@@ -32,8 +32,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SleuthTagPropagationProperties {
 
 	/**
-	 * Enables a {@link TagPropagationSpanHandler} that adds extra propagated fields to
-	 * span tags.
+	 * Enables a {@link TagPropagationFinishedSpanHandler} that adds extra propagated
+	 * fields to span tags.
 	 */
 	private boolean enabled = true;
 

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
@@ -35,8 +35,7 @@ import org.springframework.context.support.GenericApplicationContext;
 public class TraceAutoConfigurationPropagationCustomizationTests {
 
 	// Default for spring-messaging is on 2.2.x is MULTI, though 3.x it is
-	// SINGLE_NO_PARENT
-	// spring-cloud/spring-cloud-sleuth#1607
+	// SINGLE_NO_PARENT spring-cloud/spring-cloud-sleuth#1607
 	Propagation.Factory defaultB3Propagation = B3Propagation.newFactoryBuilder()
 			.injectFormat(Format.MULTI).build();
 
@@ -56,7 +55,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 		this.contextRunner.withPropertyValues("spring.sleuth.baggage-keys=my-baggage")
 				.run((context) -> {
 					BDDAssertions.then(context.getBean(Propagation.Factory.class))
-							.hasFieldOrPropertyWithValue("delegate.delegate",
+							.hasFieldOrPropertyWithValue("delegate",
 									B3Propagation.FACTORY);
 				});
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfigurationTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.autoconfig;
+
+import brave.baggage.BaggageField;
+import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
+import brave.baggage.BaggagePropagationCustomizer;
+import brave.propagation.Propagation;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.groups.Tuple;
+import org.junit.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class TraceBaggageConfigurationTests {
+
+	static final String[] EMPTY_ARRAY = {};
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(TraceBaggageConfiguration.class));
+
+	@Test
+	public void shouldCreateLocalFields() {
+		this.contextRunner.withPropertyValues("spring.sleuth.local-keys=bp")
+				.run((context) -> assertThatBaggageFieldNameToKeyNames(context)
+						.containsOnly(tuple("bp", EMPTY_ARRAY)));
+	}
+
+	static ListAssert<Tuple> assertThatBaggageFieldNameToKeyNames(
+			AssertableApplicationContext context) {
+		return assertThat(context.getBean(Propagation.Factory.class))
+				.extracting("configs").asInstanceOf(InstanceOfAssertFactories.ARRAY)
+				.extracting("field.name", "keyNames.toArray")
+				.asInstanceOf(InstanceOfAssertFactories.list(Tuple.class));
+	}
+
+	@Test
+	public void shouldCreateRemoteFields() {
+		this.contextRunner
+				.withPropertyValues(
+						"spring.sleuth.propagation-keys=x-vcap-request-id,country-code")
+				.run((context) -> assertThatBaggageFieldNameToKeyNames(context)
+						.containsOnly(
+								tuple("x-vcap-request-id",
+										new String[] { "x-vcap-request-id" }),
+								tuple("country-code", new String[] { "country-code" })));
+	}
+
+	@Test
+	public void shouldCreateBaggageFields() {
+		this.contextRunner.withPropertyValues("spring.sleuth.baggage-keys=country-code")
+				.run((context) -> assertThatBaggageFieldNameToKeyNames(context)
+						.containsOnly(tuple("country-code", new String[] {
+								"baggage-country-code", "baggage_country-code" })));
+	}
+
+	@Test
+	public void canCreateBaggageFieldsWithJavaConfig() {
+		this.contextRunner.withUserConfiguration(CustomBaggageConfiguration.class)
+				.run((context) -> assertThatBaggageFieldNameToKeyNames(context)
+						.containsOnly(tuple("country-code", new String[] {
+								"baggage-country-code", "baggage_country-code" })));
+	}
+
+	@Configuration
+	static class CustomBaggageConfiguration {
+
+		@Bean
+		BaggagePropagationCustomizer countryCodeBaggageConfig() {
+			return fb -> fb.add(
+					SingleBaggageField.newBuilder(BaggageField.create("country-code"))
+							.addKeyName("baggage-country-code")
+							.addKeyName("baggage_country-code").build());
+		}
+
+	}
+
+}


### PR DESCRIPTION
This allows integrations of Sleuth to use the same approach for 2.2.x as 3.x:

If you have a custom base propagation format, override the `BaggagePropagation.Factory`
bean instead of `ExtraFieldsPropagation.Factory`

Note: one subtle difference 2.2.x to 3.x is the change in the primary inject format.

2.2.x is
```java
return BaggagePropagation.newFactoryBuilder(B3Propagation.newFactoryBuilder()
                         .injectFormat(B3Propagation.Format.MULTI).build());
```

3.0 is
```java
return BaggagePropagation.newFactoryBuilder(B3Propagation.newFactoryBuilder()
                         .injectFormat(B3Propagation.Format.SINGLE_NO_PARENT).build());
```
per #1607

See https://github.com/spring-cloud/spring-cloud-gcp/issues/2268