### PR TITLE
Drops zipkin dependency from spring-cloud-sleuth-core

### DIFF
--- a/spring-cloud-sleuth-core/pom.xml
+++ b/spring-cloud-sleuth-core/pom.xml
@@ -184,6 +184,16 @@
 		<dependency>
 			<groupId>io.zipkin.brave</groupId>
 			<artifactId>brave</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>io.zipkin.reporter2</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.zipkin.zipkin2</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>io.zipkin.brave</groupId>

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfiguration.java
@@ -16,13 +16,10 @@
 
 package org.springframework.cloud.sleuth.autoconfig;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import brave.CurrentSpanCustomizer;
-import brave.ErrorParser;
 import brave.Tracer;
 import brave.Tracing;
 import brave.TracingCustomizer;
@@ -32,20 +29,8 @@ import brave.propagation.CurrentTraceContextCustomizer;
 import brave.propagation.Propagation;
 import brave.propagation.ThreadLocalCurrentTraceContext;
 import brave.sampler.Sampler;
-import io.micrometer.core.instrument.MeterRegistry;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import zipkin2.Span;
-import zipkin2.reporter.InMemoryReporterMetrics;
-import zipkin2.reporter.Reporter;
-import zipkin2.reporter.ReporterMetrics;
-import zipkin2.reporter.brave.ZipkinSpanHandler;
-import zipkin2.reporter.metrics.micrometer.MicrometerReporterMetrics;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.LocalServiceName;
@@ -85,38 +70,17 @@ public class TraceAutoConfiguration {
 	 */
 	public static final String DEFAULT_SERVICE_NAME = "default";
 
-	/**
-	 * Sort Zipkin Handlers last, so that redactions etc happen prior.
-	 */
-	static final Comparator<SpanHandler> SPAN_HANDLER_COMPARATOR = (o1, o2) -> {
-		if (o1 instanceof ZipkinSpanHandler) {
-			if (o2 instanceof ZipkinSpanHandler) {
-				return 0;
-			}
-			return 1;
-		}
-		else if (o2 instanceof ZipkinSpanHandler) {
-			return -1;
-		}
-		return 0;
-	};
-
 	@Bean
 	@ConditionalOnMissingBean
 	// NOTE: stable bean name as might be used outside sleuth
 	Tracing tracing(@LocalServiceName String serviceName, Propagation.Factory factory,
 			CurrentTraceContext currentTraceContext, Sampler sampler,
-			ErrorParser errorParser, SleuthProperties sleuthProperties,
-			@Nullable List<Reporter<zipkin2.Span>> spanReporters,
-			@Nullable List<SpanHandler> spanHandlers,
+			SleuthProperties sleuthProperties, @Nullable List<SpanHandler> spanHandlers,
 			@Nullable List<TracingCustomizer> tracingCustomizers) {
 		Tracing.Builder builder = Tracing.newBuilder().sampler(sampler)
-				.errorParser(errorParser)
 				.localServiceName(StringUtils.isEmpty(serviceName) ? DEFAULT_SERVICE_NAME
 						: serviceName)
 				.propagationFactory(factory).currentTraceContext(currentTraceContext)
-				.spanReporter(new CompositeReporter(
-						spanReporters != null ? spanReporters : Collections.emptyList()))
 				.traceId128Bit(sleuthProperties.isTraceId128())
 				.supportsJoin(sleuthProperties.isSupportsJoin());
 		if (spanHandlers != null) {
@@ -130,18 +94,7 @@ public class TraceAutoConfiguration {
 			}
 		}
 
-		reorderZipkinHandlersLast(builder);
 		return builder.build();
-	}
-
-	private void reorderZipkinHandlersLast(Tracing.Builder builder) {
-		List<SpanHandler> configuredSpanHandlers = new ArrayList<>(
-				builder.spanHandlers());
-		configuredSpanHandlers.sort(SPAN_HANDLER_COMPARATOR);
-		builder.clearSpanHandlers();
-		for (SpanHandler spanHandler : configuredSpanHandlers) {
-			builder.addSpanHandler(spanHandler);
-		}
 	}
 
 	@Bean(name = TRACER_BEAN_NAME)
@@ -184,108 +137,9 @@ public class TraceAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	Reporter<zipkin2.Span> noOpSpanReporter() {
-		return Reporter.NOOP;
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
-	ErrorParser errorParser() {
-		return new ErrorParser();
-	}
-
-	@Bean
-	@ConditionalOnMissingBean
 	// NOTE: stable bean name as might be used outside sleuth
 	CurrentSpanCustomizer spanCustomizer(Tracing tracing) {
 		return CurrentSpanCustomizer.create(tracing);
-	}
-
-	private static final class CompositeReporter implements Reporter<zipkin2.Span> {
-
-		private static final Log log = LogFactory.getLog(CompositeReporter.class);
-
-		private final Reporter<zipkin2.Span> spanReporter;
-
-		private CompositeReporter(List<Reporter<Span>> spanReporters) {
-			this.spanReporter = spanReporters.size() == 1 ? spanReporters.get(0)
-					: new ListReporter(spanReporters);
-		}
-
-		@Override
-		public void report(Span span) {
-			this.spanReporter.report(span);
-		}
-
-		@Override
-		public String toString() {
-			return "CompositeReporter{ spanReporters=" + this.spanReporter + '}';
-		}
-
-		private static final class ListReporter implements Reporter<zipkin2.Span> {
-
-			private final List<Reporter<Span>> spanReporters;
-
-			private ListReporter(List<Reporter<Span>> spanReporters) {
-				this.spanReporters = spanReporters;
-			}
-
-			@Override
-			public void report(Span span) {
-				for (Reporter<zipkin2.Span> spanReporter : this.spanReporters) {
-					try {
-						spanReporter.report(span);
-					}
-					catch (Exception ex) {
-						log.warn("Exception occurred while trying to report the span "
-								+ span, ex);
-					}
-				}
-			}
-
-			@Override
-			public String toString() {
-				return "ListReporter{" + "spanReporters=" + this.spanReporters + '}';
-			}
-
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnMissingClass("io.micrometer.core.instrument.MeterRegistry")
-	static class TraceMetricsInMemoryConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean
-		ReporterMetrics sleuthReporterMetrics() {
-			return new InMemoryReporterMetrics();
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(MeterRegistry.class)
-	static class TraceMetricsMicrometerConfiguration {
-
-		@Configuration(proxyBeanMethods = false)
-		@ConditionalOnMissingBean(ReporterMetrics.class)
-		static class NoReporterMetricsBeanConfiguration {
-
-			@Bean
-			@ConditionalOnBean(MeterRegistry.class)
-			ReporterMetrics sleuthMicrometerReporterMetrics(MeterRegistry meterRegistry) {
-				return MicrometerReporterMetrics.create(meterRegistry);
-			}
-
-			@Bean
-			@ConditionalOnMissingBean(MeterRegistry.class)
-			ReporterMetrics sleuthReporterMetrics() {
-				return new InMemoryReporterMetrics();
-			}
-
-		}
-
 	}
 
 }

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectFluxTests.java
@@ -312,8 +312,8 @@ public class SleuthSpanCreatorAspectFluxTests {
 		Awaitility.await().untilAsserted(() -> {
 			then(this.spans).hasSize(1);
 			then(this.spans.get(0).name()).isEqualTo("test-method12");
-			then(this.spans.get(0).tags()).containsEntry("testTag12", "test")
-					.containsEntry("error", "test exception 12");
+			then(this.spans.get(0).tags()).containsEntry("testTag12", "test");
+			then(this.spans.get(0).error()).hasMessageContaining("test exception 12");
 			then(this.spans.get(0).finishTimestamp()).isNotZero();
 			then(this.tracer.currentSpan()).isNull();
 		});
@@ -341,7 +341,7 @@ public class SleuthSpanCreatorAspectFluxTests {
 		Awaitility.await().untilAsserted(() -> {
 			then(this.spans).hasSize(1);
 			then(this.spans.get(0).name()).isEqualTo("foo");
-			then(this.spans.get(0).tags()).containsEntry("error", "test exception 13");
+			then(this.spans.get(0).error()).hasMessageContaining("test exception 13");
 			then(this.spans.get(0).annotations().stream().map(Map.Entry::getValue)
 					.collect(Collectors.toList())).contains("testMethod13.before",
 							"testMethod13.afterFailure", "testMethod13.after");

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectMonoTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectMonoTests.java
@@ -325,8 +325,8 @@ public class SleuthSpanCreatorAspectMonoTests {
 		Awaitility.await().untilAsserted(() -> {
 			then(this.spans).hasSize(1);
 			then(this.spans.get(0).name()).isEqualTo("test-method12");
-			then(this.spans.get(0).tags()).containsEntry("testTag12", "test")
-					.containsEntry("error", "test exception 12");
+			then(this.spans.get(0).tags()).containsEntry("testTag12", "test");
+			then(this.spans.get(0).error()).hasMessageContaining("test exception 12");
 			then(this.spans.get(0).finishTimestamp()).isNotZero();
 			then(this.tracer.currentSpan()).isNull();
 		});
@@ -354,7 +354,7 @@ public class SleuthSpanCreatorAspectMonoTests {
 		Awaitility.await().untilAsserted(() -> {
 			then(this.spans).hasSize(1);
 			then(this.spans.get(0).name()).isEqualTo("foo");
-			then(this.spans.get(0).tags()).containsEntry("error", "test exception 13");
+			then(this.spans.get(0).error()).hasMessageContaining("test exception 13");
 			then(this.spans.get(0).annotations().stream().map(Map.Entry::getValue)
 					.collect(Collectors.toList())).contains("testMethod13.before",
 							"testMethod13.afterFailure", "testMethod13.after");

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/annotation/SleuthSpanCreatorAspectTests.java
@@ -233,8 +233,8 @@ public class SleuthSpanCreatorAspectTests {
 
 		then(this.spans).hasSize(1);
 		then(this.spans.get(0).name()).isEqualTo("test-method12");
-		then(this.spans.get(0).tags()).containsEntry("testTag12", "test")
-				.containsEntry("error", "test exception 12");
+		then(this.spans.get(0).tags()).containsEntry("testTag12", "test");
+		then(this.spans.get(0).error()).hasMessageContaining("test exception 12");
 		then(this.spans.get(0).finishTimestamp()).isNotZero();
 		then(this.tracer.currentSpan()).isNull();
 	}
@@ -256,7 +256,7 @@ public class SleuthSpanCreatorAspectTests {
 
 		then(this.spans).hasSize(1);
 		then(this.spans.get(0).name()).isEqualTo("foo");
-		then(this.spans.get(0).tags()).containsEntry("error", "test exception 13");
+		then(this.spans.get(0).error()).hasMessageContaining("test exception 13");
 		then(this.spans.get(0).annotations().stream().map(Map.Entry::getValue)
 				.collect(Collectors.toList())).contains("testMethod13.before",
 						"testMethod13.afterFailure", "testMethod13.after");

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.sleuth.autoconfig;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import brave.Tracing;
@@ -24,9 +23,11 @@ import brave.baggage.BaggageField;
 import brave.baggage.BaggagePropagation;
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
 import brave.baggage.BaggagePropagationCustomizer;
+import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.Propagation;
+import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
 import brave.sampler.RateLimitingSampler;
 import brave.sampler.Sampler;
@@ -34,75 +35,17 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
-import zipkin2.reporter.InMemoryReporterMetrics;
-import zipkin2.reporter.Reporter;
-import zipkin2.reporter.ReporterMetrics;
-import zipkin2.reporter.brave.ZipkinSpanHandler;
-import zipkin2.reporter.metrics.micrometer.MicrometerReporterMetrics;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration.SPAN_HANDLER_COMPARATOR;
 
 public class TraceAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(TraceAutoConfiguration.class));
-
-	@Test
-	void span_handler_comparator() {
-		SpanHandler handler1 = mock(SpanHandler.class);
-		SpanHandler handler2 = mock(SpanHandler.class);
-		ZipkinSpanHandler zipkin1 = mock(ZipkinSpanHandler.class);
-		ZipkinSpanHandler zipkin2 = mock(ZipkinSpanHandler.class);
-
-		ArrayList<SpanHandler> spanHandlers = new ArrayList<>();
-		spanHandlers.add(handler1);
-		spanHandlers.add(zipkin1);
-		spanHandlers.add(handler2);
-		spanHandlers.add(zipkin2);
-
-		spanHandlers.sort(SPAN_HANDLER_COMPARATOR);
-
-		assertThat(spanHandlers).containsExactly(handler1, handler2, zipkin1, zipkin2);
-	}
-
-	@Test
-	void should_apply_micrometer_reporter_metrics_when_meter_registry_bean_present() {
-		this.contextRunner.withUserConfiguration(WithMeterRegistry.class)
-				.run((context) -> {
-					ReporterMetrics bean = context.getBean(ReporterMetrics.class);
-
-					BDDAssertions.then(bean)
-							.isInstanceOf(MicrometerReporterMetrics.class);
-				});
-	}
-
-	@Test
-	void should_apply_in_memory_metrics_when_meter_registry_bean_missing() {
-		this.contextRunner.run((context) -> {
-			ReporterMetrics bean = context.getBean(ReporterMetrics.class);
-
-			BDDAssertions.then(bean).isInstanceOf(InMemoryReporterMetrics.class);
-		});
-	}
-
-	@Test
-	void should_apply_in_memory_metrics_when_meter_registry_class_missing() {
-		this.contextRunner.withClassLoader(new FilteredClassLoader(MeterRegistry.class))
-				.run((context) -> {
-					ReporterMetrics bean = context.getBean(ReporterMetrics.class);
-
-					BDDAssertions.then(bean).isInstanceOf(InMemoryReporterMetrics.class);
-				});
-	}
 
 	/**
 	 * Duplicates
@@ -123,8 +66,8 @@ public class TraceAutoConfigurationTests {
 	 * intentionally, to ensure configuration condition bugs do not exist.
 	 */
 	@Test
-	void should_use_RateLimitedSampler_when_reporting() {
-		this.contextRunner.withUserConfiguration(WithReporter.class).run((context -> {
+	void should_use_RateLimitedSampler_withSpanHandler() {
+		this.contextRunner.withUserConfiguration(WithSpanHandler.class).run((context -> {
 			final Sampler bean = context.getBean(Sampler.class);
 			BDDAssertions.then(bean).isInstanceOf(RateLimitingSampler.class);
 		}));
@@ -137,11 +80,10 @@ public class TraceAutoConfigurationTests {
 	 */
 	@Test
 	void should_override_sampler() {
-		this.contextRunner.withUserConfiguration(WithReporter.class, WithSampler.class)
-				.run((context -> {
-					final Sampler bean = context.getBean(Sampler.class);
-					BDDAssertions.then(bean).isSameAs(Sampler.ALWAYS_SAMPLE);
-				}));
+		this.contextRunner.withUserConfiguration(WithSampler.class).run((context -> {
+			final Sampler bean = context.getBean(Sampler.class);
+			BDDAssertions.then(bean).isSameAs(Sampler.ALWAYS_SAMPLE);
+		}));
 	}
 
 	@Test
@@ -231,21 +173,16 @@ public class TraceAutoConfigurationTests {
 	}
 
 	@Configuration
-	static class WithMeterRegistry {
+	static class WithSpanHandler {
 
 		@Bean
-		MeterRegistry meterRegistry() {
-			return new SimpleMeterRegistry();
-		}
-
-	}
-
-	@Configuration
-	static class WithReporter {
-
-		@Bean
-		Reporter<zipkin2.Span> spanReporter() {
-			return zipkin2.Span::toString;
+		SpanHandler testSpanHandler() {
+			return new SpanHandler() {
+				@Override
+				public boolean end(TraceContext context, MutableSpan span, Cause cause) {
+					return true;
+				}
+			};
 		}
 
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/discoveryexception/WebClientDiscoveryExceptionTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/discoveryexception/WebClientDiscoveryExceptionTests.java
@@ -97,7 +97,7 @@ public class WebClientDiscoveryExceptionTests {
 		// hystrix commands should finish at this point
 		Thread.sleep(200);
 		then(this.spans.spans().stream().filter(span1 -> span1.kind() == Span.Kind.CLIENT)
-				.findFirst().get().tags()).containsKey("error");
+				.findFirst().get().error()).isNotNull();
 	}
 
 	@Test

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exception/WebClientExceptionTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/exception/WebClientExceptionTests.java
@@ -98,7 +98,7 @@ public class WebClientExceptionTests {
 
 		then(this.tracer.tracer().currentSpan()).isNull();
 		then(this.spans).isNotEmpty();
-		then(this.spans.get(0).tags()).containsKey("error");
+		then(this.spans.get(0).error()).isNotNull();
 	}
 
 	static Stream<Object> parametersForShouldCloseSpanUponException() {

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/sampler/SamplerAutoConfigurationTests.java
@@ -25,8 +25,6 @@ import brave.sampler.RateLimitingSampler;
 import brave.sampler.Sampler;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
-import zipkin2.Span;
-import zipkin2.reporter.Reporter;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -60,28 +58,11 @@ public class SamplerAutoConfigurationTests {
 	}
 
 	@Test
-	void should_use_RateLimitedSampler_withReporter() {
-		this.contextRunner.withUserConfiguration(WithReporter.class).run((context -> {
-			final Sampler bean = context.getBean(Sampler.class);
-			BDDAssertions.then(bean).isInstanceOf(RateLimitingSampler.class);
-		}));
-	}
-
-	@Test
 	void should_use_RateLimitedSampler_withTracingCustomizer() {
 		this.contextRunner.withUserConfiguration(WithTracingCustomizer.class)
 				.run((context -> {
 					final Sampler bean = context.getBean(Sampler.class);
 					BDDAssertions.then(bean).isInstanceOf(RateLimitingSampler.class);
-				}));
-	}
-
-	@Test
-	void should_override_sampler() {
-		this.contextRunner.withUserConfiguration(WithReporter.class, WithSampler.class)
-				.run((context -> {
-					final Sampler bean = context.getBean(Sampler.class);
-					BDDAssertions.then(bean).isSameAs(Sampler.ALWAYS_SAMPLE);
 				}));
 	}
 
@@ -147,26 +128,6 @@ public class SamplerAutoConfigurationTests {
 					return true;
 				}
 			};
-		}
-
-	}
-
-	@Configuration
-	static class WithReporter {
-
-		@Bean
-		Reporter<Span> spanReporter() {
-			return zipkin2.Span::toString;
-		}
-
-	}
-
-	@Configuration
-	static class WithSampler {
-
-		@Bean
-		Sampler alwaysSampler() {
-			return Sampler.ALWAYS_SAMPLE;
 		}
 
 	}

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinAutoConfiguration.java
@@ -16,24 +16,38 @@
 
 package org.springframework.cloud.sleuth.zipkin2;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import brave.Tag;
+import brave.TracingCustomizer;
+import brave.handler.SpanHandler;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import zipkin2.CheckResult;
 import zipkin2.Span;
 import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.InMemoryReporterMetrics;
 import zipkin2.reporter.Reporter;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.Sender;
+import zipkin2.reporter.brave.ZipkinSpanHandler;
+import zipkin2.reporter.metrics.micrometer.MicrometerReporterMetrics;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -45,6 +59,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
+import org.springframework.lang.Nullable;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -73,6 +88,22 @@ import org.springframework.web.client.RestTemplate;
 public class ZipkinAutoConfiguration {
 
 	private static final Log log = LogFactory.getLog(ZipkinAutoConfiguration.class);
+
+	/**
+	 * Sort Zipkin Handlers last, so that redactions etc happen prior.
+	 */
+	static final Comparator<SpanHandler> SPAN_HANDLER_COMPARATOR = (o1, o2) -> {
+		if (o1 instanceof ZipkinSpanHandler) {
+			if (o2 instanceof ZipkinSpanHandler) {
+				return 0;
+			}
+			return 1;
+		}
+		else if (o2 instanceof ZipkinSpanHandler) {
+			return -1;
+		}
+		return 0;
+	};
 
 	/**
 	 * Zipkin reporter bean name. Name of the bean matters for supporting multiple tracing
@@ -143,6 +174,44 @@ public class ZipkinAutoConfiguration {
 		}
 	}
 
+	/** Returns one handler for as many reporters as exist. */
+	@Bean
+	SpanHandler zipkinSpanHandler(@Nullable List<Reporter<Span>> spanReporters,
+			@Nullable Tag<Throwable> errorTag) {
+		if (spanReporters == null) {
+			return SpanHandler.NOOP;
+		}
+
+		LinkedHashSet<Reporter<Span>> reporters = new LinkedHashSet<>(spanReporters);
+		reporters.remove(Reporter.NOOP);
+		if (spanReporters.isEmpty()) {
+			return SpanHandler.NOOP;
+		}
+
+		Reporter<Span> spanReporter = reporters.size() == 1 ? reporters.iterator().next()
+				: new CompositeSpanReporter(reporters.toArray(new Reporter[0]));
+
+		ZipkinSpanHandler.Builder builder = ZipkinSpanHandler.newBuilder(spanReporter);
+		if (errorTag != null) {
+			builder.errorTag(errorTag);
+		}
+		return builder.build();
+	}
+
+	/** This ensures Zipkin reporters end up after redaction, etc. */
+	@Bean
+	TracingCustomizer reorderZipkinHandlersLast() {
+		return builder -> {
+			List<SpanHandler> configuredSpanHandlers = new ArrayList<>(
+					builder.spanHandlers());
+			configuredSpanHandlers.sort(SPAN_HANDLER_COMPARATOR);
+			builder.clearSpanHandlers();
+			for (SpanHandler spanHandler : configuredSpanHandlers) {
+				builder.addSpanHandler(spanHandler);
+			}
+		};
+	}
+
 	@Bean
 	@ConditionalOnMissingBean
 	public ZipkinRestTemplateCustomizer zipkinRestTemplateCustomizer(
@@ -202,6 +271,86 @@ public class ZipkinAutoConfiguration {
 		public EndpointLocator zipkinEndpointLocator() {
 			return new DefaultEndpointLocator(this.registration, this.serverProperties,
 					this.environment, this.zipkinProperties, this.inetUtils);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnMissingClass("io.micrometer.core.instrument.MeterRegistry")
+	static class TraceMetricsInMemoryConfiguration {
+
+		@Bean
+		@ConditionalOnMissingBean
+		ReporterMetrics sleuthReporterMetrics() {
+			return new InMemoryReporterMetrics();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(MeterRegistry.class)
+	static class TraceMetricsMicrometerConfiguration {
+
+		@Configuration(proxyBeanMethods = false)
+		@ConditionalOnMissingBean(ReporterMetrics.class)
+		static class NoReporterMetricsBeanConfiguration {
+
+			@Bean
+			@ConditionalOnBean(MeterRegistry.class)
+			ReporterMetrics sleuthMicrometerReporterMetrics(MeterRegistry meterRegistry) {
+				return MicrometerReporterMetrics.create(meterRegistry);
+			}
+
+			@Bean
+			@ConditionalOnMissingBean(MeterRegistry.class)
+			ReporterMetrics sleuthReporterMetrics() {
+				return new InMemoryReporterMetrics();
+			}
+
+		}
+
+	}
+
+	// Zipkin conversion only happens once per mutable span
+	static final class CompositeSpanReporter implements Reporter<Span> {
+
+		final Reporter<Span>[] reporters;
+
+		CompositeSpanReporter(Reporter<Span>[] reporters) {
+			this.reporters = reporters;
+		}
+
+		@Override
+		public void report(Span span) {
+			for (Reporter<Span> reporter : reporters) {
+				try {
+					reporter.report(span);
+				}
+				catch (RuntimeException ex) {
+					// TODO: message lifted from ListReporter: this is probably too much
+					// for warn level
+					log.warn("Exception occurred while trying to report the span " + span,
+							ex);
+				}
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			return Arrays.hashCode(reporters);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof CompositeSpanReporter)) {
+				return false;
+			}
+			return Arrays.equals(((CompositeSpanReporter) obj).reporters, reporters);
+		}
+
+		@Override
+		public String toString() {
+			return Arrays.toString(reporters);
 		}
 
 	}

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterIntegrationTests.java
@@ -197,7 +197,7 @@ public class TraceFilterIntegrationTests extends AbstractMvcIntegrationTest {
 		// we need to dump the span cause it's not in TracingFilter since TF
 		// has also error dispatch and the ErrorController would report the span
 		then(this.spans).hasSize(1);
-		then(this.spans.get(0).tags()).containsEntry("error",
+		then(this.spans.get(0).error()).hasMessageContaining(
 				"Request processing failed; nested exception is java.lang.RuntimeException");
 	}
 

--- a/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-mvc-tests/src/test/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterWebIntegrationTests.java
@@ -107,7 +107,7 @@ public class TraceFilterWebIntegrationTests {
 		}
 
 		then(this.currentTraceContext.get()).isNull();
-		MutableSpan fromFirstTraceFilterFlow = spanHandler.takeRemoteSpanWithErrorTag(
+		MutableSpan fromFirstTraceFilterFlow = spanHandler.takeRemoteSpanWithErrorMessage(
 				Kind.SERVER,
 				"Request processing failed; nested exception is java.lang.RuntimeException: Throwing exception");
 		then(fromFirstTraceFilterFlow.tags()).containsEntry("http.method", "GET")


### PR DESCRIPTION
There was emmense work to prepare for decoupling of spring-cloud-sleuth-core
from Zipkin. This included complete test conversion and deprecations between
2.2.x and 3.0.x.

This moves all Zipkin related code to spring-cloud-sleuth-zipkin, making the
primary data recording tool `SpanHandler` as opposed to `Reporter<zipkin2.Span>`

For example, Wavefront and soon Stackdriver can implement `SpanHandler` and
skip conversion into the Zipkin model first. `SpanHandler` also includes
begin and end hooks which allow data extensions to be developed.

see https://github.com/wavefrontHQ/wavefront-spring-boot