### PR TITLE
Uses B3 single for non-remote spans (2.2.x)

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfiguration.java
@@ -25,6 +25,7 @@ import brave.baggage.BaggagePropagation;
 import brave.baggage.BaggagePropagationConfig.SingleBaggageField;
 import brave.baggage.BaggagePropagationCustomizer;
 import brave.propagation.B3Propagation;
+import brave.propagation.B3Propagation.Format;
 import brave.propagation.ExtraFieldCustomizer;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;
@@ -57,6 +58,11 @@ class TraceBaggageConfiguration {
 	static final String BAGGAGE_KEYS = "spring.sleuth.baggage-keys";
 	static final String PROPAGATION_KEYS = "spring.sleuth.propagation-keys";
 
+	// Note: Versions <2.2.3 use injectFormat(MULTI) for non-remote (ex spring-messaging)
+	// See #1643
+	static final Propagation.Factory B3_FACTORY =
+			B3Propagation.newFactoryBuilder().injectFormat(Format.SINGLE_NO_PARENT).build();
+
 	// These List<String> beans allow us to get deprecated property values, regardless of
 	// if they were comma or yaml encoded. This keeps them out of SleuthBaggageProperties
 
@@ -82,14 +88,15 @@ class TraceBaggageConfiguration {
 	 * To override the underlying context format, override this bean and set the delegate
 	 * to what you need. {@link BaggagePropagation.FactoryBuilder} will unwrap itself if
 	 * no fields are configured.
+	 *
+	 * <p>
+	 * This will use {@link Format#SINGLE_NO_PARENT} for non-remote spans,
+	 * such as for messaging. Note: it will still parse incoming multi-header spans.
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	BaggagePropagation.FactoryBuilder baggagePropagationFactoryBuilder() {
-		// Default for spring-messaging is on 2.2.x is MULTI, though 3.x it is
-		// SINGLE_NO_PARENT spring-cloud/spring-cloud-sleuth#1607
-		return BaggagePropagation.newFactoryBuilder(B3Propagation.newFactoryBuilder()
-				.injectFormat(B3Propagation.Format.MULTI).build());
+		return BaggagePropagation.newFactoryBuilder(B3_FACTORY);
 	}
 
 	Propagation.Factory sleuthPropagation(
@@ -105,8 +112,7 @@ class TraceBaggageConfiguration {
 			factoryBuilder = extraFieldPropagationFactoryBuilder;
 		}
 		else {
-			factoryBuilder = ExtraFieldPropagation
-					.newFactoryBuilder(B3Propagation.FACTORY);
+			factoryBuilder = ExtraFieldPropagation.newFactoryBuilder(B3_FACTORY);
 		}
 		if (!baggageKeys.isEmpty()) {
 			factoryBuilder

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceBaggageConfiguration.java
@@ -60,8 +60,8 @@ class TraceBaggageConfiguration {
 
 	// Note: Versions <2.2.3 use injectFormat(MULTI) for non-remote (ex spring-messaging)
 	// See #1643
-	static final Propagation.Factory B3_FACTORY =
-			B3Propagation.newFactoryBuilder().injectFormat(Format.SINGLE_NO_PARENT).build();
+	static final Propagation.Factory B3_FACTORY = B3Propagation.newFactoryBuilder()
+			.injectFormat(Format.SINGLE_NO_PARENT).build();
 
 	// These List<String> beans allow us to get deprecated property values, regardless of
 	// if they were comma or yaml encoded. This keeps them out of SleuthBaggageProperties
@@ -90,8 +90,8 @@ class TraceBaggageConfiguration {
 	 * no fields are configured.
 	 *
 	 * <p>
-	 * This will use {@link Format#SINGLE_NO_PARENT} for non-remote spans,
-	 * such as for messaging. Note: it will still parse incoming multi-header spans.
+	 * This will use {@link Format#SINGLE_NO_PARENT} for non-remote spans, such as for
+	 * messaging. Note: it will still parse incoming multi-header spans.
 	 */
 	@Bean
 	@ConditionalOnMissingBean

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.sleuth.autoconfig;
 
-import brave.propagation.B3Propagation;
-import brave.propagation.B3Propagation.Format;
 import brave.propagation.B3SinglePropagation;
 import brave.propagation.ExtraFieldPropagation;
 import brave.propagation.Propagation;

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceAutoConfigurationPropagationCustomizationTests.java
@@ -34,11 +34,6 @@ import org.springframework.context.support.GenericApplicationContext;
 
 public class TraceAutoConfigurationPropagationCustomizationTests {
 
-	// Default for spring-messaging is on 2.2.x is MULTI, though 3.x it is
-	// SINGLE_NO_PARENT spring-cloud/spring-cloud-sleuth#1607
-	Propagation.Factory defaultB3Propagation = B3Propagation.newFactoryBuilder()
-			.injectFormat(Format.MULTI).build();
-
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(TraceAutoConfiguration.class));
 
@@ -46,7 +41,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 	public void stillCreatesDefault() {
 		this.contextRunner.run((context) -> {
 			BDDAssertions.then(context.getBean(Propagation.Factory.class))
-					.isEqualTo(defaultB3Propagation);
+					.isEqualTo(TraceBaggageConfiguration.B3_FACTORY);
 		});
 	}
 
@@ -56,7 +51,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 				.run((context) -> {
 					BDDAssertions.then(context.getBean(Propagation.Factory.class))
 							.hasFieldOrPropertyWithValue("delegate",
-									B3Propagation.FACTORY);
+									TraceBaggageConfiguration.B3_FACTORY);
 				});
 	}
 
@@ -65,7 +60,7 @@ public class TraceAutoConfigurationPropagationCustomizationTests {
 		this.contextRunner.withPropertyValues("spring.application.name=")
 				.run((context) -> {
 					BDDAssertions.then(context.getBean(Propagation.Factory.class))
-							.isEqualTo(B3Propagation.FACTORY);
+							.isEqualTo(TraceBaggageConfiguration.B3_FACTORY);
 				});
 	}
 


### PR DESCRIPTION
This makes sure there cannot be JMS problems related to use of
hyphenated headers unless someone overrides the `Propagation.Factory`.

To avoid this, we set non-remote spans to B3 single format as done on
the 3.x branch here:
https://github.com/spring-cloud/spring-cloud-sleuth/pull/1607/files#diff-db43b7e91bd69d063333c20b947c902bR83-R84

Fixes #1643