### PR TITLE
Fixes bug where we didn't fall back to current span

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/ReactorSleuthMethodInvocationProcessor.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/annotation/ReactorSleuthMethodInvocationProcessor.java
@@ -146,7 +146,9 @@ class ReactorSleuthMethodInvocationProcessor
 			Span span;
 			Tracer tracer = this.processor.tracer();
 			if (this.span == null) {
-				span = tracer.newTrace();
+				// If we aren't continuing a trace from this flow, use nextSpan so that it
+				// can consider the "current span" (typically, backed by a thread-local)
+				span = tracer.nextSpan();
 				this.processor.newSpanParser().parse(this.invocation, this.newSpan, span);
 				span.start();
 			}


### PR DESCRIPTION
I introduced a bug on #1525 which resulted in restarting of a trace, instead of continuing one. This fixes the bug and backfills the missing test.

Thanks @adirepo for the tip

Fixes #1634