### PR TITLE
Permits Actuator endpoints to depend on HttpTracing

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.sleuth.instrument.web;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +25,7 @@ import java.util.stream.Collectors;
 
 import brave.Tracing;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.BeanCurrentlyInCreationException;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
@@ -43,6 +42,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -64,32 +64,53 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(SleuthWebProperties.class)
 public class TraceWebAutoConfiguration {
 
-	@Autowired(required = false)
-	List<SingleSkipPattern> patterns = new ArrayList<>();
-
 	@Bean
 	@ConditionalOnMissingBean
-	SkipPatternProvider sleuthSkipPatternProvider() {
-		if (this.patterns == null) {
+	SkipPatternProvider sleuthSkipPatternProvider(
+			@Nullable List<SingleSkipPattern> patterns) {
+		if (patterns == null || patterns.isEmpty()) {
 			return null;
 		}
-		List<Pattern> presentPatterns = this.patterns.stream()
+
+		// Most applications will not introduce a cyclic dependency on HttpTracing, ex by
+		// injecting
+		// it into an actuator endpoint. Rather than making everything lazy for the odd
+		// case, this
+		// assumes there's no cyclic dep and falls back if we found out there was. See
+		// #1679
+		try {
+			Pattern result = consolidateSkipPatterns(patterns);
+			if (result == null) {
+				return null;
+			}
+			return () -> result;
+		}
+		catch (BeanCurrentlyInCreationException e) {
+			// Most likely case is an actuator endpoint declares a constructor param of
+			// HttpTracing
+			// instead of Tracing, SpanCustomizer, etc.
+			return () -> consolidateSkipPatterns(patterns);
+		}
+	}
+
+	@Nullable
+	static Pattern consolidateSkipPatterns(List<SingleSkipPattern> patterns) {
+		List<Pattern> presentPatterns = patterns.stream()
 				.map(SingleSkipPattern::skipPattern).filter(Optional::isPresent)
 				.map(Optional::get).collect(Collectors.toList());
 		if (presentPatterns.isEmpty()) {
 			return null;
 		}
 		if (presentPatterns.size() == 1) {
-			Pattern pattern = presentPatterns.get(0);
-			return () -> pattern;
+			return presentPatterns.get(0);
 		}
+
 		StringJoiner joiner = new StringJoiner("|");
 		for (Pattern pattern : presentPatterns) {
 			String s = pattern.pattern();
 			joiner.add(s);
 		}
-		Pattern pattern = Pattern.compile(joiner.toString());
-		return () -> pattern;
+		return Pattern.compile(joiner.toString());
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceWebAutoConfiguration.java
@@ -90,9 +90,8 @@ public class TraceWebAutoConfiguration {
 			return () -> result;
 		}
 		catch (BeanCurrentlyInCreationException e) {
-			// Most likely case is an actuator endpoint declares a constructor param of
-			// HttpTracing
-			// instead of Tracing, SpanCustomizer, etc.
+			// Most likely, there is an actuator endpoint that indirectly references an
+			// instrumented HTTP client.
 			return () -> consolidateSkipPatterns(patterns);
 		}
 	}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/EndpointWithCyclicDependenciesTests.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/EndpointWithCyclicDependenciesTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.web;
+
+import brave.http.HttpTracing;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * It is unusual to inject {@link HttpTracing} into an endpoint vs an end-user api such as
+ * {@link brave.Tracer} or {@link brave.SpanCustomizer}. However, someone has done this in
+ * the past in #1679 and we decided to allow this. This test shows the odd case will work
+ * even though it implies a cyclic dependency.
+ *
+ * @author Marcin Grzejszczak
+ */
+@SpringBootTest(classes = { EndpointWithCyclicDependenciesTests.Config.class })
+public class EndpointWithCyclicDependenciesTests {
+
+	@Test
+	public void should_load_context() {
+
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	static class Config {
+
+		@Bean
+		MyEndpoint myEndpoint(HttpTracing httpTracing) {
+			return new MyEndpoint(httpTracing);
+		}
+
+	}
+
+	@Endpoint(id = "my-endpoint")
+	public static class MyEndpoint {
+
+		public MyEndpoint(HttpTracing httpTracing) {
+			// do something with httpTracing
+		}
+
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/web/SkipPatternProviderConfigTest.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.sleuth.instrument.web;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -42,6 +43,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -113,10 +115,9 @@ public class SkipPatternProviderConfigTest {
 
 	@Test
 	public void should_return_empty_when_no_endpoints() {
-		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier = Collections::emptyList;
 		Optional<Pattern> pattern = new TraceWebAutoConfiguration.ActuatorSkipPatternProviderConfig()
 				.skipPatternForActuatorEndpointsSamePort(new ServerProperties(),
-						new WebEndpointProperties(), endpointsSupplier)
+						new WebEndpointProperties(), Collections::emptyList)
 				.skipPattern();
 
 		then(pattern).isEmpty();
@@ -237,9 +238,9 @@ public class SkipPatternProviderConfigTest {
 	@Test
 	public void should_combine_skip_patterns_from_list() throws Exception {
 		TraceWebAutoConfiguration configuration = new TraceWebAutoConfiguration();
-		configuration.patterns.addAll(Arrays.asList(foo(), bar()));
+		List<SingleSkipPattern> patterns = Arrays.asList(foo(), bar());
 
-		Pattern pattern = configuration.sleuthSkipPatternProvider().skipPattern();
+		Pattern pattern = configuration.sleuthSkipPatternProvider(patterns).skipPattern();
 
 		then(pattern.pattern()).isEqualTo("foo|bar");
 	}
@@ -273,6 +274,16 @@ public class SkipPatternProviderConfigTest {
 	@Configuration
 	@EnableConfigurationProperties(ServerProperties.class)
 	static class ServerPropertiesConfig {
+
+	}
+
+	@Configuration
+	static class EmptyEndpoints {
+
+		@Bean
+		EndpointsSupplier<ExposableWebEndpoint> endpointsSupplier() {
+			return Collections::emptyList;
+		}
 
 	}
 


### PR DESCRIPTION
Actuator endpoints are queried to make the default skip pattern. There's an
edge case where actuator endpoints indirectly reference the still constructing
HttpTracing bean. Ex: an instrumented client could cause a cyclic dep.

This optimizes for the opposite: that custom actuator endpoints are not in
use. This allows configuration to be eagerly parsed, allowing any errors to
surface earlier. In the case there is a cyclic dep, this parsing becomes lazy,
deferring any errors creating the skip pattern.

Fixes #1679