### PR TITLE
Makes a nice toString on RestTemplateSender

### DIFF
--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/RestTemplateSender.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/RestTemplateSender.java
@@ -129,6 +129,11 @@ final class RestTemplateSender extends Sender {
 		this.restTemplate.exchange(requestEntity, String.class);
 	}
 
+	@Override
+	public String toString() {
+		return "RestTemplateSender{" + url + "}";
+	}
+
 	class HttpPostCall extends Call.Base<Void> {
 
 		private final byte[] message;


### PR DESCRIPTION
The AsyncZipkinSpanHandler calls 'check' once on startup to let someone
know an error that may affect tracing up front. Before, this didn't
include the endpoint so it is less obvious what could be the problem.

Ex people goof the URL (don't add /api/v2/spans or it is added twice)