### PR TITLE
Reactor hooks optimizations

### DIFF
--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/Hack.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/Hack.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.reactor;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+import reactor.core.publisher.GroupedFlux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.ParallelFlux;
+import reactor.util.annotation.Nullable;
+
+/**
+ * Helper class for reactor ON_EACH instrumentation. Reduces number of sleuth operators
+ * time in the reactive chain during Assembly by using {@code Scannable.Attr.RUN_STYLE}.
+ * Below is the example of what it does <pre>{@code
+ *	Mono.just(0) // (-)
+ * 	.map(it -> 1) // (-)
+ * 	.flatMap(it ->
+ * 		Mono.just(it) // (-)
+ * 	) // (-)
+ * 	.flatMapMany(it ->
+ * 		asyncPublisher(it) // (+)(*)
+ * 	) // (-)
+ * 	.filter(it -> true) // (-)
+ * 	.publishOn(Schedulers.single()) //(+)
+ * 	.map(it -> it) // (-)
+ * 	.map(it -> it * 10) // (-)
+ * 	.filter(it -> true) // (-)
+ * 	.scan((l, r) -> l + r) // (-)
+ * 	.doOnNext(it -> { // (-)
+ * 		//log
+ * 	})
+ * 	.doFirst(() -> { // (-)
+ * 		//log
+ * 	})
+ * 	.doFinally(signalType -> { // (-)
+ * 		//log
+ * 	})
+ * 	.subscribeOn(Schedulers.parallel()) //(+)
+ * 	.subscribe();//(*)
+ * 	(*) - captures brave context at subscription and propagates it
+ * 	(+) - is ASYNC need to decorate Publisher
+ * 	(-) - is SYNC no need to decorate Publisher
+ *}</pre> So it creates 13 (out of 16) less Publisher (+ Subscriber and all their stuff)
+ * on assembly time comparing to the original logic (decorate every Publisher and checking
+ * only at subscription time).
+ * <p/>
+ * It also handles the case when onEachHook was not applied for some operator in the chain
+ * (It could be possible if custom operators or Processor are used) by checkin source
+ * source Publisher. <pre>{@code
+ * 	processor/customOperator // (?) is async and hook is not applied
+ * 	.map(it -> ...) // (+) is SYNC but should add hook as previous Processor/operator does not use hooks
+ * 	.doOnNext(it -> { // (-) is SYNC no need to wrap
+ * 		//log
+ * 	})
+ * 	.subscribe();
+ *}</pre>
+ */
+final class Hack {
+
+	static final Class sourceProducerClass;
+	static {
+		Class c;
+		try {
+			c = Class.forName("reactor.core.publisher.SourceProducer");
+		}
+		catch (ClassNotFoundException e) {
+			c = Void.class;
+		}
+		sourceProducerClass = c;
+	}
+
+	private Hack() {
+	}
+
+	static boolean shouldDecorate(Publisher<?> p) {
+		int maxSteps = 100;
+		Publisher<?> current = p;
+		while (true) {
+			if (current == null) {
+				// is start of the chain, Publisher without source or foreign Publisher
+				return true;
+			}
+			if (current instanceof Fuseable.ScalarCallable) {
+				return false;
+			}
+			if (isDecorator(current)) {
+				return false;
+			}
+			if (!isLifter(current)) {
+				if (!isSync(current)) {
+					return true;
+				}
+
+				if (isSourceProducer(current)) {
+					return false;
+				}
+			}
+			if (--maxSteps <= 0) {
+				return true;
+			}
+			current = getParent(current);
+		}
+	}
+
+	private static boolean isDecorator(Publisher<?> current) {
+		return current instanceof SleuthDecorator;
+	}
+
+	private static boolean isSourceProducer(Publisher<?> p) {
+		return sourceProducerClass.isInstance(p);
+	}
+
+	private static boolean isSync(Publisher<?> p) {
+		return !(p instanceof Processor) && Scannable.Attr.RunStyle.SYNC == Scannable
+				.from(p).scan(Scannable.Attr.RUN_STYLE);
+	}
+
+	@Nullable
+	private static Publisher<?> getParent(Publisher<?> publisher) {
+		Object parent = Scannable.from(publisher).scanUnsafe(Scannable.Attr.PARENT);
+		if (parent instanceof Publisher) {
+			return (Publisher<?>) parent;
+		}
+		return null;
+	}
+
+	static boolean isReactorCorePublisher(String pubClassName) {
+		return pubClassName != null && pubClassName.startsWith("reactor.core.publisher");
+	}
+
+	// should be changed to Scannable. need extra Attr or interface for Lifter to
+	// distinguish from others
+	private static boolean isLifter(Publisher<?> current) {
+		if (current == null) {
+			return false;
+		}
+		String name = current.getClass().getName();
+		return isReactorCorePublisher(name)
+				&& ((name.endsWith("Lift") || name.endsWith("LiftFuseable")));
+	}
+
+	// WA need a way to determine whether Publisher is SleuthDecorator
+	// mostly it is a copy of reactor-core logic
+	// as on option - add Scannable to Lift Publishers which returns original lifter
+	// function
+	@SuppressWarnings("unchecked")
+	public static <I, O> Function<? super Publisher<I>, ? extends Publisher<O>> liftPublisher(
+			Predicate<Publisher> filter,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		Function<? super Publisher<I>, ? extends Publisher<O>> coreLifter = Operators
+				.liftPublisher(lifter);
+		return publisher -> {
+			if (filter != null && !filter.test(publisher)) {
+				return (Publisher<O>) publisher;
+			}
+
+			if (publisher instanceof Mono) {
+				return new SleuthMonoLift<>(publisher, lifter);
+			}
+			if (publisher instanceof ParallelFlux) {
+				return new SleuthParallelLift<>((ParallelFlux<I>) publisher, lifter);
+			}
+			if (publisher instanceof ConnectableFlux) {
+				return new SleuthConnectableLift<>((ConnectableFlux<I>) publisher,
+						lifter);
+			}
+			if (publisher instanceof GroupedFlux) {
+				return new SleuthGroupedLift<>((GroupedFlux<?, I>) publisher, lifter);
+			}
+			return new SleuthFluxLift<>(publisher, lifter);
+		};
+	}
+
+}
+
+final class SleuthMonoLift<I, O> extends MonoOperator<I, O> implements SleuthDecorator {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	SleuthMonoLift(Publisher<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		super(Mono.from(p));
+		this.lifter = lifter;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber input = actual;
+		try {
+			input = Objects.requireNonNull(lifter.apply(source, actual),
+					"Lifted subscriber MUST NOT be null");
+
+			source.subscribe(input);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(input, e);
+			return;
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+		return super.scanUnsafe(key);
+	}
+
+}
+
+final class SleuthFluxLift<I, O> extends FluxOperator<I, O> implements SleuthDecorator {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	SleuthFluxLift(Publisher<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		super(Flux.from(p));
+		this.lifter = lifter;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber input = actual;
+		try {
+			input = Objects.requireNonNull(lifter.apply(source, actual),
+					"Lifted subscriber MUST NOT be null");
+
+			source.subscribe(input);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(input, e);
+			return;
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+		return super.scanUnsafe(key);
+	}
+
+}
+
+final class SleuthConnectableLift<I, O> extends ConnectableFlux<O>
+		implements Scannable, SleuthDecorator {
+
+	final ConnectableFlux<I> source;
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	SleuthConnectableLift(ConnectableFlux<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public void connect(Consumer<? super Disposable> cancelSupport) {
+		this.source.connect(cancelSupport);
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PREFETCH) {
+			return source.getPrefetch();
+		}
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+		return null;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber input = actual;
+		try {
+			input = Objects.requireNonNull(lifter.apply(source, actual),
+					"Lifted subscriber MUST NOT be null");
+
+			source.subscribe(input);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(input, e);
+			return;
+		}
+	}
+
+}
+
+final class SleuthGroupedLift<K, I, O> extends GroupedFlux<K, O>
+		implements Scannable, SleuthDecorator {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	final GroupedFlux<K, I> source;
+
+	SleuthGroupedLift(GroupedFlux<K, I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public K key() {
+		return source.key();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.PREFETCH) {
+			return getPrefetch();
+		}
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+
+		return null;
+	}
+
+	@Override
+	public String stepName() {
+		if (source instanceof Scannable) {
+			return Scannable.from(source).stepName();
+		}
+		return Scannable.super.stepName();
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber<? super I> input = lifter.apply(source, actual);
+
+		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
+
+		source.subscribe(input);
+	}
+
+}
+
+final class SleuthParallelLift<I, O> extends ParallelFlux<O> implements Scannable {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	final ParallelFlux<I> source;
+
+	SleuthParallelLift(ParallelFlux<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public int parallelism() {
+		return source.parallelism();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.PREFETCH) {
+			return getPrefetch();
+		}
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+
+		return null;
+	}
+
+	@Override
+	public String stepName() {
+		if (source instanceof Scannable) {
+			return Scannable.from(source).stepName();
+		}
+		return Scannable.super.stepName();
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O>[] s) {
+		@SuppressWarnings("unchecked")
+		CoreSubscriber<? super I>[] subscribers = new CoreSubscriber[parallelism()];
+
+		int i = 0;
+		while (i < subscribers.length) {
+			subscribers[i] = Objects.requireNonNull(lifter.apply(source, s[i]),
+					"Lifted subscriber MUST NOT be null");
+			i++;
+		}
+
+		source.subscribe(subscribers);
+	}
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
@@ -115,6 +115,9 @@ final class ScopePassingSpanSubscriber<T> implements SpanSubscription<T>, Scanna
 		if (key == Attr.PARENT) {
 			return this.s;
 		}
+		else if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
 		else {
 			return key == Attr.ACTUAL ? this.subscriber : null;
 		}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
@@ -37,17 +37,17 @@ import reactor.util.context.Context;
  */
 final class ScopePassingSpanSubscriber<T> implements SpanSubscription<T>, Scannable {
 
-	private static final Log log = LogFactory.getLog(ScopePassingSpanSubscriber.class);
+	static final Log log = LogFactory.getLog(ScopePassingSpanSubscriber.class);
 
-	private final Subscriber<? super T> subscriber;
+	final Subscriber<? super T> subscriber;
 
-	private final Context context;
+	final Context context;
 
-	private final CurrentTraceContext currentTraceContext;
+	final CurrentTraceContext currentTraceContext;
 
-	private final TraceContext parent;
+	final TraceContext parent;
 
-	private Subscription s;
+	Subscription s;
 
 	ScopePassingSpanSubscriber(Subscriber<? super T> subscriber, Context ctx,
 			CurrentTraceContext currentTraceContext, @Nullable TraceContext parent) {

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SleuthDecorator.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/SleuthDecorator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.reactor;
+
+/**
+ * Only for internal use. Marker interface for Publisher and Subscriber that propagate
+ * brave context into execution Thread.
+ */
+@Deprecated
+public interface SleuthDecorator {
+
+}

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
@@ -40,7 +40,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.scope.refresh.RefreshScope;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
-import org.springframework.cloud.sleuth.instrument.async.TraceableScheduledExecutorService;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -203,11 +202,9 @@ class HookRegisteringBeanDefinitionRegistryPostProcessor
 		else if (property == SleuthReactorProperties.InstrumentationType.MANUAL) {
 			decorateOnLast(springContextSpanOperator(springContext));
 		}
-		Schedulers.setExecutorServiceDecorator(
+		Schedulers.onScheduleHook(
 				TraceReactorAutoConfiguration.SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY,
-				(scheduler,
-						scheduledExecutorService) -> new TraceableScheduledExecutorService(
-								springContext, scheduledExecutorService));
+				ReactorSleuth.sleuthOnScheduleHook(springContext));
 	}
 
 	private static void decorateOnLast(
@@ -233,7 +230,7 @@ class HookRegisteringBeanDefinitionRegistryPostProcessor
 		}
 		Hooks.resetOnEachOperator(SLEUTH_TRACE_REACTOR_KEY);
 		Hooks.resetOnLastOperator(SLEUTH_TRACE_REACTOR_KEY);
-		Schedulers.removeExecutorServiceDecorator(
+		Schedulers.resetOnScheduleHook(
 				TraceReactorAutoConfiguration.SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
 	}
 

--- a/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
+++ b/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfiguration.java
@@ -47,6 +47,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 
+import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.onEachScopePassingSpanOperatorForOnEachHook;
+import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.onLastScopePassingSpanOperatorForOnEachHook;
 import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.scopePassingSpanOperator;
 import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.springContextSpanOperator;
 import static org.springframework.cloud.sleuth.instrument.reactor.TraceReactorAutoConfiguration.TraceReactorConfiguration.SLEUTH_TRACE_REACTOR_KEY;
@@ -136,7 +138,9 @@ class HooksRefresher implements ApplicationListener<RefreshScopeRefreshedEvent> 
 				log.trace("Decorating onEach operator instrumentation");
 			}
 			Hooks.onEachOperator(SLEUTH_TRACE_REACTOR_KEY,
-					scopePassingSpanOperator(this.context));
+					onEachScopePassingSpanOperatorForOnEachHook(this.context));
+			Hooks.onLastOperator(SLEUTH_TRACE_REACTOR_KEY,
+					onLastScopePassingSpanOperatorForOnEachHook(this.context));
 			break;
 		case DECORATE_ON_LAST:
 			if (log.isTraceEnabled()) {
@@ -191,6 +195,7 @@ class HookRegisteringBeanDefinitionRegistryPostProcessor
 		}
 		else if (property == SleuthReactorProperties.InstrumentationType.DECORATE_ON_EACH) {
 			decorateOnEach(springContext);
+			decorateOnLast(onLastScopePassingSpanOperatorForOnEachHook(springContext));
 		}
 		else if (property == SleuthReactorProperties.InstrumentationType.DECORATE_ON_LAST) {
 			decorateOnLast(scopePassingSpanOperator(springContext));
@@ -218,7 +223,7 @@ class HookRegisteringBeanDefinitionRegistryPostProcessor
 			log.trace("Decorating onEach operator instrumentation");
 		}
 		Hooks.onEachOperator(SLEUTH_TRACE_REACTOR_KEY,
-				scopePassingSpanOperator(springContext));
+				onEachScopePassingSpanOperatorForOnEachHook(springContext));
 	}
 
 	@Override

--- a/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
+++ b/spring-cloud-sleuth-core/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
@@ -44,7 +44,7 @@ public final class TraceReactorAutoConfigurationAccessorConfiguration {
 		}
 		Hooks.resetOnEachOperator(SLEUTH_TRACE_REACTOR_KEY);
 		Hooks.resetOnLastOperator(SLEUTH_TRACE_REACTOR_KEY);
-		Schedulers.removeExecutorServiceDecorator(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
+		Schedulers.resetOnScheduleHook(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
 	}
 
 	public static void setup(ConfigurableApplicationContext context) {

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -37,6 +37,14 @@
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+<!--	fixme Caused by: java.lang.NoSuchMethodError: reactor.core.publisher.Sinks$Many.tryEmitNext(Ljava/lang/Object;)Lreactor/core/publisher/Sinks$Emission;		-->
+			<dependency>
+				<groupId>io.projectreactor</groupId>
+				<artifactId>reactor-bom</artifactId>
+				<version>2020.0.0-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-sleuth-core</artifactId>

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/FlowsScopePassingSpanSubscriberTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/FlowsScopePassingSpanSubscriberTests.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.scopePassingSpanOperator;
+import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.onEachScopePassingSpanOperatorForOnEachHook;
 import static org.springframework.cloud.sleuth.instrument.reactor.TraceReactorAutoConfiguration.TraceReactorConfiguration.SLEUTH_TRACE_REACTOR_KEY;
 
 /**
@@ -80,7 +80,7 @@ public class FlowsScopePassingSpanSubscriberTests {
 		springContext.registerBean(CurrentTraceContext.class, () -> currentTraceContext);
 		springContext.refresh();
 
-		Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = scopePassingSpanOperator(
+		Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = onEachScopePassingSpanOperatorForOnEachHook(
 				this.springContext);
 
 		try (Scope ws = this.currentTraceContext.newScope(context)) {

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
@@ -121,7 +121,7 @@ public class ScopePassingSpanSubscriberTests {
 		// prevent should_not_scope_scalar_subscribe from being interfered with.
 		Hooks.resetOnEachOperator(SLEUTH_TRACE_REACTOR_KEY);
 		Hooks.resetOnLastOperator(SLEUTH_TRACE_REACTOR_KEY);
-		Schedulers.removeExecutorServiceDecorator(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
+		Schedulers.resetOnScheduleHook(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
 	}
 
 	@After

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
@@ -192,6 +192,46 @@ public class ScopePassingSpanSubscriberTests {
 	}
 
 	@Test
+	public void should_not_double_wrap() {
+		springContext.registerBean(CurrentTraceContext.class, () -> currentTraceContext);
+		springContext.refresh();
+
+		Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = scopePassingSpanOperator(
+				this.springContext);
+
+		try (Scope ws = this.currentTraceContext.newScope(context)) {
+			Publisher<Integer> one = transformer.apply(Mono.just(1).hide());
+			Publisher<Integer> deferred = transformer
+					.apply(Mono.defer(() -> Mono.from(one)));
+
+			deferred.subscribe(new CoreSubscriber<Object>() {
+				@Override
+				public void onSubscribe(Subscription s) {
+					s.request(Long.MAX_VALUE);
+					assertThat(s).isInstanceOf(ScopePassingSpanSubscriber.class);
+					assertThat(((ScopePassingSpanSubscriber) s).subscriber)
+							.isNotInstanceOf(ScopePassingSpanSubscriber.class);
+				}
+
+				@Override
+				public void onNext(Object o) {
+
+				}
+
+				@Override
+				public void onError(Throwable t) {
+					throw new AssertionError(t);
+				}
+
+				@Override
+				public void onComplete() {
+
+				}
+			});
+		}
+	}
+
+	@Test
 	public void should_scope_scalar_hide_subscribe() {
 		springContext.registerBean(CurrentTraceContext.class, () -> currentTraceContext);
 		springContext.refresh();

--- a/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
+++ b/tests/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
@@ -44,7 +44,7 @@ public final class TraceReactorAutoConfigurationAccessorConfiguration {
 		}
 		Hooks.resetOnEachOperator(SLEUTH_TRACE_REACTOR_KEY);
 		Hooks.resetOnLastOperator(SLEUTH_TRACE_REACTOR_KEY);
-		Schedulers.removeExecutorServiceDecorator(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
+		Schedulers.resetOnScheduleHook(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
 	}
 
 	public static void setup(ConfigurableApplicationContext context) {


### PR DESCRIPTION
Share results of my work on Sleuth Reactor instrumentation optimization  

This is WIP. There are several places which use `reactor-core` internals, but I hope they could be resolved (one of probable solution is described here https://github.com/reactor/reactor-core/issues/2242#issuecomment-683346691).  

Mostly it optimizes `DECORATE_ON_EACH` instrumentation by using `reactor-core` feature from https://github.com/reactor/reactor-core/issues/2058 (added `Scannable.Attr.RunStyle`) (Which was the follow up of #1553)  
cc @adriancole @simonbasle (as they participate in original issue)  

Result of benchmark https://github.com/spring-cloud/spring-cloud-sleuth/blob/master/benchmarks/src/test/java/org/springframework/cloud/sleuth/benchmarks/jmh/webflux/MicroBenchmarkHttpTests.java to compare effect:
current master as baseline: 
```
Benchmark                                                       (instrumentation)    Mode    Cnt      Score        Error   Units
MicroBenchmarkHttpTests.test                                       noSleuthSimple  sample  86801      0.115 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                            noSleuthSimple  sample             0.055                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                            noSleuthSimple  sample             0.123                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                            noSleuthSimple  sample             0.131                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                            noSleuthSimple  sample             0.137                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                            noSleuthSimple  sample             0.163                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                           noSleuthSimple  sample             0.213                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                          noSleuthSimple  sample             0.391                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                            noSleuthSimple  sample             3.731                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                        noSleuthSimple  sample     10    168.406 ±     69.358  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                   noSleuthSimple  sample     10  34528.748 ±     74.930    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space               noSleuthSimple  sample     10    154.906 ±    184.454  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm          noSleuthSimple  sample     10  33895.297 ±  35449.919    B/op
MicroBenchmarkHttpTests.test:·gc.count                             noSleuthSimple  sample     10      7.000               counts
MicroBenchmarkHttpTests.test:·gc.time                              noSleuthSimple  sample     10     23.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleManual  sample  70213      0.142 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleManual  sample             0.076                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleManual  sample             0.148                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleManual  sample             0.158                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleManual  sample             0.172                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleManual  sample             0.198                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleManual  sample             0.257                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleManual  sample             0.375                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleManual  sample             5.587                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleManual  sample     10    190.331 ±      3.873  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleManual  sample     10  42760.732 ±    131.501    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleManual  sample     10    184.031 ±    240.895  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleManual  sample     10  41587.725 ±  54432.434    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleManual  sample     10      6.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleManual  sample     10     29.000                   ms
MicroBenchmarkHttpTests.test                                         sleuthManual  sample  69978      0.143 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                              sleuthManual  sample             0.096                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                              sleuthManual  sample             0.148                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                              sleuthManual  sample             0.159                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                              sleuthManual  sample             0.174                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                              sleuthManual  sample             0.200                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                             sleuthManual  sample             0.259                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                            sleuthManual  sample             0.375                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                              sleuthManual  sample             5.726                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                          sleuthManual  sample     10    191.422 ±      3.551  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                     sleuthManual  sample     10  43147.201 ±    111.042    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                 sleuthManual  sample     10    180.962 ±    236.601  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm            sleuthManual  sample     10  40988.366 ±  53604.625    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space             sleuthManual  sample     10      0.002 ±      0.007  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm        sleuthManual  sample     10      0.466 ±      1.484    B/op
MicroBenchmarkHttpTests.test:·gc.count                               sleuthManual  sample     10      6.000               counts
MicroBenchmarkHttpTests.test:·gc.time                                sleuthManual  sample     10     30.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnEach  sample  52990      0.189 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnEach  sample             0.134                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnEach  sample             0.191                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnEach  sample             0.211                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnEach  sample             0.224                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnEach  sample             0.257                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnEach  sample             0.321                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnEach  sample             5.214                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnEach  sample             7.406                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnEach  sample     10    181.365 ±      3.175  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnEach  sample     10  53991.521 ±    178.747    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnEach  sample     10    213.213 ±    225.669  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnEach  sample     10  63907.694 ±  67760.995    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnEach  sample     10      7.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnEach  sample     10     36.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnLast  sample  64342      0.155 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnLast  sample             0.097                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnLast  sample             0.159                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnLast  sample             0.180                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnLast  sample             0.188                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnLast  sample             0.218                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnLast  sample             0.279                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnLast  sample             1.638                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnLast  sample             5.104                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnLast  sample     10    186.558 ±     11.177  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnLast  sample     10  45741.341 ±    148.094    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnLast  sample     10    146.143 ±    303.286  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnLast  sample     10  35825.783 ±  74235.927    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space       sleuthSimpleOnLast  sample     10      0.028 ±      0.136  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm  sleuthSimpleOnLast  sample     10      6.922 ±     33.093    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnLast  sample     10      4.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnLast  sample     10     16.000                   ms
MicroBenchmarkHttpTests.test                                      noSleuthComplex  sample   4317      2.317 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           noSleuthComplex  sample             1.241                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           noSleuthComplex  sample             2.038                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           noSleuthComplex  sample             3.035                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           noSleuthComplex  sample             3.117                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           noSleuthComplex  sample             3.150                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          noSleuthComplex  sample             3.221                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         noSleuthComplex  sample             7.078                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           noSleuthComplex  sample             7.078                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       noSleuthComplex  sample     10      9.052 ±      3.569  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  noSleuthComplex  sample     10  37530.452 ±   1490.344    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space              noSleuthComplex  sample     10     11.343 ±     36.153  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm         noSleuthComplex  sample     10  97208.953 ± 309854.228    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space          noSleuthComplex  sample     10      0.423 ±      1.350  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm     noSleuthComplex  sample     10   3629.248 ±  11569.860    B/op
MicroBenchmarkHttpTests.test:·gc.count                            noSleuthComplex  sample     10      2.000               counts
MicroBenchmarkHttpTests.test:·gc.time                             noSleuthComplex  sample     10      7.000                   ms
MicroBenchmarkHttpTests.test                                        onEachComplex  sample   4305      2.326 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onEachComplex  sample             1.446                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onEachComplex  sample             2.046                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onEachComplex  sample             3.031                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onEachComplex  sample             3.105                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onEachComplex  sample             3.150                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onEachComplex  sample             3.248                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onEachComplex  sample             3.457                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onEachComplex  sample             3.457                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onEachComplex  sample     10     15.780 ±      0.284  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onEachComplex  sample     10  57900.485 ±   1859.159    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onEachComplex  sample     10        ≈ 0               counts
MicroBenchmarkHttpTests.test                                        onLastComplex  sample   4304      2.324 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onLastComplex  sample             1.249                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onLastComplex  sample             2.040                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onLastComplex  sample             3.039                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onLastComplex  sample             3.113                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onLastComplex  sample             3.146                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onLastComplex  sample             3.299                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onLastComplex  sample             3.719                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onLastComplex  sample             3.719                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onLastComplex  sample     10     13.347 ±      0.358  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onLastComplex  sample     10  48940.329 ±   1868.315    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onLastComplex  sample     10        ≈ 0               counts
MicroBenchmarkHttpTests.test                                      onManualComplex  sample   4296      2.328 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           onManualComplex  sample             1.260                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           onManualComplex  sample             2.042                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           onManualComplex  sample             3.035                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           onManualComplex  sample             3.109                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           onManualComplex  sample             3.146                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          onManualComplex  sample             3.195                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         onManualComplex  sample             3.547                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           onManualComplex  sample             3.547                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       onManualComplex  sample     10     12.731 ±      0.516  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  onManualComplex  sample     10  46755.414 ±   1768.817    B/op
MicroBenchmarkHttpTests.test:·gc.count                            onManualComplex  sample     10        ≈ 0               counts
```

results with changes:  
```
Benchmark                                                       (instrumentation)    Mode    Cnt      Score        Error   Units
MicroBenchmarkHttpTests.test                                       noSleuthSimple  sample  88950      0.112 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                            noSleuthSimple  sample             0.046                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                            noSleuthSimple  sample             0.120                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                            noSleuthSimple  sample             0.130                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                            noSleuthSimple  sample             0.136                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                            noSleuthSimple  sample             0.161                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                           noSleuthSimple  sample             0.209                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                          noSleuthSimple  sample             0.442                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                            noSleuthSimple  sample             3.994                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                        noSleuthSimple  sample     10    172.642 ±     72.537  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                   noSleuthSimple  sample     10  34487.748 ±     67.156    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space               noSleuthSimple  sample     10    177.262 ±    201.426  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm          noSleuthSimple  sample     10  34087.974 ±  35923.281    B/op
MicroBenchmarkHttpTests.test:·gc.count                             noSleuthSimple  sample     10      7.000               counts
MicroBenchmarkHttpTests.test:·gc.time                              noSleuthSimple  sample     10     22.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleManual  sample  70942      0.141 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleManual  sample             0.077                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleManual  sample             0.147                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleManual  sample             0.156                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleManual  sample             0.170                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleManual  sample             0.196                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleManual  sample             0.255                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleManual  sample             0.394                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleManual  sample             5.538                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleManual  sample     10    180.398 ±      2.511  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleManual  sample     10  40122.316 ±    118.743    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleManual  sample     10    167.965 ±    219.985  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleManual  sample     10  37448.797 ±  49089.375    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleManual  sample     10      6.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleManual  sample     10     28.000                   ms
MicroBenchmarkHttpTests.test                                         sleuthManual  sample  69333      0.144 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                              sleuthManual  sample             0.085                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                              sleuthManual  sample             0.149                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                              sleuthManual  sample             0.165                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                              sleuthManual  sample             0.174                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                              sleuthManual  sample             0.200                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                             sleuthManual  sample             0.252                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                            sleuthManual  sample             0.367                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                              sleuthManual  sample             5.702                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                          sleuthManual  sample     10    177.864 ±      8.906  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                     sleuthManual  sample     10  40465.144 ±    113.512    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                 sleuthManual  sample     10    209.047 ±    369.025  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm            sleuthManual  sample     10  49124.407 ±  88471.096    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space             sleuthManual  sample     10      0.032 ±      0.145  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm        sleuthManual  sample     10      7.457 ±     33.018    B/op
MicroBenchmarkHttpTests.test:·gc.count                               sleuthManual  sample     10      5.000               counts
MicroBenchmarkHttpTests.test:·gc.time                                sleuthManual  sample     10     19.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnEach  sample  53947      0.185 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnEach  sample             0.118                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnEach  sample             0.188                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnEach  sample             0.205                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnEach  sample             0.220                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnEach  sample             0.249                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnEach  sample             0.315                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnEach  sample             0.434                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnEach  sample             5.931                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnEach  sample     10    120.930 ±     49.823  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnEach  sample     10  39905.655 ±    134.834    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnEach  sample     10    125.304 ±    210.758  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnEach  sample     10  41904.527 ±  66879.932    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnEach  sample     10      5.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnEach  sample     10     25.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnLast  sample  71197      0.140 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnLast  sample             0.062                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnLast  sample             0.148                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnLast  sample             0.158                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnLast  sample             0.172                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnLast  sample             0.196                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnLast  sample             0.257                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnLast  sample             4.470                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnLast  sample             5.964                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnLast  sample     10    193.766 ±     17.637  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnLast  sample     10  42924.193 ±    159.213    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnLast  sample     10    202.098 ±    213.233  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnLast  sample     10  46105.627 ±  48571.997    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnLast  sample     10      7.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnLast  sample     10     35.000                   ms
MicroBenchmarkHttpTests.test                                      noSleuthComplex  sample   4313      2.319 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           noSleuthComplex  sample             1.233                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           noSleuthComplex  sample             2.042                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           noSleuthComplex  sample             3.035                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           noSleuthComplex  sample             3.109                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           noSleuthComplex  sample             3.146                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          noSleuthComplex  sample             3.195                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         noSleuthComplex  sample             5.603                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           noSleuthComplex  sample             5.603                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       noSleuthComplex  sample     10      9.031 ±      3.626  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  noSleuthComplex  sample     10  37395.502 ±    957.550    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space              noSleuthComplex  sample     10     13.186 ±     63.043  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm         noSleuthComplex  sample     10  48508.890 ± 231916.761    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space          noSleuthComplex  sample     10      0.505 ±      2.412  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm     noSleuthComplex  sample     10   1856.267 ±   8874.652    B/op
MicroBenchmarkHttpTests.test:·gc.count                            noSleuthComplex  sample     10      1.000               counts
MicroBenchmarkHttpTests.test:·gc.time                             noSleuthComplex  sample     10      3.000                   ms
MicroBenchmarkHttpTests.test                                        onEachComplex  sample   4298      2.327 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onEachComplex  sample             1.464                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onEachComplex  sample             2.042                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onEachComplex  sample             3.035                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onEachComplex  sample             3.105                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onEachComplex  sample             3.154                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onEachComplex  sample             3.345                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onEachComplex  sample             3.518                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onEachComplex  sample             3.518                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onEachComplex  sample     10     10.400 ±      4.211  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onEachComplex  sample     10  43173.387 ±   1111.996    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onEachComplex  sample     10        ≈ 0               counts
MicroBenchmarkHttpTests.test                                        onLastComplex  sample   4329      2.310 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onLastComplex  sample             1.253                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onLastComplex  sample             2.038                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onLastComplex  sample             3.035                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onLastComplex  sample             3.109                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onLastComplex  sample             3.146                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onLastComplex  sample             3.178                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onLastComplex  sample             3.199                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onLastComplex  sample             3.199                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onLastComplex  sample     10     12.622 ±      0.411  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onLastComplex  sample     10  46008.979 ±   1882.009    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onLastComplex  sample     10        ≈ 0               counts
MicroBenchmarkHttpTests.test                                      onManualComplex  sample   4310      2.321 ±      0.023   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           onManualComplex  sample             1.239                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           onManualComplex  sample             2.040                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           onManualComplex  sample             3.035                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           onManualComplex  sample             3.111                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           onManualComplex  sample             3.150                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          onManualComplex  sample             3.258                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         onManualComplex  sample             3.387                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           onManualComplex  sample             3.387                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       onManualComplex  sample     10     11.960 ±      0.517  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  onManualComplex  sample     10  43792.191 ±   1854.119    B/op
MicroBenchmarkHttpTests.test:·gc.count                            onManualComplex  sample     10        ≈ 0               counts
```

Here some calculations:  
For `onEachComplex` case allocation reduced from plus `54.8%` to `15.45%` if compare with `noSleuthComplex`.  
`onEachComplex` allocates less than `onLastComplex` by `6.16%`, before changes `onEachComplex` allocated more by `25.8%`  
