### PR TITLE
Fixing #1797 via wiring beans by id not by type

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/messaging/TraceWebSocketAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/messaging/TraceWebSocketAutoConfiguration.java
@@ -56,10 +56,10 @@ class TraceWebSocketAutoConfiguration extends AbstractWebSocketMessageBrokerConf
 	Propagator propagator;
 
 	@Autowired
-	Propagator.Setter<MessageHeaderAccessor> setter;
+	Propagator.Setter<MessageHeaderAccessor> traceMessagePropagationSetter;
 
 	@Autowired
-	Propagator.Getter<MessageHeaderAccessor> getter;
+	Propagator.Getter<MessageHeaderAccessor> traceMessagePropagationGetter;
 
 	@Autowired
 	SleuthMessagingProperties sleuthMessagingProperties;
@@ -72,21 +72,21 @@ class TraceWebSocketAutoConfiguration extends AbstractWebSocketMessageBrokerConf
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
 		registry.configureBrokerChannel().setInterceptors(new TracingChannelInterceptor(this.tracer, this.propagator,
-				this.setter, this.getter,
+				this.traceMessagePropagationSetter, this.traceMessagePropagationGetter,
 				TraceSpringIntegrationAutoConfiguration.remoteServiceNameMapper(this.sleuthMessagingProperties)));
 	}
 
 	@Override
 	public void configureClientOutboundChannel(ChannelRegistration registration) {
-		registration.setInterceptors(new TracingChannelInterceptor(this.tracer, this.propagator, this.setter,
-				this.getter,
+		registration.setInterceptors(new TracingChannelInterceptor(this.tracer, this.propagator,
+				this.traceMessagePropagationSetter, this.traceMessagePropagationGetter,
 				TraceSpringIntegrationAutoConfiguration.remoteServiceNameMapper(this.sleuthMessagingProperties)));
 	}
 
 	@Override
 	public void configureClientInboundChannel(ChannelRegistration registration) {
-		registration.setInterceptors(new TracingChannelInterceptor(this.tracer, this.propagator, this.setter,
-				this.getter,
+		registration.setInterceptors(new TracingChannelInterceptor(this.tracer, this.propagator,
+				this.traceMessagePropagationSetter, this.traceMessagePropagationGetter,
 				TraceSpringIntegrationAutoConfiguration.remoteServiceNameMapper(this.sleuthMessagingProperties)));
 	}
 


### PR DESCRIPTION
Fixes #1797.

It seems M6 introduced two dependencies in TraceWebSocketAutoConfiguration:
- Propagator.Setter<MessageHeaderAccessor>
- Propagator.Getter<MessageHeaderAccessor>

Both of them are created in TraceSpringMessagingAutoConfiguration. If you look closer, they are referencing the very same object: MessageHeaderPropagation.INSTANCE
This is possible because MessageHeaderPropagation implements both Propagator.Setter<MessageHeaderAccessor> and Propagator.Getter<MessageHeaderAccessor>. So when the context is created there will be two beans:
- traceMessagePropagationSetter
- traceMessagePropagationGetter

Both of them are a Propagator.Setter<MessageHeaderAccessor> and a Propagator.Getter<MessageHeaderAccessor> at the same time. So we have two beans both of them are getters and setters so we have two getters and two setters at runtime and Spring does not know which one is the right one, one possible fix is wiring these beans in using their id.