### PR TITLE
Updating readme: use Java 8 instead of 7

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ Please visit the https://docs.spring.io/spring-cloud-sleuth/docs/[documentation 
 
 == Building
 
-:jdkversion: 1.7
+:jdkversion: 1.8
 
 === Basic Compile and Test
 


### PR DESCRIPTION
The pom says 1.8, I guess this is outdated.