### PR TITLE
Fix typo in docs (index file)

### DIFF
--- a/docs/src/main/asciidoc/_index.adoc
+++ b/docs/src/main/asciidoc/_index.adoc
@@ -15,4 +15,4 @@ The reference documentation consists of the following sections:
 <<project-features.adoc#features,{project-full-name} Features>> :: Span creation, context propagation, and more.
 <<howto.adoc#howto,"`How-to`" Guides>> :: Add sampling, propagate remote tags, and more.
 <<integrations.adoc#sleuth-integration,{project-full-name} Integrations>> :: Instrumentation configuration, context propagation, and more.
-<<appendix.adoc#appendix,Appendices>> :: Configuration propertie.
+<<appendix.adoc#appendix,Appendices>> :: Configuration properties.


### PR DESCRIPTION
While reading docs I found a small typo in index file. "propertie" instead of "properties", this commit fixes that.