### PR TITLE
Set remote IP and port for servlet HTTP server traces.

### DIFF
--- a/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/BraveHttpServerRequest.java
+++ b/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/BraveHttpServerRequest.java
@@ -20,6 +20,8 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.http.HttpServerRequest;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -130,6 +132,10 @@ class BraveHttpServerRequest implements HttpServerRequest {
 						return false;
 					}
 					return span.remoteIpAndPort(addr.getAddress().getHostAddress(), addr.getPort());
+				}
+				else if (delegate instanceof HttpServletRequest) {
+					HttpServletRequest servletRequest = (HttpServletRequest) delegate;
+					return span.remoteIpAndPort(servletRequest.getRemoteAddr(), servletRequest.getRemotePort());
 				}
 				return false;
 			}

--- a/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/BraveHttpServerRequest.java
+++ b/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/BraveHttpServerRequest.java
@@ -20,7 +20,7 @@ import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.servlet.ServletRequest;
 
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.http.HttpServerRequest;
@@ -133,9 +133,13 @@ class BraveHttpServerRequest implements HttpServerRequest {
 					}
 					return span.remoteIpAndPort(addr.getAddress().getHostAddress(), addr.getPort());
 				}
-				else if (delegate instanceof HttpServletRequest) {
-					HttpServletRequest servletRequest = (HttpServletRequest) delegate;
-					return span.remoteIpAndPort(servletRequest.getRemoteAddr(), servletRequest.getRemotePort());
+				else if (delegate instanceof ServletRequest) {
+					ServletRequest servletRequest = (ServletRequest) delegate;
+					String addr = servletRequest.getRemoteAddr();
+					if (addr == null) {
+						return false;
+					}
+					return span.remoteIpAndPort(addr, servletRequest.getRemotePort());
 				}
 				return false;
 			}

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/web/TraceFilterTests.java
@@ -107,6 +107,7 @@ public abstract class TraceFilterTests implements TestTracingAwareSupplier {
 				HttpMethod.GET.toString());
 		// we don't check for status_code anymore cause Brave doesn't support it oob
 		// .containsEntry("http.status_code", "200")
+		BDDAssertions.then(this.spans.get(0).getRemoteIp()).isEqualTo("127.0.0.1");
 	}
 
 	@Test


### PR DESCRIPTION
Spring Cloud 2020.0.0 stopped setting the remote IP and port on traces coming from HTTP servlet requests. This change brings that functionality back.