### PR TITLE
Remove spanExportable from sample log file entry in docs

### DIFF
--- a/docs/src/main/asciidoc/project-features.adoc
+++ b/docs/src/main/asciidoc/project-features.adoc
@@ -396,8 +396,8 @@ Paste that into your distributed tracing system to visualize the entire trace, r
 
 [source]
 ----
-backend.log:  2020-04-09 17:45:40.516 ERROR [backend,5e8eeec48b08e26882aba313eb08f0a4,dcc1df555b5777b3,true] 97203 --- [nio-9000-exec-1] o.s.c.s.i.web.ExceptionLoggingFilter     : Uncaught exception thrown
-frontend.log:2020-04-09 17:45:40.574 ERROR [frontend,5e8eeec48b08e26882aba313eb08f0a4,82aba313eb08f0a4,true] 97192 --- [nio-8081-exec-2] o.s.c.s.i.web.ExceptionLoggingFilter     : Uncaught exception thrown
+backend.log:  2020-04-09 17:45:40.516 ERROR [backend,5e8eeec48b08e26882aba313eb08f0a4,dcc1df555b5777b3] 97203 --- [nio-9000-exec-1] o.s.c.s.i.web.ExceptionLoggingFilter     : Uncaught exception thrown
+frontend.log:2020-04-09 17:45:40.574 ERROR [frontend,5e8eeec48b08e26882aba313eb08f0a4,82aba313eb08f0a4] 97192 --- [nio-8081-exec-2] o.s.c.s.i.web.ExceptionLoggingFilter     : Uncaught exception thrown
 ----
 
 Above, you'll notice the trace ID is `5e8eeec48b08e26882aba313eb08f0a4`, for example.


### PR DESCRIPTION
The docs still contained a sample including the [removed](https://github.com/spring-cloud/spring-cloud-sleuth/wiki/Spring-Cloud-Sleuth-3.0-Migration-Guide#parentid-and-sampled-spanexportable-mdc-fields-names-are-no-longer-set) `spanExportable` field in the log entries. 