### PR TITLE
optimize reactor on_each instrumentation

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/reactor/SleuthReactorProperties.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/reactor/SleuthReactorProperties.java
@@ -89,9 +89,7 @@ public class SleuthReactorProperties {
 		/**
 		 * Decorates on each operator, will be less performing, but logging will always
 		 * contain the tracing entries in each operator.
-		 * @deprecated to be removed in Sleuth 4.0.0
 		 */
-		@Deprecated
 		DECORATE_ON_EACH,
 
 		/**

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/reactor/TraceReactorAutoConfigurationAccessorConfiguration.java
@@ -43,7 +43,7 @@ public final class TraceReactorAutoConfigurationAccessorConfiguration {
 		}
 		Hooks.resetOnEachOperator(SLEUTH_TRACE_REACTOR_KEY);
 		Hooks.resetOnLastOperator(SLEUTH_TRACE_REACTOR_KEY);
-		Schedulers.removeExecutorServiceDecorator(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
+		Schedulers.resetOnScheduleHook(SLEUTH_REACTOR_EXECUTOR_SERVICE_KEY);
 	}
 
 	public static void setup(ConfigurableApplicationContext context) {

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/TraceWebFluxConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/TraceWebFluxConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.autoconfig.instrument.web;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.cloud.sleuth.CurrentTraceContext;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.http.HttpServerHandler;
 import org.springframework.cloud.sleuth.instrument.web.TraceWebFilter;
@@ -38,8 +39,8 @@ class TraceWebFluxConfiguration {
 
 	@Bean
 	TraceWebFilter traceFilter(Tracer tracer, HttpServerHandler httpServerHandler,
-			SleuthWebProperties sleuthWebProperties) {
-		TraceWebFilter traceWebFilter = new TraceWebFilter(tracer, httpServerHandler);
+			CurrentTraceContext currentTraceContext, SleuthWebProperties sleuthWebProperties) {
+		TraceWebFilter traceWebFilter = new TraceWebFilter(tracer, httpServerHandler, currentTraceContext);
 		traceWebFilter.setOrder(sleuthWebProperties.getFilterOrder());
 		return traceWebFilter;
 	}

--- a/spring-cloud-sleuth-brave/src/test/java/org/springframework/cloud/sleuth/internal/LazyBeanTests.java
+++ b/spring-cloud-sleuth-brave/src/test/java/org/springframework/cloud/sleuth/internal/LazyBeanTests.java
@@ -20,10 +20,12 @@ import brave.propagation.CurrentTraceContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.BDDAssertions.then;
 
 public class LazyBeanTests {
@@ -52,6 +54,15 @@ public class LazyBeanTests {
 		LazyBean<CurrentTraceContext> provider = LazyBean.create(context, CurrentTraceContext.class);
 
 		then(provider.get()).isNull();
+	}
+
+	@Test
+	public void should_throw_error_when_no_basic_type() {
+		context.refresh();
+
+		LazyBean<CurrentTraceContext> provider = LazyBean.create(context, CurrentTraceContext.class);
+
+		assertThatCode(() -> provider.getOrError()).isInstanceOf(NoSuchBeanDefinitionException.class);
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-sleuth-instrumentation/pom.xml
+++ b/spring-cloud-sleuth-instrumentation/pom.xml
@@ -166,6 +166,11 @@
 			<artifactId>archunit-junit5</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/annotation/ReactorSleuthMethodInvocationProcessor.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/annotation/ReactorSleuthMethodInvocationProcessor.java
@@ -36,6 +36,7 @@ import org.springframework.cloud.sleuth.TraceContext;
 import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.annotation.ContinueSpan;
 import org.springframework.cloud.sleuth.annotation.NewSpan;
+import org.springframework.cloud.sleuth.instrument.reactor.TraceContextPropagator;
 import org.springframework.util.StringUtils;
 
 /**
@@ -146,7 +147,7 @@ public class ReactorSleuthMethodInvocationProcessor extends AbstractSleuthMethod
 
 	}
 
-	private static final class MonoSpan extends MonoOperator<Object, Object> {
+	private static final class MonoSpan extends MonoOperator<Object, Object> implements TraceContextPropagator {
 
 		final Span span;
 
@@ -187,6 +188,14 @@ public class ReactorSleuthMethodInvocationProcessor extends AbstractSleuthMethod
 				this.source.subscribe(new SpanSubscriber(actual, this.processor, this.invocation, this.span == null,
 						span, this.log, this.hasLog));
 			}
+		}
+
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (key == Attr.RUN_STYLE) {
+				return Attr.RunStyle.SYNC;
+			}
+			return super.scanUnsafe(key);
 		}
 
 	}

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelper.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelper.java
@@ -143,7 +143,7 @@ final class ReactorHooksHelper {
 		}
 	}
 
-	private static boolean isTraceContextPropagator(Publisher<?> current) {
+	static boolean isTraceContextPropagator(Publisher<?> current) {
 		return current instanceof TraceContextPropagator;
 	}
 

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelper.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelper.java
@@ -129,14 +129,13 @@ final class ReactorHooksHelper {
 			if (isTraceContextPropagator(current)) {
 				return false;
 			}
-			if (!isLifter(current)) {
-				if (!isSync(current)) {
-					return true;
-				}
 
-				if (isSourceProducer(current)) {
-					return false;
-				}
+			if (!isSync(current)) {
+				return true;
+			}
+
+			if (isSourceProducer(current)) {
+				return false;
 			}
 
 			current = getParent(current);
@@ -163,18 +162,6 @@ final class ReactorHooksHelper {
 			return (Publisher<?>) parent;
 		}
 		return null;
-	}
-
-	private static boolean isReactorCorePublisher(String pubClassName) {
-		return pubClassName != null && pubClassName.startsWith("reactor.core.publisher");
-	}
-
-	private static boolean isLifter(Publisher<?> current) {
-		if (current == null) {
-			return false;
-		}
-		String name = current.getClass().getName();
-		return isReactorCorePublisher(name) && ((name.endsWith("Lift") || name.endsWith("LiftFuseable")));
 	}
 
 	/**

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelper.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelper.java
@@ -1,0 +1,476 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.reactor;
+
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Fuseable;
+import reactor.core.Scannable;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxOperator;
+import reactor.core.publisher.GroupedFlux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.ParallelFlux;
+import reactor.util.annotation.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * Helper class for reactor ON_EACH instrumentation. Reduces number of sleuth operators
+ * time in the reactive chain during Assembly by using {@code Scannable.Attr.RUN_STYLE}.
+ * Below is the example of what it does <pre>{@code
+ *	Mono.just(0) // (-)
+ * 	.map(it -> 1) // (-)
+ * 	.flatMap(it ->
+ * 		Mono.just(it) // (-)
+ * 	) // (-)
+ * 	.flatMapMany(it ->
+ * 		asyncPublisher(it) // (+)(*)
+ * 	) // (-)
+ * 	.filter(it -> true) // (-)
+ * 	.publishOn(Schedulers.single()) //(+)
+ * 	.map(it -> it) // (-)
+ * 	.map(it -> it * 10) // (-)
+ * 	.filter(it -> true) // (-)
+ * 	.scan((l, r) -> l + r) // (-)
+ * 	.doOnNext(it -> { // (-)
+ * 		//log
+ * 	})
+ * 	.doFirst(() -> { // (-)
+ * 		//log
+ * 	})
+ * 	.doFinally(signalType -> { // (-)
+ * 		//log
+ * 	})
+ * 	.subscribeOn(Schedulers.parallel()) //(+)
+ * 	.subscribe();//(*)
+ * 	(*) - captures tracing context if it differs from what was captured before at subscription and propagates it.
+ *  As far as check is performed on Subscriber Context it allocates Publisher to access it.
+ * 	(+) - is ASYNC need to decorate Publisher
+ * 	(-) - is SYNC no need to decorate Publisher
+ *}</pre> So it creates 13 (out of 16) less Publisher (+ Subscriber and all their stuff)
+ * on assembly time comparing to the original logic (decorate every Publisher and checking
+ * only at subscription time).
+ * <p/>
+ * It also handles the case when onEachHook was not applied for some operator in the chain
+ * (It could be possible if custom operators or Processor are used) by checkin source
+ * source Publisher. <pre>{@code
+ * 	processor/customOperator // (?) is async and hook is not applied
+ * 	.map(it -> ...) // (+) is SYNC but should add hook as previous Processor/operator does not use hooks
+ * 	.doOnNext(it -> { // (-) is SYNC no need to wrap
+ * 		//log
+ * 	})
+ * 	.subscribe();
+ *}</pre>
+ */
+final class ReactorHooksHelper {
+
+	// need a way to determine SYNC sources to not add redundant scope passing decorator
+	// most of reactor-core SYNC sources are marked with SourceProducer interface
+	static final Class<?> sourceProducerClass;
+	static {
+		Class<?> c;
+		try {
+			c = Class.forName("reactor.core.publisher.SourceProducer");
+		}
+		catch (ClassNotFoundException e) {
+			c = Void.class;
+		}
+		sourceProducerClass = c;
+	}
+
+	private ReactorHooksHelper() {
+	}
+
+	/**
+	 * Determines whether to decorate input publisher with
+	 * {@code ScopePassingSpanOperator}.
+	 * @param p publisher to check
+	 * @return returns true if input publisher or one of its source publishers is not
+	 * {@code RunStyle.SYNC} and there is no {@link TraceContextPropagator} between input
+	 * publisher and not SYNC publisher.
+	 */
+	public static boolean shouldDecorate(Publisher<?> p) {
+		Assert.notNull(p, "source Publisher is null");
+		Publisher<?> current = p;
+		while (true) {
+			if (current == null) {
+				// is start of the chain, Publisher without source or foreign Publisher
+				return true;
+			}
+			if (current instanceof Fuseable.ScalarCallable) {
+				return false;
+			}
+			if (isTraceContextPropagator(current)) {
+				return false;
+			}
+			if (!isLifter(current)) {
+				if (!isSync(current)) {
+					return true;
+				}
+
+				if (isSourceProducer(current)) {
+					return false;
+				}
+			}
+
+			current = getParent(current);
+		}
+	}
+
+	private static boolean isTraceContextPropagator(Publisher<?> current) {
+		return current instanceof TraceContextPropagator;
+	}
+
+	private static boolean isSourceProducer(Publisher<?> p) {
+		return sourceProducerClass.isInstance(p);
+	}
+
+	private static boolean isSync(Publisher<?> p) {
+		return !(p instanceof Processor)
+				&& Scannable.Attr.RunStyle.SYNC == Scannable.from(p).scan(Scannable.Attr.RUN_STYLE);
+	}
+
+	@Nullable
+	private static Publisher<?> getParent(Publisher<?> publisher) {
+		Object parent = Scannable.from(publisher).scanUnsafe(Scannable.Attr.PARENT);
+		if (parent instanceof Publisher) {
+			return (Publisher<?>) parent;
+		}
+		return null;
+	}
+
+	private static boolean isReactorCorePublisher(String pubClassName) {
+		return pubClassName != null && pubClassName.startsWith("reactor.core.publisher");
+	}
+
+	private static boolean isLifter(Publisher<?> current) {
+		if (current == null) {
+			return false;
+		}
+		String name = current.getClass().getName();
+		return isReactorCorePublisher(name) && ((name.endsWith("Lift") || name.endsWith("LiftFuseable")));
+	}
+
+	/**
+	 * Decorates {@link Publisher} with {@link TraceContextPropagator} {@code Publisher}.
+	 * Mostly it is a copy of reactor-core logic from
+	 * {@code reactor.core.publisher.Operators#liftPublisher()}.
+	 * @param filter the Predicate that the raw Publisher must pass for the transformation
+	 * to occur
+	 * @param lifter the {@link BiFunction} taking the raw {@link Publisher} and
+	 * {@link CoreSubscriber}. The function must return a receiving {@link CoreSubscriber}
+	 * that will immediately subscribe to the {@link Publisher}.
+	 * @param <O> the input and output type.
+	 * @return a new {@link Function}.
+	 */
+	public static <O> Function<? super Publisher<O>, ? extends Publisher<O>> liftPublisher(Predicate<Publisher> filter,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super O>> lifter) {
+		Assert.notNull(lifter, "lifter is null");
+		return publisher -> {
+			if (filter != null && !filter.test(publisher)) {
+				return (Publisher<O>) publisher;
+			}
+
+			if (publisher instanceof Mono) {
+				return new SleuthMonoLift<>(publisher, lifter);
+			}
+			if (publisher instanceof ParallelFlux) {
+				return new SleuthParallelLift<>((ParallelFlux<O>) publisher, lifter);
+			}
+			if (publisher instanceof ConnectableFlux) {
+				return new SleuthConnectableLift<>((ConnectableFlux<O>) publisher, lifter);
+			}
+			if (publisher instanceof GroupedFlux) {
+				return new SleuthGroupedLift<>((GroupedFlux<?, O>) publisher, lifter);
+			}
+			return new SleuthFluxLift<>(publisher, lifter);
+		};
+	}
+
+}
+
+/**
+ * Copy of {@code reactor.core.publisher.MonoLift} which implements
+ * {@link TraceContextPropagator}.
+ */
+final class SleuthMonoLift<I, O> extends MonoOperator<I, O> implements TraceContextPropagator {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	SleuthMonoLift(Publisher<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		super(Mono.from(p));
+		this.lifter = lifter;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber input = actual;
+		try {
+			input = Objects.requireNonNull(lifter.apply(source, actual), "Lifted subscriber MUST NOT be null");
+
+			source.subscribe(input);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(input, e);
+			return;
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+		return super.scanUnsafe(key);
+	}
+
+}
+
+/**
+ * Copy of {@code reactor.core.publisher.FluxLift} which implements
+ * {@link TraceContextPropagator}.
+ */
+final class SleuthFluxLift<I, O> extends FluxOperator<I, O> implements TraceContextPropagator {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	SleuthFluxLift(Publisher<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		super(Flux.from(p));
+		this.lifter = lifter;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber input = actual;
+		try {
+			input = Objects.requireNonNull(lifter.apply(source, actual), "Lifted subscriber MUST NOT be null");
+
+			source.subscribe(input);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(input, e);
+			return;
+		}
+	}
+
+	@Override
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+		return super.scanUnsafe(key);
+	}
+
+}
+
+/**
+ * Copy of {@code reactor.core.publisher.ConnectableLift} which implements
+ * {@link TraceContextPropagator}.
+ */
+final class SleuthConnectableLift<I, O> extends ConnectableFlux<O> implements Scannable, TraceContextPropagator {
+
+	final ConnectableFlux<I> source;
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	SleuthConnectableLift(ConnectableFlux<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public void connect(Consumer<? super Disposable> cancelSupport) {
+		this.source.connect(cancelSupport);
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PREFETCH) {
+			return source.getPrefetch();
+		}
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+		return null;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber input = actual;
+		try {
+			input = Objects.requireNonNull(lifter.apply(source, actual), "Lifted subscriber MUST NOT be null");
+
+			source.subscribe(input);
+		}
+		catch (Throwable e) {
+			Operators.reportThrowInSubscribe(input, e);
+			return;
+		}
+	}
+
+}
+
+/**
+ * Copy of {@code reactor.core.publisher.GroupedLift} which implements
+ * {@link TraceContextPropagator}.
+ */
+final class SleuthGroupedLift<K, I, O> extends GroupedFlux<K, O> implements Scannable, TraceContextPropagator {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	final GroupedFlux<K, I> source;
+
+	SleuthGroupedLift(GroupedFlux<K, I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public K key() {
+		return source.key();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.PREFETCH) {
+			return getPrefetch();
+		}
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+
+		return null;
+	}
+
+	@Override
+	public String stepName() {
+		if (source instanceof Scannable) {
+			return Scannable.from(source).stepName();
+		}
+		return Scannable.super.stepName();
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O> actual) {
+		CoreSubscriber<? super I> input = lifter.apply(source, actual);
+
+		Objects.requireNonNull(input, "Lifted subscriber MUST NOT be null");
+
+		source.subscribe(input);
+	}
+
+}
+
+/**
+ * Copy of {@code reactor.core.publisher.ParallelLift} which implements
+ * {@link TraceContextPropagator}.
+ */
+final class SleuthParallelLift<I, O> extends ParallelFlux<O> implements Scannable, TraceContextPropagator {
+
+	final BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter;
+
+	final ParallelFlux<I> source;
+
+	SleuthParallelLift(ParallelFlux<I> p,
+			BiFunction<Publisher, ? super CoreSubscriber<? super O>, ? extends CoreSubscriber<? super I>> lifter) {
+		this.source = Objects.requireNonNull(p, "source");
+		this.lifter = lifter;
+	}
+
+	@Override
+	public int getPrefetch() {
+		return source.getPrefetch();
+	}
+
+	@Override
+	public int parallelism() {
+		return source.parallelism();
+	}
+
+	@Override
+	@Nullable
+	public Object scanUnsafe(Attr key) {
+		if (key == Attr.PARENT) {
+			return source;
+		}
+		if (key == Attr.PREFETCH) {
+			return getPrefetch();
+		}
+		if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
+		}
+
+		return null;
+	}
+
+	@Override
+	public String stepName() {
+		if (source instanceof Scannable) {
+			return Scannable.from(source).stepName();
+		}
+		return Scannable.super.stepName();
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super O>[] s) {
+		@SuppressWarnings("unchecked")
+		CoreSubscriber<? super I>[] subscribers = new CoreSubscriber[parallelism()];
+
+		int i = 0;
+		while (i < subscribers.length) {
+			subscribers[i] = Objects.requireNonNull(lifter.apply(source, s[i]), "Lifted subscriber MUST NOT be null");
+			i++;
+		}
+
+		source.subscribe(subscribers);
+	}
+
+}

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriber.java
@@ -44,7 +44,7 @@ final class ScopePassingSpanSubscriber<T> implements SpanSubscription<T>, Scanna
 
 	private final CurrentTraceContext currentTraceContext;
 
-	private final TraceContext parent;
+	final TraceContext parent;
 
 	private Subscription s;
 
@@ -108,10 +108,14 @@ final class ScopePassingSpanSubscriber<T> implements SpanSubscription<T>, Scanna
 		return this.context;
 	}
 
+	@reactor.util.annotation.Nullable
 	@Override
 	public Object scanUnsafe(Attr key) {
 		if (key == Attr.PARENT) {
 			return this.s;
+		}
+		else if (key == Attr.RUN_STYLE) {
+			return Attr.RunStyle.SYNC;
 		}
 		else {
 			return key == Attr.ACTUAL ? this.subscriber : null;

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceContextPropagator.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/TraceContextPropagator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.reactor;
+
+/**
+ * Only for internal use. Marker interface for Publisher and Subscriber that propagate
+ * Tracing context into execution Thread.
+ */
+public interface TraceContextPropagator {
+
+}

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/internal/LazyBean.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/internal/LazyBean.java
@@ -55,12 +55,8 @@ public final class LazyBean<T> {
 	 */
 	@Nullable
 	public T get() {
-		if (this.value != null) {
-			return this.value;
-		}
-
 		try {
-			this.value = springContext.getBean(requiredType);
+			return getOrError();
 		}
 		catch (Exception ex) {
 			if (log.isDebugEnabled()) {
@@ -68,6 +64,21 @@ public final class LazyBean<T> {
 			}
 		}
 		return this.value;
+	}
+
+	/**
+	 * Attempts to provision from the underlying bean factory, if not already provisioned.
+	 * @return the bean value. This variant does not catch exception.
+	 */
+	public T getOrError() {
+		T bean = this.value;
+		if (bean != null) {
+			return bean;
+		}
+
+		bean = springContext.getBean(requiredType);
+		this.value = bean;
+		return bean;
 	}
 
 }

--- a/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelperTests.java
+++ b/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/reactor/ReactorHooksHelperTests.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.reactor;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Scannable;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.ConnectableFlux;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.GroupedFlux;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.ParallelFlux;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.util.annotation.Nullable;
+import reactor.util.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class ReactorHooksHelperTests {
+
+	@BeforeEach
+	public void setUp() {
+		Hooks.resetOnEachOperator();
+		Hooks.resetOnLastOperator();
+		Schedulers.resetOnScheduleHooks();
+	}
+
+	@Test
+	public void shouldDecorateWhenSyncSourceThanShouldNotDecorate() {
+		boolean actual = ReactorHooksHelper.shouldDecorate(Mono.just(1).map(Function.identity()));
+		assertThat(actual).isFalse();
+	}
+
+	@Test
+	public void shouldDecorateWhenSyncSourceProducerThanShouldNotDecorate() {
+		// Mono.fromSupplier() is instance of SourceProduced and is not
+		// Fuseable.ScalarCallable like Mono.just()
+		Mono<Integer> syncSource = Mono.fromSupplier(() -> 1);
+		boolean actual = ReactorHooksHelper.shouldDecorate(syncSource.map(Function.identity()));
+		assertThat(actual).isFalse();
+	}
+
+	@Test
+	public void shouldDecorateWhenNotSyncSourceProducerThanShouldDecorate() {
+		Mono<Long> asyncSource = Mono.delay(Duration.ofMillis(10));
+		boolean actual = ReactorHooksHelper.shouldDecorate(asyncSource.map(Function.identity()));
+		assertThat(actual).isTrue();
+	}
+
+	@Test
+	public void shouldDecorateWhenProcessorSourceThanShouldNotDecorate() {
+		Mono<Long> asyncSource = Sinks.<Long>one().asMono();
+		boolean actual = ReactorHooksHelper.shouldDecorate(asyncSource.map(Function.identity()));
+		assertThat(actual).isTrue();
+	}
+
+	@Test
+	public void shouldDecorateWhenAsyncSourceAndLifterThanShouldDecorate() {
+		Mono<?> asyncSourceWithLifter = Mono.delay(Duration.ofMillis(10)).transform(Operators.liftPublisher(
+				new BiFunction<Publisher, CoreSubscriber<? super Object>, CoreSubscriber<? super Long>>() {
+					@Override
+					public CoreSubscriber<? super Long> apply(Publisher pub, CoreSubscriber<? super Object> sub) {
+						return sub;
+					}
+				}));
+		boolean actual = ReactorHooksHelper.shouldDecorate(asyncSourceWithLifter.map(Function.identity()));
+		assertThat(actual).isTrue();
+	}
+
+	@Test
+	public void shouldDecorateWhenSyncSourceAndLifterThanShouldNotDecorate() {
+		Mono<?> syncSourceWithLifter = Mono.fromSupplier(() -> 1L).transform(Operators.liftPublisher(
+				new BiFunction<Publisher, CoreSubscriber<? super Object>, CoreSubscriber<? super Long>>() {
+					@Override
+					public CoreSubscriber<? super Long> apply(Publisher pub, CoreSubscriber<? super Object> sub) {
+						return sub;
+					}
+				}));
+		boolean actual = ReactorHooksHelper.shouldDecorate(syncSourceWithLifter.map(Function.identity()));
+		assertThat(actual).isFalse();
+	}
+
+	@Test
+	public void shouldDecorateWhenAsyncSourceAndTraceContextPropagatorThanShouldNotDecorate() {
+		Function<? super Publisher<Long>, ? extends Publisher<Long>> traceContextPropagator = ReactorHooksHelper
+				.liftPublisher(publisher -> true, (publisher, coreSubscriber) -> coreSubscriber);
+		Mono<?> syncSourceWithLifter = Mono.delay(Duration.ofMillis(10)).transform(traceContextPropagator);
+		boolean actual = ReactorHooksHelper.shouldDecorate(syncSourceWithLifter.map(Function.identity()));
+		assertThat(actual).isFalse();
+	}
+
+	@Test
+	public void shouldDecorateWhenNullSourceProducerThanError() {
+		assertThatCode(() -> ReactorHooksHelper.shouldDecorate(null)).isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("source Publisher is null");
+	}
+
+	@Test
+	public void shouldDecorateWhenOperatorWithoutRunStyleThanShouldDecorate() {
+		Mono<?> source = Mono.just(1).as(CustomMonoWithoutRunStyleOperator::new);
+		boolean actual = ReactorHooksHelper.shouldDecorate(source.map(Function.identity()));
+		assertThat(actual).isTrue();
+	}
+
+	@Test
+	public void liftPublisherWhenFilterDiscardsThenReturnSource() {
+		Mono<Integer> source = Mono.just(1);
+		final Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = ReactorHooksHelper
+				.liftPublisher(p -> false, (p, s) -> s);
+		Mono<Integer> transformed = source.transform(transformer);
+		assertThat(source).isSameAs(transformed);
+	}
+
+	@Test
+	public void liftPublisherWhenFilterIsNullThenDecorate() {
+		Mono<Integer> source = Mono.just(1);
+		final Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = ReactorHooksHelper
+				.liftPublisher(null, (p, s) -> s);
+		Mono<Integer> transformed = source.transform(transformer);
+		assertThat(source).isNotSameAs(transformed);
+		assertThat(transformed).isInstanceOf(SleuthMonoLift.class);
+	}
+
+	@Test
+	public void liftPublisherWhenSourceMonoThenDecorateWithMono() {
+		Mono<Integer> source = Mono.just(1);
+		final Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = ReactorHooksHelper
+				.liftPublisher(p -> true, (p, s) -> new PlusOneSubscriber(s));
+		Mono<Integer> transformed = source.transform(transformer);
+		assertThat(source).isNotSameAs(transformed);
+		assertThat(transformed).isInstanceOf(SleuthMonoLift.class).isInstanceOf(TraceContextPropagator.class);
+
+		StepVerifier.create(transformed).expectSubscription().expectNext(2).expectComplete()
+				.verify(Duration.ofSeconds(5));
+	}
+
+	@Test
+	public void liftPublisherWhenSourceFluxThenDecorateWithFlux() {
+		Flux<Integer> source = Flux.just(1, 2, 3);
+		final Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = ReactorHooksHelper
+				.liftPublisher(p -> true, (p, s) -> new PlusOneSubscriber(s));
+		Flux<Integer> transformed = source.transform(transformer);
+		assertThat(source).isNotSameAs(transformed);
+		assertThat(transformed).isInstanceOf(SleuthFluxLift.class).isInstanceOf(TraceContextPropagator.class);
+
+		StepVerifier.create(transformed).expectSubscription().expectNext(2).expectNext(3).expectNext(4).expectComplete()
+				.verify(Duration.ofSeconds(5));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void liftPublisherWhenSourceParallelFluxThenDecorateWithParallelFlux() {
+		ParallelFlux<Integer> source = Flux.just(1, 2, 3).parallel();
+
+		Function function = ReactorHooksHelper.liftPublisher(p -> true,
+				(p, s) -> (CoreSubscriber) new PlusOneSubscriber(s));
+
+		ParallelFlux<Integer> transformed = source.transform(function);
+		assertThat(source).isNotSameAs(transformed);
+		assertThat(transformed).isInstanceOf(SleuthParallelLift.class).isInstanceOf(TraceContextPropagator.class);
+		Flux<Integer> sorted = transformed.map(it -> it).sequential().sort();
+		StepVerifier.create(sorted).expectSubscription().expectNext(2).expectNext(3).expectNext(4).expectComplete()
+				.verify(Duration.ofSeconds(5));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void liftPublisherWhenSourceConnectableFluxThenDecorateWithConnectableFlux() {
+		final AtomicBoolean sourceCanceled = new AtomicBoolean();
+		ConnectableFlux<Integer> source = Flux.just(1, 2, 3).doOnCancel(() -> sourceCanceled.set(true)).replay();
+
+		Function function = ReactorHooksHelper.liftPublisher(p -> true,
+				(p, s) -> (CoreSubscriber) new PlusOneSubscriber(s));
+
+		Flux<Integer> transformed = source.transform(function);
+		assertThat(source).isNotSameAs(transformed);
+		assertThat(transformed).isInstanceOf(SleuthConnectableLift.class).isInstanceOf(TraceContextPropagator.class);
+		final AtomicReference<Disposable> cancelSource = new AtomicReference<>();
+		Flux<Integer> autoConnect = ((ConnectableFlux<Integer>) transformed).autoConnect(1, cancelSource::set);
+
+		StepVerifier.create(autoConnect).expectSubscription().expectNext(2).expectNext(3).expectNext(4).thenCancel()
+				.verify(Duration.ofSeconds(5));
+
+		assertThat(cancelSource.get()).isNotNull();
+		cancelSource.get().dispose();
+		assertThat(sourceCanceled).isTrue();
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void liftPublisherWhenSourceGroupedFluxThenDecorateWithGroupedFlux() {
+		Flux<GroupedFlux<Integer, Integer>> source = Flux.just(1, 2, 3).groupBy(i -> i % 2);
+
+		Function function = ReactorHooksHelper.liftPublisher(p -> true,
+				(p, s) -> (CoreSubscriber) new PlusOneSubscriber(s));
+
+		GroupedFlux<Integer, Integer> grouped = source.filter(it -> it.key() == 1).blockFirst();
+		Flux<Integer> transformed = grouped.transform(function);
+		assertThat(grouped).isNotSameAs(transformed);
+		assertThat(transformed).isInstanceOf(SleuthGroupedLift.class).isInstanceOf(TraceContextPropagator.class);
+
+		assertThat(((GroupedFlux) transformed).key()).isEqualTo(1);
+
+		StepVerifier.create(transformed).expectSubscription().expectNext(2).expectNext(4).expectComplete()
+				.verify(Duration.ofSeconds(5));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void sleuthMonoLiftWhenScanRunStyleThenSync() {
+		final Mono source = Mockito.mock(Mono.class);
+
+		SleuthMonoLift lifter = new SleuthMonoLift(source, (p, s) -> s);
+
+		assertThat(lifter.scanUnsafe(Scannable.Attr.RUN_STYLE)).isEqualTo(Scannable.Attr.RunStyle.SYNC);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PARENT)).isEqualTo(source);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PREFETCH)).isEqualTo(Integer.MAX_VALUE);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testSleuthFluxLiftScanUnsafe() {
+		final Flux source = Mockito.mock(Flux.class);
+
+		SleuthFluxLift lifter = new SleuthFluxLift(source, (p, s) -> s);
+
+		assertThat(lifter.scanUnsafe(Scannable.Attr.RUN_STYLE)).isEqualTo(Scannable.Attr.RunStyle.SYNC);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PARENT)).isEqualTo(source);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PREFETCH)).isEqualTo(lifter.getPrefetch());
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testSleuthConnectableLiftScanUnsafe() {
+		final ConnectableFlux source = Mockito.mock(ConnectableFlux.class);
+		int sourcePrefetch = 1;
+		Mockito.when(source.getPrefetch()).thenReturn(sourcePrefetch);
+
+		SleuthConnectableLift lifter = new SleuthConnectableLift(source, (p, s) -> s);
+
+		assertThat(lifter.scanUnsafe(Scannable.Attr.RUN_STYLE)).isEqualTo(Scannable.Attr.RunStyle.SYNC);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PARENT)).isEqualTo(source);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PREFETCH)).isEqualTo(sourcePrefetch);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testSleuthGroupedLiftFluxScanUnsafe() {
+		final GroupedFlux source = Mockito.mock(GroupedFlux.class);
+		int sourcePrefetch = 1;
+		Mockito.when(source.getPrefetch()).thenReturn(sourcePrefetch);
+
+		SleuthGroupedLift lifter = new SleuthGroupedLift(source, (p, s) -> s);
+
+		assertThat(lifter.scanUnsafe(Scannable.Attr.RUN_STYLE)).isEqualTo(Scannable.Attr.RunStyle.SYNC);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PARENT)).isEqualTo(source);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PREFETCH)).isEqualTo(sourcePrefetch);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testSleuthParallelLiftScanUnsafe() {
+		final ParallelFlux source = Mockito.mock(ParallelFlux.class);
+		int sourcePrefetch = 1;
+		Mockito.when(source.getPrefetch()).thenReturn(sourcePrefetch);
+
+		SleuthParallelLift lifter = new SleuthParallelLift(source, (p, s) -> s);
+
+		assertThat(lifter.scanUnsafe(Scannable.Attr.RUN_STYLE)).isEqualTo(Scannable.Attr.RunStyle.SYNC);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PARENT)).isEqualTo(source);
+		assertThat(lifter.scanUnsafe(Scannable.Attr.PREFETCH)).isEqualTo(sourcePrefetch);
+	}
+
+	static class CustomMonoWithoutRunStyleOperator<O> extends MonoOperator<O, O> {
+
+		/**
+		 * Build a {@link MonoOperator} wrapper around the passed parent {@link Publisher}
+		 * @param source the {@link Publisher} to decorate
+		 */
+		protected CustomMonoWithoutRunStyleOperator(Mono<? extends O> source) {
+			super(source);
+		}
+
+		@Override
+		public void subscribe(CoreSubscriber<? super O> actual) {
+			source.subscribe(actual);
+		}
+
+		@Nullable
+		@Override
+		public Object scanUnsafe(Attr key) {
+			if (Attr.RUN_STYLE == key) {
+				return null;
+			}
+			return super.scanUnsafe(key);
+		}
+
+	}
+
+	static class PlusOneSubscriber extends BaseSubscriber<Integer> {
+
+		CoreSubscriber<? super Integer> actual;
+
+		PlusOneSubscriber(CoreSubscriber<? super Integer> actual) {
+			this.actual = actual;
+		}
+
+		@Override
+		public Context currentContext() {
+			return actual.currentContext();
+		}
+
+		@Override
+		protected void hookOnSubscribe(Subscription subscription) {
+			actual.onSubscribe(subscription);
+		}
+
+		@Override
+		protected void hookOnNext(Integer value) {
+			actual.onNext(value + 1);
+		}
+
+		@Override
+		protected void hookOnComplete() {
+			actual.onComplete();
+		}
+
+		@Override
+		protected void hookOnError(Throwable throwable) {
+			actual.onError(throwable);
+		}
+
+	}
+
+}

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/FlowsScopePassingSpanSubscriberTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/FlowsScopePassingSpanSubscriberTests.java
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.scopePassingSpanOperator;
+import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.onEachOperatorForOnEachInstrumentation;
 
 /**
  * @author Marcin Grzejszczak
@@ -78,7 +78,7 @@ public abstract class FlowsScopePassingSpanSubscriberTests {
 		springContext.registerBean(CurrentTraceContext.class, this::currentTraceContext);
 		springContext.refresh();
 
-		Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = scopePassingSpanOperator(
+		Function<? super Publisher<Integer>, ? extends Publisher<Integer>> transformer = onEachOperatorForOnEachInstrumentation(
 				this.springContext);
 
 		try (CurrentTraceContext.Scope ws = currentTraceContext().newScope(context())) {

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/ScopePassingSpanSubscriberTests.java
@@ -143,7 +143,7 @@ public abstract class ScopePassingSpanSubscriberTests {
 				"org.springframework.cloud.sleuth.autoconfig.instrument.reactor.TraceReactorAutoConfiguration.TraceReactorConfiguration");
 		Hooks.resetOnLastOperator(
 				"org.springframework.cloud.sleuth.autoconfig.instrument.reactor.TraceReactorAutoConfiguration.TraceReactorConfiguration");
-		Schedulers.removeExecutorServiceDecorator("s;euth");
+		Schedulers.resetOnScheduleHook("sleuth");
 	}
 
 	@AfterEach


### PR DESCRIPTION
this is rebased https://github.com/spring-cloud/spring-cloud-sleuth/pull/1733 on top of master (3.0.1-SNAPSHOT) + tests   
results of org.springframework.cloud.sleuth.benchmarks.jmh.webflux.MicroBenchmarkHttpTests to compare difference  
Before 
```
Benchmark                                                       (instrumentation)  (tracerImplementation)    Mode    Cnt       Score        Error   Units
MicroBenchmarkHttpTests.test                                      noSleuthComplex                   brave  sample   4294       2.330 ±      0.025   ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  noSleuthComplex                   brave  sample     10   38261.367 ±   2419.172    B/op

MicroBenchmarkHttpTests.test                                        onEachComplex                   brave  sample   4264       2.347 ±      0.025   ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onEachComplex                   brave  sample     10   58462.763 ±   1751.771    B/op

MicroBenchmarkHttpTests.test                                      onManualComplex                   brave  sample   4298       2.328 ±      0.025   ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  onManualComplex                   brave  sample     10   43581.296 ±   1292.146    B/op
```

After
```
Benchmark                                                       (instrumentation)  (tracerImplementation)    Mode    Cnt      Score        Error   Units
MicroBenchmarkHttpTests.test                                      noSleuthComplex                   brave  sample   4283      2.336 ±      0.024   ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  noSleuthComplex                   brave  sample     10  37601.047 ±   1213.439    B/op

MicroBenchmarkHttpTests.test                                        onEachComplex                   brave  sample   4253      2.352 ±      0.026   ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onEachComplex                   brave  sample     10  43311.298 ±   1514.039    B/op

MicroBenchmarkHttpTests.test                                      onManualComplex                   brave  sample   4249      2.354 ±      0.026   ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  onManualComplex                   brave  sample     10  44106.164 ±   4158.778    B/op
```

as example here difference of stack traces before changes  
```
java.lang.Throwable: 
	at org.springframework.cloud.sleuth.benchmarks.app.webflux.SleuthBenchmarkingSpringWebFluxApp.lambda$complex$8(SleuthBenchmarkingSpringWebFluxApp.java:122)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:125)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxDoOnEach$DoOnEachSubscriber.onNext(FluxDoOnEach.java:173)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoStreamCollector$StreamCollectorSubscriber.onComplete(MonoStreamCollector.java:178)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onComplete(ScopePassingSpanSubscriber.java:102)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onComplete(FluxMapFuseable.java:150)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onComplete(ScopePassingSpanSubscriber.java:102)
	at reactor.core.publisher.FluxRange$RangeSubscription.fastPath(FluxRange.java:137)
	at reactor.core.publisher.FluxRange$RangeSubscription.request(FluxRange.java:108)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.request(ScopePassingSpanSubscriber.java:74)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:169)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.request(ScopePassingSpanSubscriber.java:74)
	at reactor.core.publisher.MonoStreamCollector$StreamCollectorSubscriber.onSubscribe(MonoStreamCollector.java:121)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onSubscribe(ScopePassingSpanSubscriber.java:67)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:96)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onSubscribe(ScopePassingSpanSubscriber.java:67)
	at reactor.core.publisher.FluxRange.subscribe(FluxRange.java:68)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoFlatMap$FlatMapInner.onNext(MonoFlatMap.java:249)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableSubscriber.onNext(FluxPeekFuseable.java:210)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxPeekFuseable$PeekFuseableSubscriber.onNext(FluxPeekFuseable.java:210)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoIgnoreThen$ThenAcceptInner.onNext(MonoIgnoreThen.java:305)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoFlatMap$FlatMapInner.onNext(MonoFlatMap.java:249)
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2359)
	at reactor.core.publisher.MonoFlatMap$FlatMapInner.onSubscribe(MonoFlatMap.java:238)
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:54)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2359)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onSubscribe(MonoFlatMap.java:110)
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:54)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain(MonoIgnoreThen.java:154)
	at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:56)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onNext(FluxSwitchIfEmpty.java:73)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.MonoNext$NextSubscriber.onNext(MonoNext.java:82)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.innerNext(FluxConcatMap.java:281)
	at reactor.core.publisher.FluxConcatMap$ConcatMapInner.onNext(FluxConcatMap.java:860)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:127)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onNext(MonoPeekTerminal.java:180)
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2359)
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.request(MonoPeekTerminal.java:139)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.request(ScopePassingSpanSubscriber.java:74)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:169)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.request(ScopePassingSpanSubscriber.java:74)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2167)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2041)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onSubscribe(ScopePassingSpanSubscriber.java:67)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:96)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onSubscribe(ScopePassingSpanSubscriber.java:67)
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onSubscribe(MonoPeekTerminal.java:152)
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:54)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4046)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.drain(FluxConcatMap.java:448)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.onNext(FluxConcatMap.java:250)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxIterable$IterableSubscription.slowPath(FluxIterable.java:270)
	at reactor.core.publisher.FluxIterable$IterableSubscription.request(FluxIterable.java:228)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.request(ScopePassingSpanSubscriber.java:74)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.onSubscribe(FluxConcatMap.java:235)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onSubscribe(ScopePassingSpanSubscriber.java:67)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:164)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:86)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at org.springframework.cloud.sleuth.instrument.web.TraceWebFilter$MonoWebFilterTrace.subscribe(TraceWebFilter.java:135)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4046)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain(MonoIgnoreThen.java:173)
	at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:56)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.netty.http.server.HttpServer$HttpServerHandle.onStateChange(HttpServer.java:860)
	at reactor.netty.ReactorNetty$CompositeConnectionObserver.onStateChange(ReactorNetty.java:638)
	at reactor.netty.transport.ServerTransport$ChildObserver.onStateChange(ServerTransport.java:475)
	at reactor.netty.http.server.HttpServerOperations.onInboundNext(HttpServerOperations.java:525)
	at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:94)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at reactor.netty.http.server.HttpTrafficHandler.channelRead(HttpTrafficHandler.java:209)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
after changes 
```
java.lang.Throwable: 
	at org.springframework.cloud.sleuth.benchmarks.app.webflux.SleuthBenchmarkingSpringWebFluxApp.lambda$complex$8(SleuthBenchmarkingSpringWebFluxApp.java:122)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:125)
	at reactor.core.publisher.FluxDoOnEach$DoOnEachSubscriber.onNext(FluxDoOnEach.java:173)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoStreamCollector$StreamCollectorSubscriber.onComplete(MonoStreamCollector.java:178)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onComplete(FluxMapFuseable.java:150)
	at reactor.core.publisher.FluxRange$RangeSubscription.fastPath(FluxRange.java:137)
	at reactor.core.publisher.FluxRange$RangeSubscription.request(FluxRange.java:108)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:169)
	at reactor.core.publisher.MonoStreamCollector$StreamCollectorSubscriber.onSubscribe(MonoStreamCollector.java:121)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:96)
	at reactor.core.publisher.FluxRange.subscribe(FluxRange.java:68)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoFlatMap$FlatMapInner.onNext(MonoFlatMap.java:249)
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:79)
	at reactor.core.publisher.FluxPeek$PeekSubscriber.onNext(FluxPeek.java:199)
	at reactor.core.publisher.FluxPeek$PeekSubscriber.onNext(FluxPeek.java:199)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1789)
	at reactor.core.publisher.MonoIgnoreThen$ThenAcceptInner.onNext(MonoIgnoreThen.java:305)
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2359)
	at reactor.core.publisher.MonoIgnoreThen$ThenAcceptInner.onSubscribe(MonoIgnoreThen.java:294)
	at reactor.core.publisher.FluxFlatMap.trySubscribeScalarMap(FluxFlatMap.java:191)
	at reactor.core.publisher.MonoFlatMap.subscribeOrReturn(MonoFlatMap.java:53)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:57)
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain(MonoIgnoreThen.java:154)
	at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:56)
	at org.springframework.cloud.sleuth.instrument.reactor.SleuthMonoLift.subscribe(ReactorHooksHelper.java:215)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onNext(MonoFlatMap.java:157)
	at reactor.core.publisher.FluxSwitchIfEmpty$SwitchIfEmptySubscriber.onNext(FluxSwitchIfEmpty.java:73)
	at reactor.core.publisher.MonoNext$NextSubscriber.onNext(MonoNext.java:82)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.innerNext(FluxConcatMap.java:281)
	at reactor.core.publisher.FluxConcatMap$ConcatMapInner.onNext(FluxConcatMap.java:860)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onNext(ScopePassingSpanSubscriber.java:88)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:127)
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onNext(MonoPeekTerminal.java:180)
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2359)
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.request(MonoPeekTerminal.java:139)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:169)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.request(ScopePassingSpanSubscriber.java:74)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.set(Operators.java:2167)
	at reactor.core.publisher.Operators$MultiSubscriptionSubscriber.onSubscribe(Operators.java:2041)
	at org.springframework.cloud.sleuth.instrument.reactor.ScopePassingSpanSubscriber.onSubscribe(ScopePassingSpanSubscriber.java:67)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:96)
	at reactor.core.publisher.MonoPeekTerminal$MonoTerminalPeekSubscriber.onSubscribe(MonoPeekTerminal.java:152)
	at reactor.core.publisher.MonoJust.subscribe(MonoJust.java:54)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at org.springframework.cloud.sleuth.instrument.reactor.SleuthMonoLift.subscribe(ReactorHooksHelper.java:215)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4046)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.drain(FluxConcatMap.java:448)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.onSubscribe(FluxConcatMap.java:218)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:164)
	at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:86)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
	at org.springframework.cloud.sleuth.instrument.web.TraceWebFilter$MonoWebFilterTrace.subscribe(TraceWebFilter.java:145)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52)
	at reactor.core.publisher.Mono.subscribe(Mono.java:4046)
	at reactor.core.publisher.MonoIgnoreThen$ThenIgnoreMain.drain(MonoIgnoreThen.java:173)
	at reactor.core.publisher.MonoIgnoreThen.subscribe(MonoIgnoreThen.java:56)
	at org.springframework.cloud.sleuth.instrument.reactor.SleuthMonoLift.subscribe(ReactorHooksHelper.java:215)
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:64)
	at reactor.netty.http.server.HttpServer$HttpServerHandle.onStateChange(HttpServer.java:860)
	at reactor.netty.ReactorNetty$CompositeConnectionObserver.onStateChange(ReactorNetty.java:638)
	at reactor.netty.transport.ServerTransport$ChildObserver.onStateChange(ServerTransport.java:475)
	at reactor.netty.http.server.HttpServerOperations.onInboundNext(HttpServerOperations.java:525)
	at reactor.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:94)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at reactor.netty.http.server.HttpTrafficHandler.channelRead(HttpTrafficHandler.java:209)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
the size is reduced by 30 lines

Full benchmark results
Before 
```
Benchmark                                                       (instrumentation)  (tracerImplementation)    Mode    Cnt       Score        Error   Units
MicroBenchmarkHttpTests.test                                       noSleuthSimple                   brave  sample  89518       0.112 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                            noSleuthSimple                   brave  sample              0.044                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                            noSleuthSimple                   brave  sample              0.114                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                            noSleuthSimple                   brave  sample              0.130                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                            noSleuthSimple                   brave  sample              0.138                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                            noSleuthSimple                   brave  sample              0.157                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                           noSleuthSimple                   brave  sample              0.199                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                          noSleuthSimple                   brave  sample              3.473                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                            noSleuthSimple                   brave  sample              4.059                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                        noSleuthSimple                   brave  sample     10     167.792 ±     68.266  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                   noSleuthSimple                   brave  sample     10   33415.793 ±    143.706    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space               noSleuthSimple                   brave  sample     10     169.836 ±    147.675  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm          noSleuthSimple                   brave  sample     10   32583.675 ±  26267.672    B/op
MicroBenchmarkHttpTests.test:·gc.count                             noSleuthSimple                   brave  sample     10       8.000               counts
MicroBenchmarkHttpTests.test:·gc.time                              noSleuthSimple                   brave  sample     10      26.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleManual                   brave  sample  74249       0.134 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleManual                   brave  sample              0.059                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleManual                   brave  sample              0.141                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleManual                   brave  sample              0.152                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleManual                   brave  sample              0.162                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleManual                   brave  sample              0.183                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleManual                   brave  sample              0.229                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleManual                   brave  sample              4.963                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleManual                   brave  sample              5.841                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleManual                   brave  sample     10     155.197 ±     63.288  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleManual                   brave  sample     10   37264.886 ±    167.252    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleManual                   brave  sample     10     164.174 ±    154.278  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleManual                   brave  sample     10   41253.771 ±  33157.982    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleManual                   brave  sample     10       8.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleManual                   brave  sample     10      39.000                   ms
MicroBenchmarkHttpTests.test                                         sleuthManual                   brave  sample  71871       0.139 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                              sleuthManual                   brave  sample              0.079                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                              sleuthManual                   brave  sample              0.144                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                              sleuthManual                   brave  sample              0.163                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                              sleuthManual                   brave  sample              0.168                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                              sleuthManual                   brave  sample              0.191                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                             sleuthManual                   brave  sample              0.237                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                            sleuthManual                   brave  sample              0.450                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                              sleuthManual                   brave  sample              6.332                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                          sleuthManual                   brave  sample     10     152.681 ±     62.195  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                     sleuthManual                   brave  sample     10   37929.266 ±    170.659    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                 sleuthManual                   brave  sample     10     167.053 ±    265.022  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm            sleuthManual                   brave  sample     10   40157.582 ±  59118.340    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space             sleuthManual                   brave  sample     10       0.529 ±      2.380  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm        sleuthManual                   brave  sample     10     117.095 ±    524.445    B/op
MicroBenchmarkHttpTests.test:·gc.count                               sleuthManual                   brave  sample     10       6.000               counts
MicroBenchmarkHttpTests.test:·gc.time                                sleuthManual                   brave  sample     10      29.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnEach                   brave  sample  56958       0.175 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnEach                   brave  sample              0.110                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnEach                   brave  sample              0.178                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnEach                   brave  sample              0.198                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnEach                   brave  sample              0.212                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnEach                   brave  sample              0.237                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnEach                   brave  sample              0.295                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnEach                   brave  sample              5.120                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnEach                   brave  sample              5.784                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnEach                   brave  sample     10     161.040 ±     65.472  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnEach                   brave  sample     10   50541.603 ±    342.560    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnEach                   brave  sample     10     161.785 ±    151.965  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnEach                   brave  sample     10   53299.426 ±  42716.166    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space       sleuthSimpleOnEach                   brave  sample     10       0.001 ±      0.007  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm  sleuthSimpleOnEach                   brave  sample     10       0.388 ±      1.853    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnEach                   brave  sample     10       8.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnEach                   brave  sample     10      38.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnLast                   brave  sample  69227       0.144 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnLast                   brave  sample              0.083                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnLast                   brave  sample              0.150                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnLast                   brave  sample              0.166                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnLast                   brave  sample              0.172                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnLast                   brave  sample              0.195                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnLast                   brave  sample              0.247                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnLast                   brave  sample              0.762                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnLast                   brave  sample              6.095                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnLast                   brave  sample     10     157.947 ±     64.172  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnLast                   brave  sample     10   40704.927 ±    135.942    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnLast                   brave  sample     10     159.930 ±    257.781  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnLast                   brave  sample     10   40400.196 ±  62050.352    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space       sleuthSimpleOnLast                   brave  sample     10       0.540 ±      2.396  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm  sleuthSimpleOnLast                   brave  sample     10     132.719 ±    593.034    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnLast                   brave  sample     10       6.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnLast                   brave  sample     10      29.000                   ms
MicroBenchmarkHttpTests.test                                      noSleuthComplex                   brave  sample   4294       2.330 ±      0.025   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           noSleuthComplex                   brave  sample              1.249                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           noSleuthComplex                   brave  sample              2.028                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           noSleuthComplex                   brave  sample              3.039                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           noSleuthComplex                   brave  sample              3.101                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           noSleuthComplex                   brave  sample              3.150                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          noSleuthComplex                   brave  sample              3.230                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         noSleuthComplex                   brave  sample             10.011                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           noSleuthComplex                   brave  sample             10.011                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       noSleuthComplex                   brave  sample     10       9.215 ±      3.797  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  noSleuthComplex                   brave  sample     10   38261.367 ±   2419.172    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space              noSleuthComplex                   brave  sample     10      32.889 ±    104.828  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm         noSleuthComplex                   brave  sample     10  121435.539 ± 387051.728    B/op
MicroBenchmarkHttpTests.test:·gc.count                            noSleuthComplex                   brave  sample     10       2.000               counts
MicroBenchmarkHttpTests.test:·gc.time                             noSleuthComplex                   brave  sample     10      15.000                   ms
MicroBenchmarkHttpTests.test                                        onEachComplex                   brave  sample   4264       2.347 ±      0.025   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onEachComplex                   brave  sample              1.477                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onEachComplex                   brave  sample              2.030                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onEachComplex                   brave  sample              3.039                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onEachComplex                   brave  sample              3.105                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onEachComplex                   brave  sample              3.158                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onEachComplex                   brave  sample              3.397                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onEachComplex                   brave  sample              8.536                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onEachComplex                   brave  sample              8.536                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onEachComplex                   brave  sample     10      13.976 ±      5.686  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onEachComplex                   brave  sample     10   58462.763 ±   1751.771    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                onEachComplex                   brave  sample     10      13.114 ±     62.698  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm           onEachComplex                   brave  sample     10   49418.534 ± 236265.691    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space            onEachComplex                   brave  sample     10       0.238 ±      1.140  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm       onEachComplex                   brave  sample     10     898.176 ±   4294.101    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onEachComplex                   brave  sample     10       1.000               counts
MicroBenchmarkHttpTests.test:·gc.time                               onEachComplex                   brave  sample     10       7.000                   ms
MicroBenchmarkHttpTests.test                                        onLastComplex                   brave  sample   4296       2.328 ±      0.024   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onLastComplex                   brave  sample              1.425                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onLastComplex                   brave  sample              2.028                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onLastComplex                   brave  sample              3.031                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onLastComplex                   brave  sample              3.092                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onLastComplex                   brave  sample              3.146                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onLastComplex                   brave  sample              3.226                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onLastComplex                   brave  sample              7.971                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onLastComplex                   brave  sample              7.971                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onLastComplex                   brave  sample     10      11.342 ±      4.712  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onLastComplex                   brave  sample     10   47078.045 ±   3940.955    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                onLastComplex                   brave  sample     10      27.040 ±     86.185  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm           onLastComplex                   brave  sample     10  100287.391 ± 319646.308    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space            onLastComplex                   brave  sample     10       0.521 ±      1.661  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm       onLastComplex                   brave  sample     10    1932.711 ±   6160.214    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onLastComplex                   brave  sample     10       2.000               counts
MicroBenchmarkHttpTests.test:·gc.time                               onLastComplex                   brave  sample     10      14.000                   ms
MicroBenchmarkHttpTests.test                                      onManualComplex                   brave  sample   4298       2.328 ±      0.025   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           onManualComplex                   brave  sample              1.272                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           onManualComplex                   brave  sample              2.025                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           onManualComplex                   brave  sample              3.035                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           onManualComplex                   brave  sample              3.092                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           onManualComplex                   brave  sample              3.150                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          onManualComplex                   brave  sample              3.259                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         onManualComplex                   brave  sample              9.077                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           onManualComplex                   brave  sample              9.077                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       onManualComplex                   brave  sample     10      10.462 ±      4.105  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  onManualComplex                   brave  sample     10   43581.296 ±   1292.146    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space              onManualComplex                   brave  sample     10      26.735 ±     85.213  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm         onManualComplex                   brave  sample     10   98710.902 ± 314620.089    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space          onManualComplex                   brave  sample     10       0.491 ±      1.566  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm     onManualComplex                   brave  sample     10    1812.974 ±   5779.945    B/op
MicroBenchmarkHttpTests.test:·gc.count                            onManualComplex                   brave  sample     10       2.000               counts
MicroBenchmarkHttpTests.test:·gc.time                             onManualComplex                   brave  sample     10      12.000                   ms
```

After
```
Benchmark                                                       (instrumentation)  (tracerImplementation)    Mode    Cnt      Score        Error   Units
MicroBenchmarkHttpTests.test                                       noSleuthSimple                   brave  sample  89905      0.111 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                            noSleuthSimple                   brave  sample             0.043                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                            noSleuthSimple                   brave  sample             0.113                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                            noSleuthSimple                   brave  sample             0.130                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                            noSleuthSimple                   brave  sample             0.136                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                            noSleuthSimple                   brave  sample             0.157                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                           noSleuthSimple                   brave  sample             0.200                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                          noSleuthSimple                   brave  sample             2.260                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                            noSleuthSimple                   brave  sample             3.957                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                        noSleuthSimple                   brave  sample     10    168.823 ±     68.884  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                   noSleuthSimple                   brave  sample     10  33468.305 ±    112.683    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space               noSleuthSimple                   brave  sample     10    162.649 ±    142.765  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm          noSleuthSimple                   brave  sample     10  31015.226 ±  25042.750    B/op
MicroBenchmarkHttpTests.test:·gc.count                             noSleuthSimple                   brave  sample     10      8.000               counts
MicroBenchmarkHttpTests.test:·gc.time                              noSleuthSimple                   brave  sample     10     26.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleManual                   brave  sample  75447      0.132 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleManual                   brave  sample             0.077                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleManual                   brave  sample             0.139                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleManual                   brave  sample             0.149                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleManual                   brave  sample             0.159                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleManual                   brave  sample             0.179                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleManual                   brave  sample             0.224                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleManual                   brave  sample             4.881                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleManual                   brave  sample             5.456                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleManual                   brave  sample     10    155.470 ±     63.698  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleManual                   brave  sample     10  36715.879 ±    176.737    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleManual                   brave  sample     10    159.370 ±    150.228  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleManual                   brave  sample     10  39365.993 ±  31804.951    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space       sleuthSimpleManual                   brave  sample     10      0.003 ±      0.009  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm  sleuthSimpleManual                   brave  sample     10      0.565 ±      1.859    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleManual                   brave  sample     10      8.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleManual                   brave  sample     10     38.000                   ms
MicroBenchmarkHttpTests.test                                         sleuthManual                   brave  sample  75083      0.133 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                              sleuthManual                   brave  sample             0.073                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                              sleuthManual                   brave  sample             0.140                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                              sleuthManual                   brave  sample             0.150                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                              sleuthManual                   brave  sample             0.158                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                              sleuthManual                   brave  sample             0.182                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                             sleuthManual                   brave  sample             0.230                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                            sleuthManual                   brave  sample             5.060                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                              sleuthManual                   brave  sample             6.496                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                          sleuthManual                   brave  sample     10    156.124 ±     64.225  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                     sleuthManual                   brave  sample     10  37022.780 ±    135.421    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                 sleuthManual                   brave  sample     10    159.367 ±    138.811  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm            sleuthManual                   brave  sample     10  36337.542 ±  29122.474    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space             sleuthManual                   brave  sample     10      0.003 ±      0.015  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm        sleuthManual                   brave  sample     10      0.646 ±      3.089    B/op
MicroBenchmarkHttpTests.test:·gc.count                               sleuthManual                   brave  sample     10      8.000               counts
MicroBenchmarkHttpTests.test:·gc.time                                sleuthManual                   brave  sample     10     40.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnEach                   brave  sample  53212      0.187 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnEach                   brave  sample             0.116                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnEach                   brave  sample             0.190                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnEach                   brave  sample             0.208                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnEach                   brave  sample             0.216                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnEach                   brave  sample             0.242                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnEach                   brave  sample             0.314                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnEach                   brave  sample             4.963                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnEach                   brave  sample             5.579                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnEach                   brave  sample     10    113.220 ±     46.103  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnEach                   brave  sample     10  37954.906 ±    327.094    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnEach                   brave  sample     10    101.974 ±    147.346  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnEach                   brave  sample     10  37349.320 ±  48714.852    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnEach                   brave  sample     10      6.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnEach                   brave  sample     10     28.000                   ms
MicroBenchmarkHttpTests.test                                   sleuthSimpleOnLast                   brave  sample  72583      0.137 ±      0.001   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                        sleuthSimpleOnLast                   brave  sample             0.086                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                        sleuthSimpleOnLast                   brave  sample             0.144                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                        sleuthSimpleOnLast                   brave  sample             0.154                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                        sleuthSimpleOnLast                   brave  sample             0.165                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                        sleuthSimpleOnLast                   brave  sample             0.187                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                       sleuthSimpleOnLast                   brave  sample             0.230                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                      sleuthSimpleOnLast                   brave  sample             5.120                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                        sleuthSimpleOnLast                   brave  sample             5.317                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                    sleuthSimpleOnLast                   brave  sample     10    153.101 ±     62.741  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm               sleuthSimpleOnLast                   brave  sample     10  37581.219 ±    119.892    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space           sleuthSimpleOnLast                   brave  sample     10    153.856 ±    144.676  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm      sleuthSimpleOnLast                   brave  sample     10  39500.964 ±  31717.124    B/op
MicroBenchmarkHttpTests.test:·gc.count                         sleuthSimpleOnLast                   brave  sample     10      8.000               counts
MicroBenchmarkHttpTests.test:·gc.time                          sleuthSimpleOnLast                   brave  sample     10     39.000                   ms
MicroBenchmarkHttpTests.test                                      noSleuthComplex                   brave  sample   4283      2.336 ±      0.024   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           noSleuthComplex                   brave  sample             1.243                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           noSleuthComplex                   brave  sample             2.040                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           noSleuthComplex                   brave  sample             3.047                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           noSleuthComplex                   brave  sample             3.113                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           noSleuthComplex                   brave  sample             3.166                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          noSleuthComplex                   brave  sample             3.239                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         noSleuthComplex                   brave  sample             5.014                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           noSleuthComplex                   brave  sample             5.014                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       noSleuthComplex                   brave  sample     10      9.008 ±      3.589  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  noSleuthComplex                   brave  sample     10  37601.047 ±   1213.439    B/op
MicroBenchmarkHttpTests.test:·gc.count                            noSleuthComplex                   brave  sample     10        ≈ 0               counts
MicroBenchmarkHttpTests.test                                        onEachComplex                   brave  sample   4253      2.352 ±      0.026   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onEachComplex                   brave  sample             1.546                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onEachComplex                   brave  sample             2.038                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onEachComplex                   brave  sample             3.042                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onEachComplex                   brave  sample             3.109                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onEachComplex                   brave  sample             3.166                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onEachComplex                   brave  sample             3.395                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onEachComplex                   brave  sample            11.239                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onEachComplex                   brave  sample            11.239                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onEachComplex                   brave  sample     10     10.315 ±      4.147  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onEachComplex                   brave  sample     10  43311.298 ±   1514.039    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                onEachComplex                   brave  sample     10     25.668 ±     81.812  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm           onEachComplex                   brave  sample     10  97172.050 ± 309716.186    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space            onEachComplex                   brave  sample     10      0.198 ±      0.637  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm       onEachComplex                   brave  sample     10    750.606 ±   2407.350    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onEachComplex                   brave  sample     10      2.000               counts
MicroBenchmarkHttpTests.test:·gc.time                               onEachComplex                   brave  sample     10     14.000                   ms
MicroBenchmarkHttpTests.test                                        onLastComplex                   brave  sample   4280      2.336 ±      0.025   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                             onLastComplex                   brave  sample             1.243                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                             onLastComplex                   brave  sample             2.034                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                             onLastComplex                   brave  sample             3.043                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                             onLastComplex                   brave  sample             3.113                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                             onLastComplex                   brave  sample             3.158                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                            onLastComplex                   brave  sample             3.661                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                           onLastComplex                   brave  sample            10.600                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                             onLastComplex                   brave  sample            10.600                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                         onLastComplex                   brave  sample     10     10.418 ±      4.210  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                    onLastComplex                   brave  sample     10  43489.382 ±   2599.461    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space                onLastComplex                   brave  sample     10     25.928 ±     82.640  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm           onLastComplex                   brave  sample     10  95990.019 ± 305956.394    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space            onLastComplex                   brave  sample     10      0.243 ±      0.786  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm       onLastComplex                   brave  sample     10    901.608 ±   2916.311    B/op
MicroBenchmarkHttpTests.test:·gc.count                              onLastComplex                   brave  sample     10      2.000               counts
MicroBenchmarkHttpTests.test:·gc.time                               onLastComplex                   brave  sample     10     14.000                   ms
MicroBenchmarkHttpTests.test                                      onManualComplex                   brave  sample   4249      2.354 ±      0.026   ms/op
MicroBenchmarkHttpTests.test:test·p0.00                           onManualComplex                   brave  sample             1.262                ms/op
MicroBenchmarkHttpTests.test:test·p0.50                           onManualComplex                   brave  sample             2.044                ms/op
MicroBenchmarkHttpTests.test:test·p0.90                           onManualComplex                   brave  sample             3.047                ms/op
MicroBenchmarkHttpTests.test:test·p0.95                           onManualComplex                   brave  sample             3.113                ms/op
MicroBenchmarkHttpTests.test:test·p0.99                           onManualComplex                   brave  sample             3.164                ms/op
MicroBenchmarkHttpTests.test:test·p0.999                          onManualComplex                   brave  sample             3.473                ms/op
MicroBenchmarkHttpTests.test:test·p0.9999                         onManualComplex                   brave  sample            11.026                ms/op
MicroBenchmarkHttpTests.test:test·p1.00                           onManualComplex                   brave  sample            11.026                ms/op
MicroBenchmarkHttpTests.test:·gc.alloc.rate                       onManualComplex                   brave  sample     10     10.501 ±      4.373  MB/sec
MicroBenchmarkHttpTests.test:·gc.alloc.rate.norm                  onManualComplex                   brave  sample     10  44106.164 ±   4158.778    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space              onManualComplex                   brave  sample     10     26.047 ±     83.019  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Eden_Space.norm         onManualComplex                   brave  sample     10  98095.885 ± 312687.302    B/op
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space          onManualComplex                   brave  sample     10      0.243 ±      0.774  MB/sec
MicroBenchmarkHttpTests.test:·gc.churn.PS_Survivor_Space.norm     onManualComplex                   brave  sample     10    914.914 ±   2916.313    B/op
MicroBenchmarkHttpTests.test:·gc.count                            onManualComplex                   brave  sample     10      2.000               counts
MicroBenchmarkHttpTests.test:·gc.time                             onManualComplex                   brave  sample     10     13.000                   ms
```

