### PR TITLE
Implement mechanism to apply custom api path

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -1050,7 +1050,7 @@ If you want to find Zipkin through service discovery, you can pass the Zipkin's 
 spring.zipkin.baseUrl: https://zipkinserver/
 ----
 
-By default api path will be set to `api/v2/spans` or `api/v1/spans` depending on the encoder version. If you want to use a custom api path, you can configure it using the following property (empty case, set ""):
+By default, api path will be set to `api/v2/spans` or `api/v1/spans` depending on the encoder version. If you want to use a custom api path, you can configure it using the following property (empty case, set ""):
 
 [source,yaml]
 ----

--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -1050,6 +1050,13 @@ If you want to find Zipkin through service discovery, you can pass the Zipkin's 
 spring.zipkin.baseUrl: https://zipkinserver/
 ----
 
+By default api path will be set to `api/v2/spans` or `api/v1/spans` depending on the encoder version. If you want to use a custom api path, you can configure it using the following property (empty case, set ""):
+
+[source,yaml]
+----
+spring.zipkin.apiPath: v2/path2
+----
+
 To disable this feature just set `spring.zipkin.discoveryClientEnabled` to `false.
 
 When the Discovery Client feature is enabled, Sleuth uses

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
@@ -38,6 +38,13 @@ public class ZipkinProperties {
 	private String baseUrl = "http://localhost:9411/";
 
 	/**
+	 * Api path that will be appended to baseUrl above as suffix This is applicable if you
+	 * are using other monitoring tools. IE, new relic, the trace api doesn't need api
+	 * path, so this can be set to blank ("") in the config.
+	 */
+	private String apiPath = null;
+
+	/**
 	 * If set to {@code false}, will treat the {@link ZipkinProperties#baseUrl} as a URL
 	 * always.
 	 */
@@ -82,6 +89,14 @@ public class ZipkinProperties {
 
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
+	}
+
+	public String getApiPath() {
+		return apiPath;
+	}
+
+	public void setApiPath(String apiPath) {
+		this.apiPath = apiPath;
 	}
 
 	public boolean isEnabled() {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
@@ -38,9 +38,9 @@ public class ZipkinProperties {
 	private String baseUrl = "http://localhost:9411/";
 
 	/**
-	 * Api path that will be appended to baseUrl above as suffix This is applicable if you
-	 * are using other monitoring tools. IE, new relic, the trace api doesn't need api
-	 * path, so this can be set to blank ("") in the config.
+	 * The API path to append to baseUrl (above) as suffix. This applies if you use other
+	 * monitoring tools, such as New Relic. The trace API doesn't need the API path, so
+	 * you can set it to blank ("") in the configuration.
 	 */
 	private String apiPath = null;
 
@@ -92,7 +92,7 @@ public class ZipkinProperties {
 	}
 
 	public String getApiPath() {
-		return apiPath;
+		return this.apiPath;
 	}
 
 	public void setApiPath(String apiPath) {

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRestTemplateSenderConfiguration.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinRestTemplateSenderConfiguration.java
@@ -64,7 +64,7 @@ class ZipkinRestTemplateSenderConfiguration {
 		RestTemplate restTemplate = new ZipkinRestTemplateWrapper(zipkin, this.extractor);
 		restTemplate = zipkinRestTemplateCustomizer.customizeTemplate(restTemplate);
 		return new RestTemplateSender(restTemplate, zipkin.getBaseUrl(),
-				zipkin.getEncoder());
+				zipkin.getApiPath(), zipkin.getEncoder());
 	}
 
 	@Bean

--- a/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/sender/RestTemplateSenderTest.java
+++ b/spring-cloud-sleuth-zipkin/src/test/java/org/springframework/cloud/sleuth/zipkin2/sender/RestTemplateSenderTest.java
@@ -54,7 +54,7 @@ public class RestTemplateSenderTest {
 	String baseUrl = "http://localhost:" + this.server.getPort();
 
 	RestTemplateSender sender = new RestTemplateSender(new RestTemplate(), this.baseUrl,
-			JSON_V2);
+			null, JSON_V2);
 
 	/**
 	 * Tests that json is not manipulated as a side-effect of using rest template.
@@ -73,7 +73,8 @@ public class RestTemplateSenderTest {
 	@Test
 	public void proto3() throws Exception {
 		this.server.enqueue(new MockResponse());
-		this.sender = new RestTemplateSender(new RestTemplate(), this.baseUrl, PROTO3);
+		this.sender = new RestTemplateSender(new RestTemplate(), this.baseUrl, "",
+				PROTO3);
 
 		send(SPAN).execute();
 
@@ -83,6 +84,26 @@ public class RestTemplateSenderTest {
 		// proto3 encoding of ListOfSpan is simply a repeated span entry
 		assertThat(request.getBody().readByteArray())
 				.containsExactly(SpanBytesEncoder.PROTO3.encode(SPAN));
+	}
+
+	@Test
+	public void testWhereApiIsSetNonEmpty() {
+		final String mockedApiPath = "/test/v2";
+		final RestTemplateSender senderWithMockedApiPath = new RestTemplateSender(
+				new RestTemplate(), this.baseUrl, mockedApiPath, JSON_V2);
+
+		assertThat(senderWithMockedApiPath.toString())
+				.isEqualTo("RestTemplateSender{" + baseUrl + mockedApiPath + "}");
+	}
+
+	@Test
+	public void testWhereApiIsSetToEmpty() {
+		final String mockedApiPath = "";
+		final RestTemplateSender senderWithMockedApiPath = new RestTemplateSender(
+				new RestTemplate(), this.baseUrl, mockedApiPath, JSON_V2);
+
+		assertThat(senderWithMockedApiPath.toString())
+				.isEqualTo("RestTemplateSender{" + baseUrl + "}");
 	}
 
 	/**


### PR DESCRIPTION
This comes in handy when another monitoring tool is being used, for instance new relic, which doesn't not require path in its tracing api.

Context as of feb 19, new relic doesn't accept request to its tracing api endpoint with path. Previous it was fine, now it will throw 404 erro.
