### PR TITLE
Don't allow double Gateway instrumentation

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/client/TraceWebClientAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/client/TraceWebClientAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoRestTemplateCustomizer;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
@@ -104,6 +105,7 @@ class TraceWebClientAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(HttpHeadersFilter.class)
+	@ConditionalOnMissingClass("reactor.netty.http.client.HttpClient")
 	static class HttpHeadersFilterConfig {
 
 		@Bean

--- a/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/client/GatewayAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/client/GatewayAutoConfigurationTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.autoconfig.instrument.web.client;
+
+import org.junit.jupiter.api.Test;
+import reactor.netty.http.client.HttpClient;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gateway.filter.headers.HttpHeadersFilter;
+import org.springframework.cloud.sleuth.autoconfig.TraceNoOpAutoConfiguration;
+import org.springframework.cloud.sleuth.instrument.web.client.TraceRequestHttpHeadersFilter;
+import org.springframework.cloud.sleuth.instrument.web.client.TraceResponseHttpHeadersFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GatewayAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withPropertyValues("spring.sleuth.noop.enabled=true").withConfiguration(
+					AutoConfigurations.of(TraceNoOpAutoConfiguration.class, TraceWebClientAutoConfiguration.class));
+
+	@Test
+	void should_not_create_gateway_trace_filters_when_reactor_netty_client_on_classpath() {
+		this.contextRunner.run(context -> assertThat(context).doesNotHaveBean(HttpHeadersFilter.class));
+	}
+
+	@Test
+	void should_create_gateway_trace_filters_when_reactor_netty_client_not_on_classpath() {
+		this.contextRunner.withClassLoader(new FilteredClassLoader(HttpClient.class))
+				.run(context -> assertThat(context).hasSingleBean(TraceResponseHttpHeadersFilter.class)
+						.hasSingleBean(TraceRequestHttpHeadersFilter.class));
+	}
+
+}


### PR DESCRIPTION
with this change we're doing both HeaderFilter based Gateway instrumentation and the Netty Client one.
with this change we're conditionally enabling the HeaderFilter instrumentation only when there is no Netty Client one present on the classpath.

fixes gh-1840