### PR TITLE
Modify WebClient tracing to include the uri template in generated span names

### DIFF
--- a/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceExchangeFilterFunctionHttpClientResponseTests.java
+++ b/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/web/client/TraceExchangeFilterFunctionHttpClientResponseTests.java
@@ -29,7 +29,7 @@ public class TraceExchangeFilterFunctionHttpClientResponseTests {
 	public void should_return_0_when_invalid_status_code_is_returned() {
 		ClientResponse clientResponse = BDDMockito.mock(ClientResponse.class);
 		BDDMockito.given(clientResponse.rawStatusCode()).willReturn(-1);
-		ClientResponseWrapper response = new ClientResponseWrapper(clientResponse);
+		ClientResponseWrapper response = new ClientResponseWrapper(clientResponse, null, null);
 
 		Integer statusCode = response.statusCode();
 
@@ -40,7 +40,7 @@ public class TraceExchangeFilterFunctionHttpClientResponseTests {
 	public void should_return_status_code_when_valid_status_code_is_returned() {
 		ClientResponse clientResponse = BDDMockito.mock(ClientResponse.class);
 		BDDMockito.given(clientResponse.rawStatusCode()).willReturn(200);
-		ClientResponseWrapper response = new ClientResponseWrapper(clientResponse);
+		ClientResponseWrapper response = new ClientResponseWrapper(clientResponse, null, null);
 
 		Integer statusCode = response.statusCode();
 

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/integration/sampled/WebClientTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/web/client/integration/sampled/WebClientTests.java
@@ -68,6 +68,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -250,6 +251,25 @@ public abstract class WebClientTests {
 		thenThereIsNoCurrentSpan();
 		then(this.spans.reportedSpans().stream().filter(r -> r.getKind() != null).map(r -> r.getKind().name())
 				.collect(Collectors.toList())).isNotEmpty().contains("CLIENT");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shouldUseUriTemplateInSpanName() {
+		Span span = this.tracer.nextSpan().name("foo").start();
+
+		try (Tracer.SpanInScope ws = this.tracer.withSpan(span)) {
+			this.webClientBuilder.baseUrl("http://localhost:" + this.port).build().get()
+					.uri("/prefix/{variable}/suffix", "value").retrieve().bodyToMono(String.class)
+					.block(Duration.ofSeconds(5));
+		}
+		finally {
+			span.end();
+		}
+
+		thenThereIsNoCurrentSpan();
+		then(this.spans.reportedSpans().stream().filter(r -> r.getKind() == Span.Kind.CLIENT).map(r -> r.getName())
+				.collect(Collectors.toList())).isNotEmpty().contains("GET /prefix/{variable}/suffix");
 	}
 
 	/**
@@ -547,6 +567,11 @@ public abstract class WebClientTests {
 		@RequestMapping(value = { "/skip", "/doNotSkip" }, method = RequestMethod.GET)
 		String skip() {
 			return "ok";
+		}
+
+		@RequestMapping(value = "/prefix/{variable}/suffix", method = RequestMethod.GET)
+		String pathVariable(@PathVariable("variable") String variable) {
+			return "variable = " + variable;
 		}
 
 	}


### PR DESCRIPTION
Spans names are in the form `'<http method> <uri template>'` (e.g. `'GET /path/{id}'`). This naming strategy matches the span names generated by `TraceWebFilter`.

The improved naming strategy has not applied to `RestTemplate` as the uri template is not readily available to interceptors and `RestTemplate` is in maintenance mode. It is not entirely out of the realm of possibility of implementing as there is a solution which is used within Spring Boot for [metric instrumentation](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/web/client/MetricsClientHttpRequestInterceptor.java#L103) of RestTemplate by creating a shared thread local between the uri template handler and the interceptor