### PR TITLE
Fix not able to override datasource-proxy log-level

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -31,6 +31,7 @@
 |spring.sleuth.jdbc.datasource-proxy.query.enable-logging | `false` | Enable logging all queries to the log.
 |spring.sleuth.jdbc.datasource-proxy.query.log-level | `DEBUG` | Severity of query logger.
 |spring.sleuth.jdbc.datasource-proxy.query.logger-name |  | Name of query logger.
+|spring.sleuth.jdbc.datasource-proxy.slow-query.enable-logging | `false` | Enable logging slow queries to the log.
 |spring.sleuth.jdbc.datasource-proxy.slow-query.log-level | `WARN` | Severity of slow query logger.
 |spring.sleuth.jdbc.datasource-proxy.slow-query.logger-name |  | Name of slow query logger.
 |spring.sleuth.jdbc.datasource-proxy.slow-query.threshold | `300` | Number of seconds to consider query as slow.

--- a/docs/src/main/asciidoc/integrations.adoc
+++ b/docs/src/main/asciidoc/integrations.adoc
@@ -720,6 +720,9 @@ Please check the <<appendix.adoc#appendix,appendix>> page under `spring.sleuth.j
 
 You can configure P6Spy manually using one of available configuration methods. For more information please refer to the http://p6spy.readthedocs.io/en/latest/configandusage.html[P6Spy Configuration Guide].
 
+By default logging queries will be disabled, set `spring.sleuth.jdbc.datasource-proxy.slow-query.enable-logging` to `true` to enable logging slow queries
+and set `spring.sleuth.jdbc.datasource-proxy.query.enable-logging` to `true` to enable logging all queries.
+
 In order to disable this instrumentation set `spring.sleuth.jdbc.enabled` to `false`.
 
 [[sleuth-session-integration]]

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
@@ -84,6 +84,8 @@ class DataSourceProxyConfiguration {
 		DataSourceProxyProperties props = new DataSourceProxyProperties();
 		BeanUtils.copyProperties(originalProxy, props);
 		props.setLogging(DataSourceProxyProperties.DataSourceProxyLogging.valueOf(originalProxy.getLogging().name()));
+		BeanUtils.copyProperties(originalProxy.getQuery(), props.getQuery());
+		BeanUtils.copyProperties(originalProxy.getSlowQuery(), props.getSlowQuery());
 		return props;
 	}
 

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
@@ -50,6 +50,7 @@ import org.springframework.context.annotation.Bean;
  * {@link QueryTransformer}.
  *
  * @author Arthur Gavlyukovskiy
+ * @author Chintan Radia
  */
 @ConditionalOnClass(ProxyDataSource.class)
 @ConditionalOnProperty(name = "spring.sleuth.jdbc.datasource-proxy.enabled", havingValue = "true",

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcProperties.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcProperties.java
@@ -190,7 +190,7 @@ public class TraceJdbcProperties {
 			/**
 			 * Enable logging all queries to the log.
 			 */
-			private boolean enableLogging = true;
+			private boolean enableLogging = false;
 
 			/**
 			 * Name of query logger.
@@ -236,7 +236,7 @@ public class TraceJdbcProperties {
 			/**
 			 * Enable logging slow queries to the log.
 			 */
-			private boolean enableLogging = true;
+			private boolean enableLogging = false;
 
 			/**
 			 * Name of slow query logger.
@@ -253,7 +253,7 @@ public class TraceJdbcProperties {
 			 */
 			private long threshold = 300;
 
-			boolean isEnableLogging() {
+			public boolean isEnableLogging() {
 				return enableLogging;
 			}
 

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcProperties.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcProperties.java
@@ -190,7 +190,7 @@ public class TraceJdbcProperties {
 			/**
 			 * Enable logging all queries to the log.
 			 */
-			private boolean enableLogging = false;
+			private boolean enableLogging = true;
 
 			/**
 			 * Name of query logger.
@@ -236,7 +236,7 @@ public class TraceJdbcProperties {
 			/**
 			 * Enable logging slow queries to the log.
 			 */
-			private boolean enableLogging = false;
+			private boolean enableLogging = true;
 
 			/**
 			 * Name of slow query logger.

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/DataSourceProxyProperties.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/DataSourceProxyProperties.java
@@ -113,7 +113,7 @@ public class DataSourceProxyProperties {
 		/**
 		 * Enable logging all queries to the log.
 		 */
-		private boolean enableLogging = true;
+		private boolean enableLogging = false;
 
 		/**
 		 * Name of query logger.
@@ -164,7 +164,7 @@ public class DataSourceProxyProperties {
 		/**
 		 * Enable logging slow queries to the log.
 		 */
-		private boolean enableLogging = true;
+		private boolean enableLogging = false;
 
 		/**
 		 * Name of slow query logger.


### PR DESCRIPTION
Fixes #1973 

@marcingrzejszczak @gavlyukovskiy can you please review this PR

- Aligned default values of `Query` & `SlowQuery` in `TraceJdbcProperties.DataSourceProxyProperties` and `DataSourceProxyProperties`
- Add code to copy properties of `Query` and `SlowQuery` in `DataSourceProxyConfiguration`
- Add test case to check if `log-level` can be overridden or not