### PR TITLE
Regression: SkipPatternProvider doesn't handle all cyclic dependency cases

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/SkipPatternConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/web/SkipPatternConfiguration.java
@@ -23,7 +23,7 @@ import java.util.StringJoiner;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.BeanCurrentlyInCreationException;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
@@ -83,7 +83,7 @@ class SkipPatternConfiguration {
 			}
 			return () -> result;
 		}
-		catch (BeanCurrentlyInCreationException e) {
+		catch (BeanCreationException e) {
 			// Most likely, there is an actuator endpoint that indirectly references an
 			// instrumented HTTP client.
 			return () -> consolidateSkipPatterns(patterns);


### PR DESCRIPTION
Handle `BeanCreationException` instead of just `BeanCurrentlyInCreationException`.

This handles the case when a cyclic reference (causing a `BeanCurrentlyInCreationException`) occurs further down the creation stack ; when it is not the actuator that references the in-creation HttpTracing bean, but a dependency of that actuator. In this case the exception that bubbles up to here is an `UnsatisfiedDependencyException`, which is a `BeanCreationException`.

I originally made this issue, but instead have submitted the PR to reintroduce the change.

**Describe the bug**
In https://github.com/spring-cloud/spring-cloud-sleuth/pull/1722 a change was made to broaden the Exceptions caught in `SkipPatternConfiguration` due to the possibility of circular dependencies. It seems that when 2.2.x was merged into 3.x.x that this change was dropped. ie. The exception type caught was reverted to `BeanCurrentlyInCreationException` rather than `BeanCreationException`.