### PR TITLE
Fix traces actuator should return json by default

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/actuate/TextOutputFormat.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/actuate/TextOutputFormat.java
@@ -29,14 +29,14 @@ import org.springframework.util.MimeType;
 public enum TextOutputFormat implements Producible<TextOutputFormat> {
 
 	/**
-	 * OpenZipkin text.
-	 */
-	CONTENT_TYPE_OPENZIPKIN_JSON_V2(MediaType.APPLICATION_JSON),
-
-	/**
 	 * OTLP protobuf format.
 	 */
-	CONTENT_TYPE_OTLP_PROTOBUF(MediaType.parseMediaType("application/x-protobuf"));
+	CONTENT_TYPE_OTLP_PROTOBUF(MediaType.parseMediaType("application/x-protobuf")),
+
+	/**
+	 * OpenZipkin text.
+	 */
+	CONTENT_TYPE_OPENZIPKIN_JSON_V2(MediaType.APPLICATION_JSON);
 
 	private final MimeType mimeType;
 


### PR DESCRIPTION
Fixes gh-1996

Change order of TextOutputFormat enum and give `CONTENT_TYPE_OPENZIPKIN_JSON_V2`
highest ordinal value, so that it will be matched first by spring-boot-actuator
and in case of default Accept header JSON data will be returned.