### PR TITLE
Add property to disable Reactor support in docs

### DIFF
--- a/docs/src/main/asciidoc/integrations.adoc
+++ b/docs/src/main/asciidoc/integrations.adoc
@@ -429,6 +429,8 @@ Example:
 include::{project-root}/benchmarks/src/main/java/org/springframework/cloud/sleuth/benchmarks/app/webflux/SleuthBenchmarkingSpringWebFluxApp.java[tags=simple_manual,indent=0]
 -----
 
+To disable Reactor support, set the `spring.sleuth.reactor.enabled` property to `false`.
+
 [[sleuth-redis-integration]]
 == Redis
 


### PR DESCRIPTION
It seems to be accidentally missed.