### PR TITLE
Fix typo in document example

### DIFF
--- a/docs/src/main/asciidoc/getting-started.adoc
+++ b/docs/src/main/asciidoc/getting-started.adoc
@@ -208,7 +208,7 @@ By default, Maven compiles sources from `src/main/java`, so you need to create t
 	@EnableAutoConfiguration
 	public class Example {
 
-		private static final Logger log = LoggerFactory.getLogger(Backend.class);
+		private static final Logger log = LoggerFactory.getLogger(Example.class);
 
 		@RequestMapping("/")
 		String home() {


### PR DESCRIPTION
Using `Backend.class` getLogger() argument in `Example.class` maybe a typo.

e.g)
```java
public class Foo {
    private static final Logger log = LoggerFactory.getLogger(Foo.class);
}
```