### PR TITLE
Fix an example value using TagValueExpressionResolver

### DIFF
--- a/docs/src/main/asciidoc/using.adoc
+++ b/docs/src/main/asciidoc/using.adoc
@@ -263,7 +263,7 @@ Consider the following annotated method:
 include::{common_tests_path}/src/main/java/org/springframework/cloud/sleuth/instrument/annotation/SpanTagAnnotationHandlerTests.java[tags=spel,indent=0]
 ----
 
-No custom implementation of a `TagValueExpressionResolver` leads to evaluation of the SPEL expression, and a tag with a value of `4 characters` is set on the span.
+No custom implementation of a `TagValueExpressionResolver` leads to evaluation of the SPEL expression, and a tag with a value of `hello characters` is set on the span.
 If you want to use some other expression resolution mechanism, you can create your own implementation of the bean.
 
 [[using-annotations-to-string]]


### PR DESCRIPTION
Refer to SpanTagAnnotationHandlerTests.java, `@SpanTag(key = "test", expression = "'hello' + ' characters'")` produces `hello characters` value of tag.

https://github.com/spring-cloud/spring-cloud-sleuth/blob/2b17d08ee19b4b8e30d0343e633eaa900e6d2b8c/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/annotation/SpanTagAnnotationHandlerTests.java#L74

So, `hello characters` is right value of tag in `Resolving Expressions for a Value` document section.