### PR TITLE
Caches executor wrappers

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/async/TraceAsyncDefaultAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/async/TraceAsyncDefaultAutoConfiguration.java
@@ -92,7 +92,7 @@ public class TraceAsyncDefaultAutoConfiguration {
 		@Override
 		public Executor getAsyncExecutor() {
 			Executor delegate = getDefaultExecutor();
-			return new LazyTraceExecutor(this.beanFactory, delegate);
+			return LazyTraceExecutor.wrap(this.beanFactory, delegate);
 		}
 
 		/**

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizer.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizer.java
@@ -47,7 +47,7 @@ public class LazyTraceAsyncCustomizer extends AsyncConfigurerSupport {
 		if (this.delegate.getAsyncExecutor() instanceof LazyTraceExecutor) {
 			return this.delegate.getAsyncExecutor();
 		}
-		return new LazyTraceExecutor(this.beanFactory, this.delegate.getAsyncExecutor());
+		return LazyTraceExecutor.wrap(this.beanFactory, this.delegate.getAsyncExecutor());
 	}
 
 	@Override

--- a/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizerTest.java
+++ b/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceAsyncCustomizerTest.java
@@ -17,10 +17,12 @@
 package org.springframework.cloud.sleuth.instrument.async;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -45,6 +47,8 @@ public class LazyTraceAsyncCustomizerTest {
 
 	@Test
 	public void should_wrap_async_executor_in_trace_version() throws Exception {
+		BDDMockito.given(this.asyncConfigurer.getAsyncExecutor()).willReturn(Executors.newSingleThreadExecutor());
+
 		Executor executor = this.lazyTraceAsyncCustomizer.getAsyncExecutor();
 
 		BDDAssertions.then(executor).isExactlyInstanceOf(LazyTraceExecutor.class);

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskSchedulerTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskSchedulerTests.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 
@@ -94,6 +95,8 @@ public abstract class LazyTraceThreadPoolTaskSchedulerTests implements TestTraci
 
 	@Test
 	public void getScheduledExecutor() {
+		BDDMockito.given(this.delegate.getScheduledExecutor()).willReturn(Executors.newScheduledThreadPool(1));
+
 		this.executor.getScheduledExecutor();
 
 		BDDMockito.then(this.delegate).should().getScheduledExecutor();


### PR DESCRIPTION
without this change whenever a traced executor is created (either via a proxy or directly) we create a new instance of that traced wrapper. The problem with that is such that we create a lot of objects (e.g. each getExecutor() would return a new instance of the traced version). There are projects such as Micrometer that create WeakReferences to those objects. That means that if we don't cache the traced instance then we will lose the WeakReference upon the first GC.

with this change we're introducing new static wrapper methods that cache the traced instance for a given delegate. That means that not only will we create fewer objects but also we will honour the WeakReference mechanisms.

fixes gh-2020