### PR TITLE
Use Sleuth API for Redis instrumentation

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/brave/instrument/redis/BraveRedisAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/brave/instrument/redis/BraveRedisAutoConfiguration.java
@@ -32,8 +32,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration;
-import org.springframework.cloud.sleuth.brave.instrument.redis.ClientResourcesBuilderCustomizer;
-import org.springframework.cloud.sleuth.brave.instrument.redis.TraceLettuceClientResourcesBuilderCustomizer;
+import org.springframework.cloud.sleuth.instrument.redis.ClientResourcesBuilderCustomizer;
+import org.springframework.cloud.sleuth.instrument.redis.TraceLettuceClientResourcesBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -66,7 +66,9 @@ public class BraveRedisAutoConfiguration {
 	TraceLettuceClientResourcesBuilderCustomizer traceLettuceClientResourcesBuilderCustomizer(Tracing tracing,
 			TraceRedisProperties traceRedisProperties, Sampler sampler) {
 		eagerlyInitializePotentiallyRefreshScopeSampler(sampler);
-		return new TraceLettuceClientResourcesBuilderCustomizer(tracing, traceRedisProperties.getRemoteServiceName());
+		BraveTracing braveTracing = BraveTracing.builder().tracing(tracing).excludeCommandArgsFromSpanTags()
+				.serviceName(traceRedisProperties.getRemoteServiceName()).build();
+		return new TraceLettuceClientResourcesBuilderCustomizer(braveTracing);
 	}
 
 	/**

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/redis/TraceLettuceClientResourcesBeanPostProcessor.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/redis/TraceLettuceClientResourcesBeanPostProcessor.java
@@ -33,7 +33,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.cloud.sleuth.autoconfig.brave.instrument.redis.TraceRedisProperties;
-import org.springframework.cloud.sleuth.brave.instrument.redis.TraceLettuceClientResourcesBuilderCustomizer;
+import org.springframework.cloud.sleuth.instrument.redis.TraceLettuceClientResourcesBuilderCustomizer;
 import org.springframework.cloud.sleuth.internal.ContextUtil;
 
 /**

--- a/spring-cloud-sleuth-brave/pom.xml
+++ b/spring-cloud-sleuth-brave/pom.xml
@@ -296,12 +296,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<!-- Instrumentation of Lettuce -->
-		<dependency>
-			<groupId>io.lettuce</groupId>
-			<artifactId>lettuce-core</artifactId>
-			<optional>true</optional>
-		</dependency>
 		<!-- For Instrumentation of Quartz -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-instrumentation/pom.xml
+++ b/spring-cloud-sleuth-instrumentation/pom.xml
@@ -186,6 +186,12 @@
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjrt</artifactId>
 		</dependency>
+		<!-- Instrumentation of Lettuce -->
+		<dependency>
+			<groupId>io.lettuce</groupId>
+			<artifactId>lettuce-core</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- For Instrumentation of Quartz -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/redis/ClientResourcesBuilderCustomizer.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/redis/ClientResourcesBuilderCustomizer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.sleuth.brave.instrument.redis;
+package org.springframework.cloud.sleuth.instrument.redis;
 
 import io.lettuce.core.resource.ClientResources;
 

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceLettuceClientResourcesBuilderCustomizer.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/redis/TraceLettuceClientResourcesBuilderCustomizer.java
@@ -14,27 +14,25 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.sleuth.brave.instrument.redis;
+package org.springframework.cloud.sleuth.instrument.redis;
 
-import brave.Tracing;
 import io.lettuce.core.resource.ClientResources;
-import io.lettuce.core.tracing.BraveTracing;
-
-import org.springframework.beans.factory.config.BeanPostProcessor;
+import io.lettuce.core.tracing.Tracing;
 
 /**
- * {@link BeanPostProcessor} for wrapping Lettuce components in a tracing representation.
+ * {@link ClientResourcesBuilderCustomizer} for wrapping Lettuce components in a tracing
+ * representation.
  *
  * @author Marcin Grzejszczak
+ * @author Thomas Vitale
  * @since 3.0.4
  */
 public class TraceLettuceClientResourcesBuilderCustomizer implements ClientResourcesBuilderCustomizer {
 
-	private final BraveTracing tracing;
+	private final Tracing tracing;
 
-	public TraceLettuceClientResourcesBuilderCustomizer(Tracing tracing, String serviceName) {
-		this.tracing = BraveTracing.builder().tracing(tracing).excludeCommandArgsFromSpanTags().serviceName(serviceName)
-				.build();
+	public TraceLettuceClientResourcesBuilderCustomizer(Tracing tracing) {
+		this.tracing = tracing;
 	}
 
 	@Override


### PR DESCRIPTION
Extracted Brave-specific Redis instrumentation to use the Sleuth API, and registered the implementation in Brave autoconfiguration.

Fixes gh-2045