### PR TITLE
Refactored TraceListenerStrategy to better track current scope in case multiple connections are used

### DIFF
--- a/spring-cloud-sleuth-api/src/main/java/org/springframework/cloud/sleuth/SpanAndScope.java
+++ b/spring-cloud-sleuth-api/src/main/java/org/springframework/cloud/sleuth/SpanAndScope.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
  * Container object for {@link Span} and its corresponding {@link Tracer.SpanInScope}.
  *
  * @author Marcin Grzejszczak
+ * @author Arthur Gavlyukovskiy
  * @since 3.1.0
  */
 public class SpanAndScope implements Closeable {
@@ -58,7 +59,9 @@ public class SpanAndScope implements Closeable {
 		if (log.isTraceEnabled()) {
 			log.trace("Closing span [" + this.span + "]");
 		}
-		this.scope.close();
+		if (this.scope != null) {
+			this.scope.close();
+		}
 		this.span.end();
 	}
 

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
@@ -44,6 +44,8 @@ import org.springframework.cloud.sleuth.instrument.jdbc.TraceListenerStrategySpa
 import org.springframework.cloud.sleuth.instrument.jdbc.TraceQueryExecutionListener;
 import org.springframework.context.annotation.Bean;
 
+import javax.sql.CommonDataSource;
+
 /**
  * Configuration for integration with datasource-proxy, allows to use define custom
  * {@link QueryExecutionListener}, {@link ParameterTransformer} and
@@ -100,7 +102,7 @@ class DataSourceProxyConfiguration {
 	@Bean
 	TraceQueryExecutionListener traceQueryExecutionListener(Tracer tracer,
 			TraceJdbcProperties dataSourceDecoratorProperties,
-			ObjectProvider<List<TraceListenerStrategySpanCustomizer>> customizers) {
+			ObjectProvider<List<TraceListenerStrategySpanCustomizer<? super CommonDataSource>>> customizers) {
 		return new TraceQueryExecutionListener(tracer, dataSourceDecoratorProperties.getIncludes(),
 				customizers.getIfAvailable(ArrayList::new));
 	}

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/DataSourceProxyConfiguration.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.sleuth.autoconfig.instrument.jdbc;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.sql.CommonDataSource;
+
 import net.ttddyy.dsproxy.listener.MethodExecutionListener;
 import net.ttddyy.dsproxy.listener.QueryCountStrategy;
 import net.ttddyy.dsproxy.listener.QueryExecutionListener;
@@ -43,8 +45,6 @@ import org.springframework.cloud.sleuth.instrument.jdbc.DataSourceProxyPropertie
 import org.springframework.cloud.sleuth.instrument.jdbc.TraceListenerStrategySpanCustomizer;
 import org.springframework.cloud.sleuth.instrument.jdbc.TraceQueryExecutionListener;
 import org.springframework.context.annotation.Bean;
-
-import javax.sql.CommonDataSource;
 
 /**
  * Configuration for integration with datasource-proxy, allows to use define custom

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/P6SpyConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/P6SpyConfiguration.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.sleuth.autoconfig.instrument.jdbc;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.sql.CommonDataSource;
+
 import com.p6spy.engine.event.JdbcEventListener;
 import com.p6spy.engine.spy.DefaultJdbcEventListenerFactory;
 import com.p6spy.engine.spy.JdbcEventListenerFactory;
@@ -36,8 +38,6 @@ import org.springframework.cloud.sleuth.instrument.jdbc.TraceJdbcEventListener;
 import org.springframework.cloud.sleuth.instrument.jdbc.TraceListenerStrategySpanCustomizer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-
-import javax.sql.CommonDataSource;
 
 /**
  * Configuration for integration with p6spy, allows to define custom

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/P6SpyConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/P6SpyConfiguration.java
@@ -37,6 +37,8 @@ import org.springframework.cloud.sleuth.instrument.jdbc.TraceListenerStrategySpa
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
+import javax.sql.CommonDataSource;
+
 /**
  * Configuration for integration with p6spy, allows to define custom
  * {@link JdbcEventListener}.
@@ -56,7 +58,7 @@ class P6SpyConfiguration {
 	@ConditionalOnMissingBean
 	JdbcEventListenerFactory traceJdbcEventListenerFactory(ObjectProvider<List<JdbcEventListener>> listeners) {
 		JdbcEventListenerFactory jdbcEventListenerFactory = new DefaultJdbcEventListenerFactory();
-		List<JdbcEventListener> listenerList = listeners.getIfAvailable(() -> null);
+		List<JdbcEventListener> listenerList = listeners.getIfAvailable();
 		return listenerList != null ? new P6SpyContextJdbcEventListenerFactory(jdbcEventListenerFactory, listenerList)
 				: jdbcEventListenerFactory;
 	}
@@ -69,7 +71,7 @@ class P6SpyConfiguration {
 	@Bean
 	TraceJdbcEventListener tracingJdbcEventListener(Tracer tracer, DataSourceNameResolver dataSourceNameResolver,
 			TraceJdbcProperties traceJdbcProperties,
-			ObjectProvider<List<TraceListenerStrategySpanCustomizer>> customizers) {
+			ObjectProvider<List<TraceListenerStrategySpanCustomizer<? super CommonDataSource>>> customizers) {
 		return new TraceJdbcEventListener(tracer, dataSourceNameResolver, traceJdbcProperties.getIncludes(),
 				traceJdbcProperties.getP6spy().getTracing().isIncludeParameterValues(),
 				customizers.getIfAvailable(ArrayList::new));

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.sleuth.autoconfig.instrument.jdbc;
 
 import javax.sql.DataSource;
 
-import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -32,7 +31,6 @@ import org.springframework.cloud.sleuth.autoconfig.brave.BraveAutoConfiguration;
 import org.springframework.cloud.sleuth.instrument.jdbc.DataSourceDecorator;
 import org.springframework.cloud.sleuth.instrument.jdbc.DataSourceNameResolver;
 import org.springframework.cloud.sleuth.instrument.jdbc.TraceHikariListenerStrategySpanCustomizer;
-import org.springframework.cloud.sleuth.instrument.jdbc.TraceListenerStrategySpanCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/jdbc/TraceJdbcAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.sleuth.autoconfig.instrument.jdbc;
 
 import javax.sql.DataSource;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -65,7 +66,7 @@ public class TraceJdbcAutoConfiguration {
 
 	@Bean
 	@ConditionalOnClass(name = "com.zaxxer.hikari.HikariDataSource")
-	TraceListenerStrategySpanCustomizer hikariTraceListenerStrategySpanCustomizer() {
+	TraceHikariListenerStrategySpanCustomizer traceHikariListenerStrategySpanCustomizer() {
 		return new TraceHikariListenerStrategySpanCustomizer();
 	}
 

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/task/TraceTaskExecutionListener.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/task/TraceTaskExecutionListener.java
@@ -62,23 +62,19 @@ public class TraceTaskExecutionListener implements TaskExecutionListener, Ordere
 	@Override
 	public void onTaskEnd(TaskExecution taskExecution) {
 		SpanAndScope spanAndScope = this.threadLocalSpan.get();
-		Span span = spanAndScope.getSpan();
-		span.end();
-		spanAndScope.getScope().close();
+		spanAndScope.close();
 		if (log.isDebugEnabled()) {
-			log.debug("Removed the [" + span + "] from thread local");
+			log.debug("Removed the [" + spanAndScope.getSpan() + "] from thread local");
 		}
 	}
 
 	@Override
 	public void onTaskFailed(TaskExecution taskExecution, Throwable throwable) {
 		SpanAndScope spanAndScope = this.threadLocalSpan.get();
-		Span span = spanAndScope.getSpan();
-		span.error(throwable);
-		span.end();
-		spanAndScope.getScope().close();
+		spanAndScope.getSpan().error(throwable);
+		spanAndScope.close();
 		if (log.isDebugEnabled()) {
-			log.debug("Removed the [" + span + "] from thread local and added error");
+			log.debug("Removed the [" + spanAndScope.getSpan() + "] from thread local and added error");
 		}
 	}
 

--- a/tests/brave/spring-cloud-sleuth-instrumentation-jdbc-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/jdbc/TraceJdbcEventListenerTests.java
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-jdbc-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/jdbc/TraceJdbcEventListenerTests.java
@@ -24,16 +24,16 @@ import org.springframework.cloud.sleuth.test.TestSpanHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-public class TracingJdbcEventListenerTests
-		extends org.springframework.cloud.sleuth.instrument.jdbc.TracingJdbcEventListenerTests {
+public class TraceJdbcEventListenerTests
+		extends org.springframework.cloud.sleuth.instrument.jdbc.TraceJdbcEventListenerTests {
 
 	@Override
-	protected Class autoConfiguration() {
+	protected Class<?> autoConfiguration() {
 		return BraveAutoConfiguration.class;
 	}
 
 	@Override
-	protected Class testConfiguration() {
+	protected Class<?> testConfiguration() {
 		return Config.class;
 	}
 

--- a/tests/brave/spring-cloud-sleuth-instrumentation-jdbc-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/jdbc/TraceQueryExecutionListenerTests.java
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-jdbc-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/jdbc/TraceQueryExecutionListenerTests.java
@@ -24,16 +24,16 @@ import org.springframework.cloud.sleuth.test.TestSpanHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-public class TracingQueryExecutionListenerTests
-		extends org.springframework.cloud.sleuth.instrument.jdbc.TracingQueryExecutionListenerTests {
+public class TraceQueryExecutionListenerTests
+		extends org.springframework.cloud.sleuth.instrument.jdbc.TraceQueryExecutionListenerTests {
 
 	@Override
-	protected Class autoConfiguration() {
+	protected Class<?> autoConfiguration() {
 		return BraveAutoConfiguration.class;
 	}
 
 	@Override
-	protected Class testConfiguration() {
+	protected Class<?> testConfiguration() {
 		return Config.class;
 	}
 

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/TraceJdbcEventListenerTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/TraceJdbcEventListenerTests.java
@@ -34,7 +34,7 @@ import org.springframework.cloud.sleuth.test.TestSpanHandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public abstract class TracingJdbcEventListenerTests extends TracingListenerStrategyTests {
+public abstract class TraceJdbcEventListenerTests extends TraceListenerStrategyTests {
 
 	protected final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(DataSourceAutoConfiguration.class,

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/TraceListenerStrategyTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/TraceListenerStrategyTests.java
@@ -41,7 +41,7 @@ import org.springframework.context.annotation.Bean;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-abstract class TracingListenerStrategyTests {
+abstract class TraceListenerStrategyTests {
 
 	public static final String SPAN_SQL_QUERY_TAG_NAME = "jdbc.query";
 
@@ -49,9 +49,9 @@ abstract class TracingListenerStrategyTests {
 
 	abstract ApplicationContextRunner parentContextRunner();
 
-	protected abstract Class autoConfiguration();
+	protected abstract Class<?> autoConfiguration();
 
-	protected abstract Class testConfiguration();
+	protected abstract Class<?> testConfiguration();
 
 	@Test
 	void testShouldAddSpanForConnection() {
@@ -387,8 +387,8 @@ abstract class TracingListenerStrategyTests {
 
 			Connection connection1 = dataSource.getConnection();
 			Connection connection2 = dataSource.getConnection();
-			connection2.close();
 			connection1.close();
+			connection2.close();
 
 			assertThat(spanReporter.reportedSpans()).hasSize(2);
 			FinishedSpan connection1Span = spanReporter.reportedSpans().get(0);

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/TraceQueryExecutionListenerTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/TraceQueryExecutionListenerTests.java
@@ -23,7 +23,7 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.sleuth.autoconfig.instrument.jdbc.TraceJdbcAutoConfiguration;
 
-public abstract class TracingQueryExecutionListenerTests extends TracingListenerStrategyTests {
+public abstract class TraceQueryExecutionListenerTests extends TraceListenerStrategyTests {
 
 	@Override
 	ApplicationContextRunner parentContextRunner() {


### PR DESCRIPTION
Refactored `remoteServiceName` resolution logic to be easier to follow
Fixed `TraceQueryExecutionListener#getConnection` that leaks connection by acquiring (and not closing) additional connection from a `DataSource`

The main idea is to track current connection and only put it and statements/resultSets it creates into the scope. For most applications there will be only one connection and all resources are closed properly, but if it's not the case we'll not mess up the scope. 
The only change that I'm not sure about is that I changed `SpanAndScope` to have optional `Scope`, if that's not okay we can always track spans/scopes inside `ConnectionInfo`/`StatementInfo`/`ResultSetInfo`.

I have also removed getters from inner classes, as it seems more in line with other inner classes in Sleuth.