### PR TITLE
Shutdown unused ClientResources

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/redis/TraceLettuceClientResourcesBeanPostProcessor.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/instrument/redis/TraceLettuceClientResourcesBeanPostProcessor.java
@@ -66,7 +66,9 @@ public class TraceLettuceClientResourcesBeanPostProcessor implements BeanPostPro
 				if (log.isDebugEnabled()) {
 					log.debug("Lettuce ClientResources bean is auto-configured to enable tracing.");
 				}
-				return cr.mutate().tracing(new LazyTracing(this.beanFactory)).build();
+				ClientResources crWithTracing = cr.mutate().tracing(new LazyTracing(this.beanFactory)).build();
+				cr.shutdown();
+				return crWithTracing;
 			}
 			else if (log.isDebugEnabled()) {
 				log.debug(


### PR DESCRIPTION
Implementations of ClientResources are stateful and must be shutdown after they are no longer in use. 

This PR will fix https://github.com/spring-cloud/spring-cloud-sleuth/issues/2059