### PR TITLE
Option to build without docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,19 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>withoutDockerTests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<excludedGroups>DockerRequired</excludedGroups>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 </project>

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaConsumerTest.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaConsumerTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -63,6 +64,7 @@ import static org.awaitility.Awaitility.await;
 
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
+@Tag("DockerRequired")
 public abstract class KafkaConsumerTest implements TestTracingAwareSupplier {
 
 	protected String testTopic;

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaProducerTest.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaProducerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -65,6 +66,7 @@ import static org.awaitility.Awaitility.await;
 
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
+@Tag("DockerRequired")
 public abstract class KafkaProducerTest implements TestTracingAwareSupplier {
 
 	protected String testTopic;

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaReceiverTest.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaReceiverTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -63,6 +64,7 @@ import static org.awaitility.Awaitility.await;
 
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
+@Tag("DockerRequired")
 public abstract class KafkaReceiverTest implements TestTracingAwareSupplier {
 
 	protected String testTopic;

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaSenderTest.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/kafka/KafkaSenderTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -69,6 +70,7 @@ import org.springframework.core.ResolvableType;
 
 @Testcontainers
 @ExtendWith(MockitoExtension.class)
+@Tag("DockerRequired")
 public abstract class KafkaSenderTest implements TestTracingAwareSupplier {
 
 	protected String testTopic;

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/mongodb/ReactiveMongoDbIntegrationTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/mongodb/ReactiveMongoDbIntegrationTests.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -47,6 +48,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 @ContextConfiguration(classes = ReactiveMongoDbIntegrationTests.TestConfig.class)
 @Testcontainers
+@Tag("DockerRequired")
 public abstract class ReactiveMongoDbIntegrationTests {
 
 	private static final Log log = LogFactory.getLog(ReactiveMongoDbIntegrationTests.class);


### PR DESCRIPTION
The build can now be executed with `-PwithoutDockerTests` and tests requiring a Docker environment will not fail the build.