### PR TITLE
#2083 improvements

### DIFF
--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProvider.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.jdbc;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Arrays.asList;
+import static java.util.regex.Pattern.compile;
+
+class SpanNameProvider {
+
+	private static final String DEFAULT_SPAN_NAME = "query";
+	private static final Pattern PATTERN_MATCHING_FIRST_WORD_OF_SQL = compile("^([a-zA-Z]+)[^a-zA-Z]?.*$");
+	private static final List<String> KNOWN_SPAN_NAMES = asList("select", "update", "insert", "delete");
+
+	String getSpanNameFor(String sql) {
+		String spanName = DEFAULT_SPAN_NAME;
+		if (!Objects.isNull(sql)) {
+			spanName = getSpanNameForNonNull(sql);
+		}
+
+		return spanName;
+	}
+
+	private String getSpanNameForNonNull(String sql) {
+		String spanName = DEFAULT_SPAN_NAME;
+		Matcher matcher = PATTERN_MATCHING_FIRST_WORD_OF_SQL.matcher(sql);
+
+		if (matcher.matches()) {
+			String firstWordOfSql = matcher.group(1).toLowerCase(Locale.ROOT);
+			if (KNOWN_SPAN_NAMES.contains(firstWordOfSql)) {
+				spanName = firstWordOfSql;
+			}
+		}
+
+		return spanName;
+	}
+}

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProvider.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProvider.java
@@ -16,20 +16,17 @@
 
 package org.springframework.cloud.sleuth.instrument.jdbc;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static java.util.Arrays.asList;
 import static java.util.regex.Pattern.compile;
 
 class SpanNameProvider {
 
 	private static final String DEFAULT_SPAN_NAME = "query";
 	private static final Pattern PATTERN_MATCHING_FIRST_WORD_OF_SQL = compile("^([a-zA-Z]+)[^a-zA-Z]?.*$");
-	private static final List<String> KNOWN_SPAN_NAMES = asList("select", "update", "insert", "delete");
 
 	String getSpanNameFor(String sql) {
 		String spanName = DEFAULT_SPAN_NAME;
@@ -45,10 +42,7 @@ class SpanNameProvider {
 		Matcher matcher = PATTERN_MATCHING_FIRST_WORD_OF_SQL.matcher(sql);
 
 		if (matcher.matches()) {
-			String firstWordOfSql = matcher.group(1).toLowerCase(Locale.ROOT);
-			if (KNOWN_SPAN_NAMES.contains(firstWordOfSql)) {
-				spanName = firstWordOfSql;
-			}
+			spanName = matcher.group(1).toLowerCase(Locale.ROOT);
 		}
 
 		return spanName;

--- a/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProviderTest.java
+++ b/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProviderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.jdbc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpanNameProviderTest {
+
+	private static final String DEFAULT_SPAN_NAME = "query";
+	private static final String SPAN_NAME_FOR_SELECTS = "select";
+	private static final String SPAN_NAME_FOR_UPDATES = "update";
+	private static final String SPAN_NAME_FOR_INSERTS = "insert";
+	private static final String SPAN_NAME_FOR_DELETES = "delete";
+
+	@Test
+	public void should_return_default_on_null_input() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = null;
+
+		@SuppressWarnings("ConstantConditions")
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(DEFAULT_SPAN_NAME);
+	}
+
+	@Test
+	public void should_return_default_on_empty_input() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = "";
+
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(DEFAULT_SPAN_NAME);
+	}
+
+	@Test
+	public void should_return_word_select_on_input_starting_with_word_select() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = "SELECT * FROM test_table;";
+
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(SPAN_NAME_FOR_SELECTS);
+	}
+
+	@Test
+	public void should_return_word_update_on_input_starting_with_word_update() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = "UPDATE test_table SET foo = 'bar';";
+
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(SPAN_NAME_FOR_UPDATES);
+	}
+
+	@Test
+	public void should_return_word_insert_on_input_starting_with_word_insert() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = "INSERT INTO test_table (foo) VALUES ('bar');";
+
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(SPAN_NAME_FOR_INSERTS);
+	}
+
+	@Test
+	public void should_return_word_delete_on_input_starting_with_word_delete() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = "DELETE FROM test_table;";
+
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(SPAN_NAME_FOR_DELETES);
+	}
+
+	@Test
+	public void should_be_case_insensitive() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String lowerCaseSql = "select * from test_table;";
+		String mixedCaseSql = "SelECT * FRom TeSt_TaBLE;";
+		String upperCaseSql = "SELECT * FROM TEST_TABLE;";
+
+		String resultForLowerCaseInput = provider.getSpanNameFor(lowerCaseSql);
+		String resultForMixedCaseInput = provider.getSpanNameFor(mixedCaseSql);
+		String resultForUpperCaseInput = provider.getSpanNameFor(upperCaseSql);
+
+		assertThat(resultForLowerCaseInput).isEqualTo(SPAN_NAME_FOR_SELECTS);
+		assertThat(resultForMixedCaseInput).isEqualTo(SPAN_NAME_FOR_SELECTS);
+		assertThat(resultForUpperCaseInput).isEqualTo(SPAN_NAME_FOR_SELECTS);
+	}
+
+	@Test
+	public void should_handle_sql_without_redundant_spaces() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = "select*from test_table;";
+
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(SPAN_NAME_FOR_SELECTS);
+	}
+
+	@Test
+	public void should_return_default_for_input_starting_with_not_handled_word() {
+		SpanNameProvider provider = new SpanNameProvider();
+		String sql = "WITH a AS SELECT * FROM test_table SELECT * FROM a;";
+
+		String result = provider.getSpanNameFor(sql);
+
+		assertThat(result).isEqualTo(DEFAULT_SPAN_NAME);
+	}
+}

--- a/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProviderTest.java
+++ b/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/instrument/jdbc/SpanNameProviderTest.java
@@ -15,7 +15,6 @@
  */
 
 package org.springframework.cloud.sleuth.instrument.jdbc;
-
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,12 +115,13 @@ public class SpanNameProviderTest {
 	}
 
 	@Test
-	public void should_return_default_for_input_starting_with_not_handled_word() {
+	public void should_return_lower_case_input_for_input_containing_only_one_word() {
 		SpanNameProvider provider = new SpanNameProvider();
-		String sql = "WITH a AS SELECT * FROM test_table SELECT * FROM a;";
+		String sql = "BEGIN";
+		String expectedResult = "begin";
 
 		String result = provider.getSpanNameFor(sql);
 
-		assertThat(result).isEqualTo(DEFAULT_SPAN_NAME);
+		assertThat(result).isEqualTo(expectedResult);
 	}
 }


### PR DESCRIPTION
My previous PR #2086 has been merged before I could respond to the comments. I've created another PR with some improvements suggested in the previous PR.

@gavlyukovskiy I've used regex instead of doing substring. I've figured substring(6) would be a result of lucky coincidence that all known query types (select, update, insert, delete) have 6 chars. If someone in the future wanted to add another type - for example BEGIN or ALTER - then they would have a refactoring problem in their hands. Now all that would need to be done is to add the new type to the list of 'known' types.

I've also extracted the span 'generation' into separate class that can be now tested, so that it's also somewhat documented now.

Please let me know if that works better.