### PR TITLE
Support configuring queuedMaxSpans in AsyncReporter

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/zipkin2/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/zipkin2/ZipkinAutoConfiguration.java
@@ -130,8 +130,8 @@ public class ZipkinAutoConfiguration {
 		CheckResult checkResult = checkResult(sender, 1_000L);
 		logCheckResult(sender, checkResult);
 
-		// historical constraint. Note: AsyncReporter supports memory bounds
-		AsyncReporter<Span> asyncReporter = AsyncReporter.builder(sender).queuedMaxSpans(1000)
+		// Note: AsyncReporter supports memory bounds
+		AsyncReporter<Span> asyncReporter = AsyncReporter.builder(sender).queuedMaxSpans(zipkin.getQueuedMaxSpans())
 				.messageTimeout(zipkin.getMessageTimeout(), TimeUnit.SECONDS).metrics(reporterMetrics)
 				.build(zipkin.getEncoder());
 

--- a/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
+++ b/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/ZipkinProperties.java
@@ -75,6 +75,11 @@ public class ZipkinProperties {
 
 	private Locator locator = new Locator();
 
+	/**
+	 * Maximum backlog of spans reported vs sent.
+	 */
+	private int queuedMaxSpans = 1000;
+
 	public Locator getLocator() {
 		return this.locator;
 	}
@@ -145,6 +150,14 @@ public class ZipkinProperties {
 
 	public void setEncoder(SpanBytesEncoder encoder) {
 		this.encoder = encoder;
+	}
+
+	public int getQueuedMaxSpans() {
+		return queuedMaxSpans;
+	}
+
+	public void setQueuedMaxSpans(int queuedMaxSpans) {
+		this.queuedMaxSpans = queuedMaxSpans;
 	}
 
 	/** When enabled, spans are gzipped before sent to the zipkin server. */


### PR DESCRIPTION
This PR provides the ability to configure the `queuedMaxSpans` property of the AsyncReporter with a config: `spring.zipkin.queuedMaxSpans`, the default is unchanged.

We would like to be able to tweak this property to support applications with a high-volume of spans, which are dropped once the queue is full. 

I understand that this bean could be overridden to achieve the same result, but this seems like a more ideal way to configure this property.

There is also `queuedMaxBytes` which provides a memory-based bound on the queue ([defaults to 1%](https://www.javadoc.io/doc/io.zipkin.reporter2/zipkin-reporter/2.6.0/zipkin2/reporter/AsyncReporter.Builder.html#queuedMaxBytes-int-)), I can also override that property in this PR (although that is not necessary for my current use-case)