### PR TITLE
Test support for Arm64

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,3 +33,25 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: ./mvnw clean install -B -U -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+
+  test_arm64: 
+     runs-on: ubuntu-latest
+     strategy:
+      matrix:
+        java: ["8"]
+      fail-fast: false
+     steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+      - name: Install and Run tests
+        run: |
+               docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+               arm64v8/ubuntu:20.04 \
+               bash -exc 'apt-get update -y && \
+                apt-get install openjdk-8-jdk -y && \
+                export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64 && \
+                export PATH=$PATH:$JAVA_HOME/bin && \
+                echo $PATH && \
+                ./mvnw clean install -B -U -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false'

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,9 @@
 					<version>2.8.2</version>
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.19.1</version>
 					<configuration>
 						<systemPropertyVariables>
 							<spring.cloud.sleuth.assertions.enabled>true</spring.cloud.sleuth.assertions.enabled>
@@ -487,7 +489,9 @@
 						</executions>
 					</plugin>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
+				                <version>2.19.1</version>
 						<configuration>
 							<!-- Sets the VM argument line used when unit tests are run. -->
 							<argLine>${surefireArgLine}</argLine>
@@ -501,7 +505,9 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.19.1</version>
 						<configuration>
 							<excludedGroups>DockerRequired</excludedGroups>
 						</configuration>


### PR DESCRIPTION
Added arm64 test support in **.github/workflows/maven.yml** and modified **pom.xml file** for running the test for arm64 platform.

Signed-off-by: [odidev@puresoftware.com](mailto:odidev@puresoftware.com)