### PR TITLE
Fixes #2156 (Bug with multiple W3C baggage headers)

### DIFF
--- a/spring-cloud-sleuth-brave/src/test/java/org/springframework/cloud/sleuth/brave/bridge/W3CBaggagePropagatorTest.java
+++ b/spring-cloud-sleuth-brave/src/test/java/org/springframework/cloud/sleuth/brave/bridge/W3CBaggagePropagatorTest.java
@@ -29,6 +29,9 @@ import brave.propagation.TraceContextOrSamplingFlags;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.cloud.sleuth.instrument.web.servlet.HttpServletRequestWrapper;
+import org.springframework.mock.web.MockHttpServletRequest;
+
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -104,6 +107,28 @@ class W3CBaggagePropagatorTest {
 
 		Map<String, String> baggageEntries = BaggageField.getAllValues(contextWithBaggage);
 		assertThat(baggageEntries).hasSize(1).containsEntry("key", "value2");
+	}
+
+	/**
+	 * We need to use {@link HttpServletRequestWrapper} for the carrier for this test, since it is what combines the
+	 * multiple baggage headers into one.
+	 */
+	@Test
+	void extract_multipleBaggageHeaders() {
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.addHeader("baggage", "key1=value1;othermetadata");
+		mockRequest.addHeader("baggage", "key2=value2,key3=value3");
+		HttpServletRequestWrapper carrier = (HttpServletRequestWrapper) HttpServletRequestWrapper.create(mockRequest);
+
+		TraceContextOrSamplingFlags contextWithBaggage = propagator
+				.contextWithBaggage(carrier, context(), HttpServletRequestWrapper::header);
+
+		Map<String, String> baggageEntries = BaggageField.getAllValues(contextWithBaggage);
+		assertThat(baggageEntries)
+				.hasSize(3)
+				.containsEntry("key1", "value1")
+				.containsEntry("key2", "value2")
+				.containsEntry("key3", "value3");
 	}
 
 	@Test

--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/web/servlet/HttpServletRequestWrapper.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/web/servlet/HttpServletRequestWrapper.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.sleuth.instrument.web.servlet;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedList;
+import java.util.List;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
@@ -32,6 +35,8 @@ import org.springframework.lang.Nullable;
  * @since 5.10
  */
 public class HttpServletRequestWrapper implements HttpServerRequest {
+
+	private static final List<String> COMBINABLE_HEADERS = Collections.singletonList("baggage");
 
 	/**
 	 * Wraps the request in a tracing representation.
@@ -89,6 +94,14 @@ public class HttpServletRequestWrapper implements HttpServerRequest {
 
 	@Override
 	public String header(String name) {
+		if (COMBINABLE_HEADERS.contains(name)) {
+			LinkedList<String> headersList = new LinkedList<>();
+			Enumeration<String> headers = delegate.getHeaders(name);
+			while (headers.hasMoreElements()) {
+				headersList.add(headers.nextElement());
+			}
+			return headersList.size() != 0 ? String.join(",", headersList) : null;
+		}
 		return delegate.getHeader(name);
 	}
 


### PR DESCRIPTION
This fixes #2156. When retrieving the baggage header, noted as a "combinable" header as per the [HTTP 1.1 specification](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2) and the [W3C baggage header specification](https://www.w3.org/TR/baggage/#baggage-http-header-format), multiple headers of the same key are allowed in certain circumstances.

When retrieving headers, sleuth sleuth currently calls `HttpServletRequest.getHeader(String name)` which returns the first header with that name. As a result, data in the non-first baggage header is lost. To solve this, I've changed it so (in the baggage case) `HttpServletRequestWrapper` calls `getHeaders(String name)` and joins the Enumeration via a "," into a single header, as per the HTTP spec: 

> A recipient MAY combine multiple header fields with the same field name into one "field-name: field-value" pair, without changing the semantics of the message, by appending each subsequent field value to the combined field value in order, separated by a comma.