### PR TITLE
Escape special characters in config Asciidoc

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -22,7 +22,7 @@
 |spring.sleuth.grpc.enabled | `true` | Enable span information propagation when using GRPC.
 |spring.sleuth.http.enabled | `true` | Enables HTTP support.
 |spring.sleuth.integration.enabled | `true` | Enable Spring Integration instrumentation.
-|spring.sleuth.integration.patterns | `[!hystrixStreamOutput*, *, !channel*]` | An array of patterns against which channel names will be matched. @see org.springframework.integration.config.GlobalChannelInterceptor#patterns() Defaults to any channel name not matching the Hystrix Stream and functional Stream channel names.
+|spring.sleuth.integration.patterns | `+++[!hystrixStreamOutput*, *, !channel*]+++` | An array of patterns against which channel names will be matched. @see org.springframework.integration.config.GlobalChannelInterceptor#patterns() Defaults to any channel name not matching the Hystrix Stream and functional Stream channel names.
 |spring.sleuth.integration.websockets.enabled | `true` | Enable tracing for WebSockets.
 |spring.sleuth.jdbc.datasource-proxy.enabled | `true` | Should the datasource-proxy tracing be enabled?
 |spring.sleuth.jdbc.datasource-proxy.json-format | `false` | Use json output for logging query. @see ProxyDataSourceBuilder#asJson()
@@ -73,7 +73,7 @@
 |spring.sleuth.rpc.enabled | `true` | Enable tracing of RPC.
 |spring.sleuth.rsocket.enabled | `true` | When true enables instrumentation for rsocket.
 |spring.sleuth.rxjava.schedulers.hook.enabled | `true` | Enable support for RxJava via RxJavaSchedulersHook.
-|spring.sleuth.rxjava.schedulers.ignoredthreads | `[HystrixMetricPoller, ^RxComputation.*$]` | Thread names for which spans will not be sampled.
+|spring.sleuth.rxjava.schedulers.ignoredthreads | `+++[HystrixMetricPoller, ^RxComputation.*$]+++` | Thread names for which spans will not be sampled.
 |spring.sleuth.sampler.probability |  | Probability of requests that should be sampled. E.g. 1.0 - 100% requests should be sampled. The precision is whole-numbers only (i.e. there's no support for 0.1% of the traces).
 |spring.sleuth.sampler.rate | `10` | A rate per second can be a nice choice for low-traffic endpoints as it allows you surge protection. For example, you may never expect the endpoint to get more than 50 requests per second. If there was a sudden surge of traffic, to 5000 requests per second, you would still end up with 50 traces per second. Conversely, if you had a percentage, like 10%, the same surge would end up with 500 traces per second, possibly overloading your storage. Amazon X-Ray includes a rate-limited sampler (named Reservoir) for this purpose. Brave has taken the same approach via the {@link brave.sampler.RateLimitingSampler}.
 |spring.sleuth.sampler.refresh.enabled | `true` | Enable refresh scope for sampler.
@@ -82,7 +82,7 @@
 |spring.sleuth.session.enabled | `true` | Enable Spring Session instrumentation.
 |spring.sleuth.span-filter.additional-span-name-patterns-to-ignore |  | Additional list of span names to ignore. Will be appended to {@link #spanNamePatternsToSkip}.
 |spring.sleuth.span-filter.enabled | `false` | Will turn on the default Sleuth handler mechanism. Might ignore exporting of certain spans;
-|spring.sleuth.span-filter.span-name-patterns-to-skip | `^catalogWatchTaskScheduler$` | List of span names to ignore. They will not be sent to external systems.
+|spring.sleuth.span-filter.span-name-patterns-to-skip | `+++^catalogWatchTaskScheduler$+++` | List of span names to ignore. They will not be sent to external systems.
 |spring.sleuth.supports-join | `true` | True means the tracing system supports sharing a span ID between a client and server.
 |spring.sleuth.task.enabled | `true` | Enable Spring Cloud Task instrumentation.
 |spring.sleuth.trace-id128 | `false` | When true, generate 128-bit trace IDs instead of 64-bit ones.
@@ -96,7 +96,7 @@
 |spring.sleuth.web.filter-order | `0` | Order in which the tracing filters should be registered.
 |spring.sleuth.web.ignore-auto-configured-skip-patterns | `false` | If set to true, auto-configured skip patterns will be ignored.
 |spring.sleuth.web.servlet.enabled | `true` | Enable servlet instrumentation.
-|spring.sleuth.web.skip-pattern | `/api-docs.*\|/swagger.*\|.*\.png\|.*\.css\|.*\.js\|.*\.html\|/favicon.ico\|/hystrix.stream` | Pattern for URLs that should be skipped in tracing.
+|spring.sleuth.web.skip-pattern | `+++/api-docs.*\|/swagger.*\|.*\.png\|.*\.css\|.*\.js\|.*\.html\|/favicon.ico\|/hystrix.stream+++` | Pattern for URLs that should be skipped in tracing.
 |spring.sleuth.web.tomcat.enabled | `true` | Enable tracing instrumentation for Tomcat.
 |spring.sleuth.web.webclient.enabled | `true` | Enable tracing instrumentation for WebClient.
 |spring.zipkin.activemq.message-max-bytes | `100000` | Maximum number of bytes for a given message with spans sent to Zipkin over ActiveMQ.


### PR DESCRIPTION
Disabling parsing of special characters in Asciidoc to show valid configuration examples