### PR TITLE
#1863 port over default-logging-pattern-enabled flag to v3

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
@@ -44,7 +44,7 @@ class TraceEnvironmentPostProcessor implements EnvironmentPostProcessor {
 		// This doesn't work with all logging systems but it's a useful default so you see
 		// traces in logs without having to configure it.
 		if (Boolean.parseBoolean(environment.getProperty("spring.sleuth.enabled", "true"))) {
-			if (!Boolean
+			if (Boolean
 					.parseBoolean(environment.getProperty("spring.sleuth.default-logging-pattern-enabled", "true"))) {
 				map.put("logging.pattern.level", "%5p [${spring.zipkin.service.name:"
 						+ "${spring.application.name:}},%X{traceId:-},%X{spanId:-}]");

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessor.java
@@ -44,8 +44,11 @@ class TraceEnvironmentPostProcessor implements EnvironmentPostProcessor {
 		// This doesn't work with all logging systems but it's a useful default so you see
 		// traces in logs without having to configure it.
 		if (Boolean.parseBoolean(environment.getProperty("spring.sleuth.enabled", "true"))) {
-			map.put("logging.pattern.level",
-					"%5p [${spring.zipkin.service.name:" + "${spring.application.name:}},%X{traceId:-},%X{spanId:-}]");
+			if (!Boolean
+					.parseBoolean(environment.getProperty("spring.sleuth.default-logging-pattern-enabled", "true"))) {
+				map.put("logging.pattern.level", "%5p [${spring.zipkin.service.name:"
+						+ "${spring.application.name:}},%X{traceId:-},%X{spanId:-}]");
+			}
 			String neverRefereshables = environment.getProperty("spring.cloud.refresh.never-refreshable",
 					"com.zaxxer.hikari.HikariDataSource");
 			map.put("spring.cloud.refresh.never-refreshable",

--- a/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessorTests.java
+++ b/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/TraceEnvironmentPostProcessorTests.java
@@ -54,4 +54,14 @@ class TraceEnvironmentPostProcessorTests {
 				"com.zaxxer.hikari.HikariDataSource,org.springframework.cloud.sleuth.instrument.jdbc.DataSourceWrapper");
 	}
 
+	@Test
+	void should_not_set_logging_pattern_level_when_config_is_disabled() {
+		this.mockEnvironment.setProperty("spring.sleuth.enabled", "true");
+		this.mockEnvironment.setProperty("spring.sleuth.default-logging-pattern-enabled", "false");
+
+		new TraceEnvironmentPostProcessor().postProcessEnvironment(this.mockEnvironment, null);
+
+		then(this.mockEnvironment.getProperty("logging.pattern.level")).isNullOrEmpty();
+	}
+
 }


### PR DESCRIPTION
Add ability to configure `spring-cloud-sleuth` to not override spring `logging.pattern.level` configuration property