### PR TITLE
Override `getQueueCapacity` to return delegate's value

### DIFF
--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/async/LazyTraceThreadPoolTaskExecutor.java
@@ -173,6 +173,11 @@ public class LazyTraceThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 	}
 
 	@Override
+	public int getQueueCapacity() {
+		return this.delegate.getQueueCapacity();
+	}
+
+	@Override
 	public void destroy() {
 		this.delegate.destroy();
 		super.destroy();


### PR DESCRIPTION
Fix for [issue](https://github.com/spring-cloud/spring-cloud-sleuth/issues/2203)