### PR TITLE
Update config props to include default-logging-pattern-enabled

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -13,6 +13,7 @@
 |spring.sleuth.cassandra.enabled | `+++true+++` | Enable Cassandra instrumentation.
 |spring.sleuth.circuitbreaker.enabled | `+++true+++` | Enable Spring Cloud CircuitBreaker instrumentation.
 |spring.sleuth.config.server.enabled | `+++true+++` | Enable Spring Cloud Config Server instrumentation.
+|spring.sleuth.default-logging-pattern-enabled | `+++true+++` | Override `logging.pattern.level` property to include trace and span ids.
 |spring.sleuth.deployer.enabled | `+++true+++` | Enable Spring Cloud Deployer instrumentation.
 |spring.sleuth.deployer.status-poll-delay | `+++500+++` | Default poll delay to retrieve the deployed application status.
 |spring.sleuth.enabled | `+++true+++` | 


### PR DESCRIPTION
Hi @marcingrzejszczak,

Just adding documentation for the ported property

On a related question do you know when 3.1.4 will be released? 
Do you know where I can find `spring-cloud-dependencies` to update `spring-cloud-sleuth` to the latest version?

Many thanks! 