### PR TITLE
fix(sec): upgrade org.apache.commons:commons-dbcp2 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  -->
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-cloud-sleuth</artifactId>
@@ -75,7 +71,7 @@
 		<p6spy.version>3.9.1</p6spy.version>
 		<datasource-proxy.version>1.7</datasource-proxy.version>
 		<tomcat-jdbc.version>10.0.6</tomcat-jdbc.version>
-		<commons-dbcp2.version>2.8.0</commons-dbcp2.version>
+		<commons-dbcp2.version>2.9.0</commons-dbcp2.version>
 		<kotlin.version>1.6.0</kotlin.version>
 
 		<!-- Until we switch it to true in sc-build -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.commons:commons-dbcp2 2.8.0
- [MPS-2022-12024](https://www.oscs1024.com/hd/MPS-2022-12024)


### What did I do？
Upgrade org.apache.commons:commons-dbcp2 from 2.8.0 to 2.9.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS