### PR TITLE
Batch application does not shutdown

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/zipkin2/ZipkinAutoConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/zipkin2/ZipkinAutoConfiguration.java
@@ -22,8 +22,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import javax.annotation.PreDestroy;
-
 import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -103,11 +101,6 @@ public class ZipkinAutoConfiguration {
 
 	private static final Log log = LogFactory.getLog(ZipkinAutoConfiguration.class);
 
-	@PreDestroy
-	void cleanup() {
-		this.zipkinExecutor.shutdown();
-	}
-
 	/** Limits {@link Sender#check()} to {@code deadlineMillis}. */
 	static CompletableFuture<CheckResult> checkResult(ExecutorService zipkinExecutor, Sender sender,
 			long deadlineMillis) {
@@ -124,6 +117,8 @@ public class ZipkinAutoConfiguration {
 				result = checkResult == null ? CheckResult.failed(exception) : checkResult;
 			}
 			logCheckResult(sender, result);
+			
+			zipkinExecutor.shutdown();
 		});
 	}
 


### PR DESCRIPTION
When a batch application ends, the application does not shut down. 

It is due to the thread created by ZipkinAutoConfiguration (non deamon thread) is supposed to be terminated at: 

```java 
        @PreDestroy
	void cleanup() {
		this.zipkinExecutor.shutdown();
	}
```

But it is not executed because still exists a non daeman thread.  (The thread create by the zipkinExecutor itself) 

At the PR you can see that the executor is shutdown when the task is completed. I think it is the best option because it is not used anymore. 

Also the shutdown is executed by the executor thread itself, in order to not block the main thread which is executing the startup of the application. 


I have attached a simple batch application which does nothing a part from starting and stopping to check the issue. 

[spring-batch.zip](https://github.com/spring-cloud/spring-cloud-sleuth/files/9785980/spring-batch.zip)
