### PR TITLE
Improved DefaultSpanNamer 

### DIFF
--- a/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/internal/DefaultSpanNamer.java
+++ b/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/internal/DefaultSpanNamer.java
@@ -42,10 +42,12 @@ import org.springframework.core.annotation.AnnotationUtils;
 public class DefaultSpanNamer implements SpanNamer {
 
 	private static boolean isDefaultToString(Object delegate, String spanName) {
-		if (delegate instanceof Method) {
-			return delegate.toString().equals(spanName);
+		try {
+			return delegate.getClass().getMethod("toString").getDeclaringClass() == Object.class;
 		}
-		return (delegate.getClass().getName() + "@" + Integer.toHexString(delegate.hashCode())).equals(spanName);
+		catch (NoSuchMethodException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override

--- a/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/internal/DefaultSpanNamerTest.java
+++ b/spring-cloud-sleuth-instrumentation/src/test/java/org/springframework/cloud/sleuth/internal/DefaultSpanNamerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.internal;
+
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.Test;
+
+class DefaultSpanNamerTest {
+
+	@Test
+	void nameWithoutToStringOverride() {
+		String defaultValue = new DefaultSpanNamer().name(new NoToStringOverride(), "default value");
+		BDDAssertions.then(defaultValue).isEqualTo("default value");
+	}
+
+	@Test
+	void nameWithToStringOverride() {
+		String defaultValue = new DefaultSpanNamer().name(new WithToStringOverride(), "default value");
+		BDDAssertions.then(defaultValue).isEqualTo("mytostring");
+	}
+
+	@Test
+	void nameWithInheritedToStringOverride() {
+		String defaultValue = new DefaultSpanNamer().name(new InheritedToString(), "default value");
+		BDDAssertions.then(defaultValue).isEqualTo("mytostring");
+	}
+
+	static class NoToStringOverride {
+
+	}
+
+	static class WithToStringOverride {
+
+		@Override
+		public String toString() {
+			return "mytostring";
+		}
+
+	}
+
+	static class InheritedToString extends WithToStringOverride {
+
+	}
+
+}


### PR DESCRIPTION
Improved `DefaultSpanNamer`. It now more efficiently checks if the delegate has a default toString.

Previously it would actually call the toString and compare the value of the String. This is expensive as it creates more garbage.