### PR TITLE
improves traceQueue cleaning logic

### DIFF
--- a/tests/brave/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/reactor/QueueWrapperTests.java
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-reactor-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/reactor/QueueWrapperTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.brave.instrument.reactor;
+
+import org.springframework.cloud.sleuth.CurrentTraceContext;
+import org.springframework.cloud.sleuth.TraceContext;
+import org.springframework.cloud.sleuth.brave.bridge.BraveAccessor;
+
+/**
+ * @author Oleh Dokuka
+ */
+public class QueueWrapperTests extends org.springframework.cloud.sleuth.instrument.reactor.QueueWrapperTests {
+
+	brave.propagation.CurrentTraceContext traceContext = brave.propagation.CurrentTraceContext.Default.create();
+
+	CurrentTraceContext currentTraceContext = BraveAccessor.currentTraceContext(traceContext);
+
+	TraceContext context = BraveAccessor
+			.traceContext(brave.propagation.TraceContext.newBuilder().traceId(1).spanId(1).sampled(true).build());
+
+	@Override
+	protected CurrentTraceContext currentTraceContext() {
+		return this.currentTraceContext;
+	}
+
+	@Override
+	protected TraceContext context() {
+		return this.context;
+	}
+
+}

--- a/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/QueueWrapperTests.java
+++ b/tests/common/src/main/java/org/springframework/cloud/sleuth/instrument/reactor/QueueWrapperTests.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.sleuth.instrument.reactor;
+
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Hooks;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.concurrent.Queues;
+
+import org.springframework.cloud.sleuth.CurrentTraceContext;
+import org.springframework.cloud.sleuth.TraceContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.springframework.cloud.sleuth.instrument.reactor.ReactorSleuth.traceQueue;
+
+/**
+ * @author Oleh Dokuka
+ */
+public abstract class QueueWrapperTests {
+
+	static {
+		// AssertJ will recognise QueueSubscription implements queue and try to invoke
+		// iterator. That's not allowed, and will cause an exception
+		// Fuseable$QueueSubscription.NOT_SUPPORTED_MESSAGE.
+		// This ensures AssertJ uses normal toString.
+		StandardRepresentation.registerFormatterForType(ScopePassingSpanSubscriber.class, Objects::toString);
+	}
+
+	protected abstract CurrentTraceContext currentTraceContext();
+
+	protected abstract TraceContext context();
+
+	AnnotationConfigApplicationContext springContext = new AnnotationConfigApplicationContext();
+
+	@BeforeEach
+	public void setup() {
+		Hooks.removeQueueWrappers();
+		Hooks.resetOnLastOperator();
+		Schedulers.resetOnScheduleHooks();
+	}
+
+	@AfterEach
+	public void close() {
+		springContext.close();
+		Hooks.removeQueueWrappers();
+		Hooks.resetOnLastOperator();
+		Schedulers.resetOnScheduleHooks();
+	}
+
+	@Test
+	void checkContextIsRestoredAndOnNullCleaned() {
+		springContext.registerBean(CurrentTraceContext.class, this::currentTraceContext);
+		springContext.refresh();
+
+		final Queue queue = traceQueue(this.springContext, Queues.get(128).get());
+
+		TraceContext context;
+		try (CurrentTraceContext.Scope ws = currentTraceContext().newScope(context())) {
+			context = currentTraceContext().context();
+			queue.offer(1);
+		}
+
+		Assertions.assertThat(queue.poll()).isEqualTo(1);
+		Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+		Assertions.assertThat(queue.poll()).isNull();
+		Assertions.assertThat(currentTraceContext().context()).isNull();
+	}
+
+	@Test
+	void checkContextIsNotCleanOnNullCleanedIfContextWasAvailableOnThread() {
+		springContext.registerBean(CurrentTraceContext.class, this::currentTraceContext);
+		springContext.refresh();
+
+		final Queue queue = traceQueue(this.springContext, Queues.get(128).get());
+
+		TraceContext context;
+		CurrentTraceContext.Scope ws = currentTraceContext().newScope(context());
+		context = currentTraceContext().context();
+		queue.offer(1);
+
+		Assertions.assertThat(queue.poll()).isEqualTo(1);
+		Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+		Assertions.assertThat(queue.poll()).isNull();
+		Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+		ws.close();
+		Assertions.assertThat(currentTraceContext().context()).isNull();
+	}
+
+	@Test
+	void checkContextIsRestoredAndOnNullCleanedInCaseOfSubsequentPolls() {
+		springContext.registerBean(CurrentTraceContext.class, this::currentTraceContext);
+		springContext.refresh();
+
+		final Queue queue = traceQueue(this.springContext, Queues.get(128).get());
+
+		TraceContext context;
+		try (CurrentTraceContext.Scope ws = currentTraceContext().newScope(context())) {
+			context = currentTraceContext().context();
+			queue.offer(1);
+			queue.offer(2);
+		}
+
+		Assertions.assertThat(queue.poll()).isEqualTo(1);
+		Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+		Assertions.assertThat(queue.poll()).isEqualTo(2);
+		Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+		Assertions.assertThat(queue.poll()).isNull();
+		Assertions.assertThat(currentTraceContext().context()).isNull();
+	}
+
+	@Test
+	void checkContextIsRestoredAndOnNullCleanedInCaseOfSubsequentPollsByAnotherThread() throws InterruptedException {
+		springContext.registerBean(CurrentTraceContext.class, this::currentTraceContext);
+		springContext.refresh();
+
+		final Queue queue = traceQueue(this.springContext, Queues.get(128).get());
+
+		TraceContext context;
+		try (CurrentTraceContext.Scope ws = currentTraceContext().newScope(context())) {
+			context = currentTraceContext().context();
+			queue.offer(1);
+			queue.offer(2);
+		}
+
+		Assertions.assertThat(queue.poll()).isEqualTo(1);
+		Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+		CountDownLatch latch = new CountDownLatch(1);
+		new Thread(() -> {
+			Assertions.assertThat(queue.poll()).isEqualTo(2);
+			Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+			Assertions.assertThat(queue.poll()).isNull();
+			Assertions.assertThat(currentTraceContext().context()).isNull();
+			latch.countDown();
+		}).start();
+
+		Assertions.assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		Assertions.assertThat(queue.poll()).isNull();
+		Assertions.assertThat(currentTraceContext().context()).isNull();
+	}
+
+	@Test
+	void checkContextIsNotCleanOnNullCleanedIfContextWasAvailableOnThreadAnotherThreadCase()
+			throws InterruptedException {
+		springContext.registerBean(CurrentTraceContext.class, this::currentTraceContext);
+		springContext.refresh();
+
+		final Queue queue = traceQueue(this.springContext, Queues.get(128).get());
+
+		TraceContext context;
+		try (CurrentTraceContext.Scope ws = currentTraceContext().newScope(context())) {
+			context = currentTraceContext().context();
+			queue.offer(1);
+			queue.offer(2);
+		}
+
+		Assertions.assertThat(queue.poll()).isEqualTo(1);
+		Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+		CountDownLatch latch = new CountDownLatch(1);
+		new Thread(() -> {
+			CurrentTraceContext.Scope ws = currentTraceContext().maybeScope(context);
+			Assertions.assertThat(queue.poll()).isEqualTo(2);
+			Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+			Assertions.assertThat(queue.poll()).isNull();
+			Assertions.assertThat(currentTraceContext().context()).isNotNull().isEqualTo(context);
+
+			ws.close();
+			Assertions.assertThat(currentTraceContext().context()).isNull();
+			latch.countDown();
+		}).start();
+
+		Assertions.assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		Assertions.assertThat(queue.poll()).isNull();
+		Assertions.assertThat(currentTraceContext().context()).isNull();
+	}
+
+}


### PR DESCRIPTION
this commit improves logic on when the previous TraceContext has to be cleaned by looking at the last reader thread as well as the last polled value and trying to match it with the context that was available before. If the context was available when the previous reader is different from the current or when the previous value is null, the logic assumes that the thread offered value and then draining queue is the same, so there is no need to clear context after the last value is drained and that responsibility is on the reader.

Signed-off-by: Oleh Dokuka <oleh.dokuka@icloud.com>