### PR TITLE
deps: bumps to Brave 5.18.1 and moves off internal type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,6 @@
 		<spring-cloud-openfeign.version>3.1.10-SNAPSHOT</spring-cloud-openfeign.version>
 		<spring-cloud-task.version>2.4.6</spring-cloud-task.version>
 		<spring-cloud-deployer.version>2.5.1</spring-cloud-deployer.version>
-		<brave.version>5.13.9</brave.version>
-		<opentracing.version>0.32.0</opentracing.version>
 		<!-- Deprecated - reached EOL -->
 		<spring-security-boot-autoconfigure.version>2.3.4.RELEASE</spring-security-boot-autoconfigure.version>
 		<spring-security-oauth2.version>2.2.0.RELEASE</spring-security-oauth2.version>

--- a/spring-cloud-sleuth-autoconfigure/pom.xml
+++ b/spring-cloud-sleuth-autoconfigure/pom.xml
@@ -414,6 +414,7 @@
 			<artifactId>zipkin</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<!-- Needed for ZipkinRestTemplateSenderConfiguration: BytesMessageEncoder  -->
 		<dependency>
 			<groupId>io.zipkin.reporter2</groupId>
 			<artifactId>zipkin-reporter</artifactId>

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/brave/BraveBaggageConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/brave/BraveBaggageConfiguration.java
@@ -334,12 +334,6 @@ class BraveBaggageConfiguration {
 			return delegate.decorate(context);
 		}
 
-		@Override
-		public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
-			Propagation<K> propagation = delegate.create(keyFactory);
-			return delegateWithoutB3Baggage(factoryFromSupplier, propagation);
-		}
-
 		private <K> Propagation<K> delegateWithoutB3Baggage(Propagation.Factory factoryFromSupplier,
 				Propagation<K> propagation) {
 			return new Propagation<K>() {

--- a/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/brave/instrument/web/BraveHttpConfiguration.java
+++ b/spring-cloud-sleuth-autoconfigure/src/main/java/org/springframework/cloud/sleuth/autoconfig/brave/instrument/web/BraveHttpConfiguration.java
@@ -77,9 +77,8 @@ public class BraveHttpConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	// NOTE: stable bean name as might be used outside sleuth
-	HttpTracing httpTracing(Tracing tracing, @Nullable SkipPatternProvider provider,
-			@Nullable brave.http.HttpClientParser clientParser, @Nullable brave.http.HttpServerParser serverParser,
-			BeanFactory beanFactory, @Nullable List<HttpTracingCustomizer> httpTracingCustomizers) {
+	HttpTracing httpTracing(Tracing tracing, @Nullable SkipPatternProvider provider, BeanFactory beanFactory,
+			@Nullable List<HttpTracingCustomizer> httpTracingCustomizers) {
 		HttpTracing.Builder builder = httpTracingBuilder(tracing, provider, beanFactory);
 		brave.http.HttpRequestParser httpClientRequestParser = httpRequestParser(beanFactory,
 				HttpClientRequestParser.NAME);
@@ -98,9 +97,6 @@ public class BraveHttpConfiguration {
 				builder.clientResponseParser(httpClientResponseParser);
 			}
 		}
-		else if (clientParser != null) { // consider deprecated last
-			builder.clientParser(clientParser);
-		}
 
 		if (httpServerRequestParser != null || httpServerResponseParser != null) {
 			if (httpServerRequestParser != null) {
@@ -109,9 +105,6 @@ public class BraveHttpConfiguration {
 			if (httpServerResponseParser != null) {
 				builder.serverResponseParser(httpServerResponseParser);
 			}
-		}
-		else if (serverParser != null) { // consider deprecated last
-			builder.serverParser(serverParser);
 		}
 
 		if (httpTracingCustomizers != null) {

--- a/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/brave/BraveAutoConfigurationTests.java
+++ b/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/brave/BraveAutoConfigurationTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.sleuth.autoconfig.brave;
 
-import java.util.List;
+import java.util.Map;
 
 import brave.Tracing;
 import brave.baggage.BaggageField;
@@ -95,8 +95,7 @@ public class BraveAutoConfigurationTests {
 	void should_use_baggageBean() {
 		this.contextRunner.withUserConfiguration(WithBaggageBeans.class, Baggage.class).run((context -> {
 			final Baggage bean = context.getBean(Baggage.class);
-			BDDAssertions.then(bean.fields).containsOnly(BaggageField.create("country-code"),
-					BaggageField.create("x-vcap-request-id"));
+			BDDAssertions.then(bean.fields).containsEntry("country-code", "x-vcap-request-id");
 		}));
 	}
 
@@ -105,7 +104,7 @@ public class BraveAutoConfigurationTests {
 		this.contextRunner.withPropertyValues("spring.sleuth.baggage.local-fields=bp")
 				.withUserConfiguration(Baggage.class).run((context -> {
 					final Baggage bean = context.getBean(Baggage.class);
-					BDDAssertions.then(bean.fields).containsExactly(BaggageField.create("bp"));
+					BDDAssertions.then(bean.fields).containsKey("bp");
 				}));
 	}
 
@@ -114,8 +113,7 @@ public class BraveAutoConfigurationTests {
 		this.contextRunner.withPropertyValues("spring.sleuth.baggage.local-fields=bp")
 				.withUserConfiguration(WithBaggageBeans.class, Baggage.class).run((context -> {
 					final Baggage bean = context.getBean(Baggage.class);
-					BDDAssertions.then(bean.fields).containsOnly(BaggageField.create("country-code"),
-							BaggageField.create("x-vcap-request-id"), BaggageField.create("bp"));
+					BDDAssertions.then(bean.fields).containsOnlyKeys("country-code", "x-vcap-request-id", "bp");
 				}));
 	}
 
@@ -131,7 +129,7 @@ public class BraveAutoConfigurationTests {
 	@Configuration(proxyBeanMethods = false)
 	static class Baggage {
 
-		List<BaggageField> fields;
+		Map<String, String> fields;
 
 		@Autowired
 		Baggage(Tracing tracing) {
@@ -139,7 +137,7 @@ public class BraveAutoConfigurationTests {
 			// TraceContextOrSamplingFlags.EMPTY
 			TraceContextOrSamplingFlags emptyExtraction = tracing.propagation().extractor((c, k) -> null)
 					.extract(Boolean.TRUE);
-			fields = BaggageField.getAll(emptyExtraction);
+			fields = BaggageField.getAllValues(emptyExtraction);
 		}
 
 	}

--- a/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/brave/BravePropagationTests.java
+++ b/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/brave/BravePropagationTests.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import brave.internal.codec.HexCodec;
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -159,8 +158,8 @@ class CustomPropagator extends Propagation.Factory implements Propagation<String
 	}
 
 	@Override
-	public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-		return StringPropagationAdapter.create(this, keyFactory);
+	public Propagation<String> get() {
+		return this;
 	}
 
 }

--- a/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/brave/baggage/CustomPropagationFactoryTests.java
+++ b/spring-cloud-sleuth-autoconfigure/src/test/java/org/springframework/cloud/sleuth/autoconfig/brave/baggage/CustomPropagationFactoryTests.java
@@ -19,7 +19,6 @@ package org.springframework.cloud.sleuth.autoconfig.brave.baggage;
 import java.util.Collections;
 import java.util.List;
 
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -94,8 +93,8 @@ public class CustomPropagationFactoryTests {
 			}
 
 			@Override
-			public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-				return StringPropagationAdapter.create(this, keyFactory);
+			public Propagation<String> get() {
+				return this;
 			}
 
 		}

--- a/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/CompositePropagationFactorySupplier.java
+++ b/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/CompositePropagationFactorySupplier.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
@@ -129,8 +128,8 @@ class CompositePropagationFactory extends Propagation.Factory implements Propaga
 	}
 
 	@Override
-	public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-		return StringPropagationAdapter.create(this, keyFactory);
+	public Propagation<String> get() {
+		return this;
 	}
 
 	@Override
@@ -177,8 +176,8 @@ class CompositePropagationFactory extends Propagation.Factory implements Propaga
 		}
 
 		@Override
-		public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-			return propagationFactory().create(keyFactory);
+		public Propagation<String> get() {
+			return new LazyPropagation(this);
 		}
 
 		@Override
@@ -189,11 +188,6 @@ class CompositePropagationFactory extends Propagation.Factory implements Propaga
 		@Override
 		public boolean requires128BitTraceId() {
 			return propagationFactory().requires128BitTraceId();
-		}
-
-		@Override
-		public Propagation<String> get() {
-			return new LazyPropagation(this);
 		}
 
 		@Override
@@ -260,8 +254,8 @@ class CompositePropagationFactory extends Propagation.Factory implements Propaga
 		}
 
 		@Override
-		public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-			return StringPropagationAdapter.create(this, keyFactory);
+		public Propagation<String> get() {
+			return this;
 		}
 
 	}

--- a/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/W3CPropagation.java
+++ b/spring-cloud-sleuth-brave/src/main/java/org/springframework/cloud/sleuth/brave/bridge/W3CPropagation.java
@@ -31,7 +31,6 @@ import brave.baggage.BaggageField;
 import brave.baggage.BaggagePropagation;
 import brave.baggage.BaggagePropagationConfig;
 import brave.internal.baggage.BaggageFields;
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
 import brave.propagation.TraceContextOrSamplingFlags;
@@ -129,8 +128,8 @@ class W3CPropagation extends Propagation.Factory implements Propagation<String> 
 	}
 
 	@Override
-	public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-		return StringPropagationAdapter.create(this, keyFactory);
+	public Propagation<String> get() {
+		return this;
 	}
 
 	@Override
@@ -321,7 +320,7 @@ class W3CBaggagePropagator {
 	private BaggagePropagation.FactoryBuilder factory() {
 		return BaggagePropagation.newFactoryBuilder(new Propagation.Factory() {
 			@Override
-			public <K> Propagation<K> create(Propagation.KeyFactory<K> keyFactory) {
+			public Propagation<String> get() {
 				return null;
 			}
 		});

--- a/spring-cloud-sleuth-dependencies/.flattened-pom.xml
+++ b/spring-cloud-sleuth-dependencies/.flattened-pom.xml
@@ -100,9 +100,10 @@
     <downloadUrl>https://github.com/spring-cloud</downloadUrl>
   </distributionManagement>
   <properties>
-    <brave.opentracing.version>0.37.4</brave.opentracing.version>
+    <brave.opentracing.version>1.0.1</brave.opentracing.version>
     <grpc.spring.boot.version>4.2.2</grpc.spring.boot.version>
-    <brave.version>5.13.9</brave.version>
+	<zipkin-reporter.version>2.17.2</zipkin-reporter.version>
+	<brave.version>5.18.0</brave.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -140,6 +141,13 @@
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-sleuth-tests-common</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.zipkin.reporter2</groupId>
+        <artifactId>zipkin-reporter-bom</artifactId>
+        <version>${zipkin-reporter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.zipkin.brave</groupId>

--- a/spring-cloud-sleuth-dependencies/pom.xml
+++ b/spring-cloud-sleuth-dependencies/pom.xml
@@ -42,8 +42,9 @@
 	</scm>
 
 	<properties>
-		<brave.version>5.13.11</brave.version>
-		<brave.opentracing.version>0.37.5</brave.opentracing.version>
+		<brave.version>5.18.1</brave.version>
+		<zipkin-reporter.version>2.17.2</zipkin-reporter.version>
+		<brave.opentracing.version>1.0.1</brave.opentracing.version>
 		<grpc.spring.boot.version>4.2.3</grpc.spring.boot.version>
 	</properties>
 	<dependencyManagement>
@@ -86,11 +87,30 @@
 			</dependency>
 			<!-- BRAVE -->
 			<dependency>
+				<groupId>io.zipkin.reporter2</groupId>
+				<artifactId>zipkin-reporter-bom</artifactId>
+				<version>${zipkin-reporter.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>io.zipkin.brave</groupId>
 				<artifactId>brave-bom</artifactId>
 				<version>${brave.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<!-- Brave prior to v6 had a reporter dependency. Remove that to avoid conflicts. -->
+			<dependency>
+				<groupId>io.zipkin.brave</groupId>
+				<artifactId>brave</artifactId>
+				<version>${brave.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>*</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>io.opentracing.brave</groupId>

--- a/spring-cloud-sleuth-zipkin/pom.xml
+++ b/spring-cloud-sleuth-zipkin/pom.xml
@@ -96,6 +96,7 @@
 			<groupId>io.zipkin.zipkin2</groupId>
 			<artifactId>zipkin</artifactId>
 		</dependency>
+		<!-- Needed for ZipkinRestTemplateSenderConfiguration: BytesMessageEncoder  -->
 		<dependency>
 			<groupId>io.zipkin.reporter2</groupId>
 			<artifactId>zipkin-reporter</artifactId>

--- a/tests/brave/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/async/TraceAsyncIntegrationTests.java
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-async-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/async/TraceAsyncIntegrationTests.java
@@ -24,8 +24,8 @@ import brave.handler.SpanHandler;
 import brave.propagation.CurrentTraceContext;
 import brave.propagation.TraceContext;
 import brave.test.IntegrationTestSpanHandler;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +48,7 @@ public class TraceAsyncIntegrationTests {
 
 	private static final Logger log = LoggerFactory.getLogger(TraceAsyncIntegrationTests.class);
 
-	@ClassRule
+	@RegisterExtension
 	public static IntegrationTestSpanHandler spans = new IntegrationTestSpanHandler();
 
 	TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();

--- a/tests/brave/spring-cloud-sleuth-instrumentation-webflux-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/web/client/MergedFactory.java
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-webflux-tests/src/test/java/org/springframework/cloud/sleuth/brave/instrument/web/client/MergedFactory.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import brave.Span;
 import brave.internal.collect.Lists;
-import brave.internal.propagation.StringPropagationAdapter;
 import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
 import brave.propagation.TraceContext;
@@ -52,8 +51,8 @@ public class MergedFactory extends Propagation.Factory implements Propagation<St
 	}
 
 	@Override
-	public <K> Propagation<K> create(KeyFactory<K> keyFactory) {
-		return StringPropagationAdapter.create(this, keyFactory);
+	public Propagation<String> get() {
+		return this;
 	}
 
 }

--- a/tests/brave/spring-cloud-sleuth-zipkin-tests/pom.xml
+++ b/tests/brave/spring-cloud-sleuth-zipkin-tests/pom.xml
@@ -82,11 +82,13 @@
 		</dependency>
 		<dependency>
 			<groupId>io.zipkin.reporter2</groupId>
-			<artifactId>zipkin-reporter</artifactId>
+			<artifactId>zipkin-reporter-brave</artifactId>
 		</dependency>
+		<!-- Needed for ZipkinRestTemplateSenderConfiguration: BytesMessageEncoder  -->
 		<dependency>
 			<groupId>io.zipkin.reporter2</groupId>
-			<artifactId>zipkin-reporter-brave</artifactId>
+			<artifactId>zipkin-reporter</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.zipkin.reporter2</groupId>

--- a/tests/common/pom.xml
+++ b/tests/common/pom.xml
@@ -241,12 +241,13 @@
 		</dependency>
 		<dependency>
 			<groupId>io.zipkin.reporter2</groupId>
-			<artifactId>zipkin-reporter</artifactId>
+			<artifactId>zipkin-reporter-brave</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<!-- Needed for ZipkinRestTemplateSenderConfiguration: BytesMessageEncoder  -->
 		<dependency>
 			<groupId>io.zipkin.reporter2</groupId>
-			<artifactId>zipkin-reporter-brave</artifactId>
+			<artifactId>zipkin-reporter</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This updates to Brave 5.18.0 and dodges an internal type that will not be in Brave 6.0. See https://github.com/openzipkin/brave/pull/1396 about Propagation and Brave 6.0