### PR TITLE
fix(sec): upgrade com.squareup.okhttp3:okhttp to 4.9.2

### DIFF
--- a/spring-cloud-sleuth-autoconfigure/pom.xml
+++ b/spring-cloud-sleuth-autoconfigure/pom.xml
@@ -499,7 +499,7 @@
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<!-- Kotlin... -->
-			<version>4.8.1</version>
+			<version>4.9.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tests/brave/spring-cloud-sleuth-instrumentation-baggage-tests/pom.xml
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-baggage-tests/pom.xml
@@ -92,7 +92,7 @@
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<!-- Kotlin... -->
-			<version>4.8.1</version>
+			<version>4.9.2</version>
 		</dependency>
 	</dependencies>
 

--- a/tests/brave/spring-cloud-sleuth-instrumentation-feign-tests/pom.xml
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-feign-tests/pom.xml
@@ -69,7 +69,7 @@
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<!-- Kotlin... -->
-			<version>4.8.1</version>
+			<version>4.9.2</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/tests/brave/spring-cloud-sleuth-instrumentation-mvc-tests/pom.xml
+++ b/tests/brave/spring-cloud-sleuth-instrumentation-mvc-tests/pom.xml
@@ -73,7 +73,7 @@
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<!-- Kotlin... -->
-			<version>4.8.1</version>
+			<version>4.9.2</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/tests/brave/spring-cloud-sleuth-zipkin-tests/pom.xml
+++ b/tests/brave/spring-cloud-sleuth-zipkin-tests/pom.xml
@@ -146,7 +146,7 @@
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
 			<!-- Kotlin... -->
-			<version>4.8.1</version>
+			<version>4.9.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.squareup.okhttp3:okhttp 4.8.1
- [CVE-2023-0833](https://www.oscs1024.com/hd/CVE-2023-0833)


### What did I do？
Upgrade com.squareup.okhttp3:okhttp from 4.8.1 to 4.9.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS