### PR TITLE
Update Spring Cloud Sleuth documentation for maintenance status

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,10 +5,9 @@ Edit the files in the src/main/asciidoc/ directory instead.
 ////
 
 
-:jdkversion: 1.8
+= Spring Cloud Sleuth is no longer actively maintained.  
 
-image::https://github.com/spring-cloud/spring-cloud-sleuth/workflows/Build/badge.svg?style=svg["Build",link="https://github.com/spring-cloud/spring-cloud-sleuth/actions"]
-image::https://badges.gitter.im/spring-cloud/spring-cloud-sleuth.svg[Gitter,link="https://gitter.im/spring-cloud/spring-cloud-sleuth?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+=== See the https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2022.0-Release-Notes#202200-m1[release notes] and https://spring.io/blog/2022/10/12/observability-with-spring-boot-3[blog post] for more information and next steps.
 
 == Spring Cloud Sleuth
 

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -1,7 +1,6 @@
-:jdkversion: 1.8
+= Spring Cloud Sleuth is no longer actively maintained.  
 
-image::https://github.com/spring-cloud/spring-cloud-sleuth/workflows/Build/badge.svg?style=svg["Build",link="https://github.com/spring-cloud/spring-cloud-sleuth/actions"]
-image::https://badges.gitter.im/spring-cloud/spring-cloud-sleuth.svg[Gitter,link="https://gitter.im/spring-cloud/spring-cloud-sleuth?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
+=== See the https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2022.0-Release-Notes#202200-m1[release notes] and https://spring.io/blog/2022/10/12/observability-with-spring-boot-3[blog post] for more information and next steps.
 
 == Spring Cloud Sleuth
 

--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -2,6 +2,10 @@
 = Spring Cloud Sleuth Reference Documentation
 Adrian Cole, Spencer Gibb, Marcin Grzejszczak, Dave Syer, Jay Bryant
 
+= Spring Cloud Sleuth is no longer actively maintained.  
+
+=== See the https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2022.0-Release-Notes#202200-m1[release notes] and https://spring.io/blog/2022/10/12/observability-with-spring-boot-3[blog post] for more information and next steps.
+
 == !!!! IMPORTANT !!!!
 
 Spring Cloud Sleuth's last minor version is 3.1. You can check the https://github.com/spring-cloud/spring-cloud-sleuth/tree/3.1.x[3.1.x] branch for the latest commits.

--- a/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-sleuth.adoc
@@ -2,10 +2,6 @@
 = Spring Cloud Sleuth Reference Documentation
 Adrian Cole, Spencer Gibb, Marcin Grzejszczak, Dave Syer, Jay Bryant
 
-= Spring Cloud Sleuth is no longer actively maintained.  
-
-=== See the https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2022.0-Release-Notes#202200-m1[release notes] and https://spring.io/blog/2022/10/12/observability-with-spring-boot-3[blog post] for more information and next steps.
-
 == !!!! IMPORTANT !!!!
 
 Spring Cloud Sleuth's last minor version is 3.1. You can check the https://github.com/spring-cloud/spring-cloud-sleuth/tree/3.1.x[3.1.x] branch for the latest commits.


### PR DESCRIPTION
Added a notice about the maintenance status of Spring Cloud Sleuth and provided links to release notes and blog post for further information.